### PR TITLE
FE-580 | Prevent esprima error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fauna-shell",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fauna-shell",
   "description": "faunadb shell",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "author": "Fauna",
   "bin": {
     "fauna": "./bin/run"

--- a/src/commands/shell.js
+++ b/src/commands/shell.js
@@ -69,9 +69,13 @@ function startShell(client, endpoint, dbscope, log) {
       return cb()
     }
     defaultEval(cmd, ctx, filename, function (error, result) {
-      let res = esprima.parseScript(cmd)
+      let res
+      try {
+        res = esprima.parseScript(cmd)
+      } catch (err) {
+        res = cmd
+      }
 
-      
       if (error) {
         if (isRecoverableError(error)) {
           return cb(new repl.Recoverable(error))


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-580)

1. This PR adds a `try / catch` to better handle the issue with `esprima.parseScript`
2. Bumps to `0.11.4`