### PR TITLE
FE-318 | Update faunadb version in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1669,6 +1669,11 @@
         "esutils": "^2.0.2"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -2153,13 +2158,14 @@
       }
     },
     "faunadb": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/faunadb/-/faunadb-2.10.0.tgz",
-      "integrity": "sha512-VQn9zvNcti5s/FQGG14b0uhvkRo/zoR4Wk+HXIP0oOdXps/gvF/U1xJd7SFWC8asEm0bm4MnJm1GCKeVJ6HaDA==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/faunadb/-/faunadb-2.11.1.tgz",
+      "integrity": "sha512-kRb0Au0zeDYRk/JXO9YJnGo7JVE2hdvVcv99THNbWlQIyOlH9KVZsaAelNHe6fzPl+qZtMjNxDO+6V092SF2xg==",
       "requires": {
         "base64-js": "^1.2.0",
         "btoa-lite": "^1.0.0",
         "cross-fetch": "^3.0.4",
+        "dotenv": "^8.2.0",
         "fn-annotate": "^1.1.3",
         "object-assign": "^4.1.0",
         "url-parse": "^1.4.7",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "cli-ux": "^4.8.0",
     "escodegen": "^1.12.0",
     "esprima": "^4.0.1",
-    "faunadb": "^2.10.0",
+    "faunadb": "^2.11.1",
     "globby": "8",
     "heroku-cli-util": "^8.0.9",
     "ini": "^1.3.5",


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-318)

Updates the version of `faunadb` from `2.10.0` to `2.11.1`

### How to test
1. Run the shell from your local repo: `./bin/run shell --endpoint [endpoint_name]`
2. Run a query using the new `Documents` function:
```
Paginate(Documents(Collection("customers")));
```
3. You should see results like this:
```
{ data:
   [ Ref(Collection("customers"), "256991337250816512"),
     Ref(Collection("customers"), "256991337255010816"),
     Ref(Collection("customers"), "256991337258156544") ] }
```