### PR TITLE
FE-306 | Fix bug where shell only returns results from last FQL expression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fauna-shell",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/commands/shell.js
+++ b/src/commands/shell.js
@@ -71,6 +71,7 @@ function startShell(client, endpoint, dbscope, log) {
     defaultEval(cmd, ctx, filename, function (error, result) {
       let res = esprima.parseScript(cmd)
 
+      
       if (error) {
         if (isRecoverableError(error)) {
           return cb(new repl.Recoverable(error))
@@ -89,7 +90,11 @@ function startShell(client, endpoint, dbscope, log) {
         })
         .catch(error => {
           ctx.lastError = error
-          log('Error:', error.message)
+          log('Error:', error.faunaError.message)
+          console.log(util.inspect(JSON.parse(error.faunaError.requestResult.responseRaw), {
+            depth: null,
+            compact: false
+          }))
 
           if (error instanceof faunadb.errors.FaunaHTTPError) {
             console.log(util.inspect(error.errors(), {depth: null}))


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-306)

### How to test
1. Navigate into the directory for your local `fauna-shell` repo
2. Connect to a local DB endpoint using the executable in the `bin/` directory

```bash
$ bin/run shell --endpoint localhost_hi
```
3. Execute queries with multiple expressions delimited by semicolons. For example:

```
Paginate(Collections());
Paginate(Indexes());
```

4. You should see the results from ALL the FQL expressions, not just the last one

**Updated**
5. Also try this query, which @trevorsibanda discovered wasn't outputting the proper error message. Now, it should work properly:

```
[CreateCollection({name: "orders"}), CreateIndex({name: "idx", source: Collection("x2")})]
```
### Screenshots
![image](https://user-images.githubusercontent.com/59929076/75185646-727d5400-5714-11ea-8bb5-2658e8146433.png)
