### PR TITLE
minor: don't add extra array on eval output

### DIFF
--- a/src/lib/misc.js
+++ b/src/lib/misc.js
@@ -381,7 +381,12 @@ function wrapQueries(expressions, client) {
 }
 
 function runQueries(expressions, client) {
-  return promiseSerial(wrapQueries(expressions, client))
+  if (expressions.length == 1) {
+    var f = wrapQueries(expressions, client)[0]
+    return f()
+  } else {
+    return promiseSerial(wrapQueries(expressions, client))
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
the following code is producing the wrong result on the output
```
$ fauna eval 'Add(1, 1)'
[ 2 ]
```
it should not be adding the array around the result.
