### PR TITLE
SHEL-22: Remove root scope warning message

### DIFF
--- a/src/commands/shell.js
+++ b/src/commands/shell.js
@@ -55,9 +55,7 @@ function filterCommands(commands, unwanted) {
 function startShell(client, endpoint, dbscope, log) {
   const dbname = dbscope ? dbscope : ''
 
-  if (dbname === '') {
-    log("Warning: You didn't specify a database. Starting the shell in the global scope.")
-  } else {
+  if (dbname !== '') {
     log(`Starting shell for database ${dbname}`)
   }
 


### PR DESCRIPTION
```bash
trevor@laptop:~/workspace/fauna/fauna-shell$ fauna shell graphql
Starting shell for database graphql
Connected to https://db.fauna.com
Type Ctrl+D or .exit to exit the shell
graphql> 

trevor@laptop:~/workspace/fauna/fauna-shell$ fauna shell 
Connected to https://db.fauna.com
Type Ctrl+D or .exit to exit the shell
> 
```