### PR TITLE
FE-249 - remove https for add-endpoint localhost example

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ DESCRIPTION
 
 EXAMPLE
   $ fauna add-endpoint https://db.fauna.com:443
+  $ fauna add-endpoint http://localhost:8443/ --alias localhost --key secret
 ```
 
 _See code: [src/commands/add-endpoint.js](https://github.com/fauna/fauna-shell/blob/v0.9.9/src/commands/add-endpoint.js)_

--- a/src/commands/add-endpoint.js
+++ b/src/commands/add-endpoint.js
@@ -38,7 +38,7 @@ Adds a connection endpoint for FaunaDB
 
 AddEndpointCommand.examples = [
   '$ fauna add-endpoint https://db.fauna.com:443',
-  '$ fauna add-endpoint https://localhost:8443/ --alias localhost --key secret',
+  '$ fauna add-endpoint http://localhost:8443/ --alias localhost --key secret',
 ]
 
 // clear the default FaunaCommand flags that accept --host, --port, etc.


### PR DESCRIPTION
- https://faunadb.atlassian.net/browse/FE-249

# How to test
- Run `fauna add-endpoint --help` 
- Check if the localhost example use http instead of https. 
- If you have a localhost instance running, you should be able to copy/paste that example and run it flawlessly.

# Screenshot
![image](https://user-images.githubusercontent.com/60099077/72994987-e4d9dc00-3dd6-11ea-9121-48f4e7d3dba2.png)
 