### PR TITLE
SHEL-26: Fix errorOut to use console.error and exit with process.exit

### DIFF
--- a/src/lib/misc.js
+++ b/src/lib/misc.js
@@ -241,7 +241,10 @@ function fileNotFound(err) {
 */
 function errorOut(msg, code) {
   code = code || 1
-  return Errors.error(msg, {exit: code})
+  console.error(`Error: ${msg}`)
+  process.exit(code)
+  //TODO: Using process.exit is not the optimal solution.
+  //return Errors.error(msg, { exit: code })
 }
 
 /**


### PR DESCRIPTION
oclif or how the code was structured seems to swallow error messages.

Exploring errorOut implementation and usage and the implementation of Errors.error suggests this is a possible fix without any adverse side effects