### PR TITLE
SHEL-30: Use fixed version of faunadb driver

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "cli-ux": "^4.8.0",
     "escodegen": "^1.11.0",
     "esprima": "^4.0.1",
-    "faunadb": "^2.5.1",
+    "faunadb": "~2.5.1",
     "globby": "8",
     "heroku-cli-util": "^8.0.9",
     "ini": "^1.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1221,9 +1221,10 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-faunadb@^2.5.1:
+faunadb@~2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/faunadb/-/faunadb-2.5.2.tgz#5f46ead861aa4f1fe696302e6c76fa12c04202c6"
+  integrity sha512-PhEd9iF611EKYr9Pqmk15SnO++6EOLh9E4+gintObxYCicBKGXfNVj7D/+ieM3NUpG9O8SEX+j9k75q6DzJ+PQ==
   dependencies:
     base64-js "^1.2.0"
     btoa-lite "^1.0.0"


### PR DESCRIPTION
I don't know the pros and cons of using a fixed version, but given our versioning doesn't follow semver I think doesn't make sense to leave it open.

The problem with this is that, devs using `fauna/faunadb:2.6.5` to test, if they install fauna-shell freshly, it will resolve the driver dependency to `faunadb@2.7.0` which is incompatible