### PR TITLE
Instruction for secret-key login through 3rd party

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ fauna cloud-login
 
 You will be prompted for your `email` and `password` from your [FaunaDB Cloud](https://dashboard.fauna.com/) account.
 
-If you would like to use 3rd party identity providers like Github or Netlify, please refer to [this guide](https://docs.fauna.com/fauna/current/start/cloud-github.html)
+If you would like to use 3rd party identity providers like Github or Netlify, please refer to [this guide](https://docs.fauna.com/fauna/current/start/cloud-github.html).
 
 Now that we have an endpoint to connect to we can try to create a database to start playing with FaunaDB. See [connecting to different endpoints](#connecting-to-different-endpoints).
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ $ fauna cloud-login
 
 You will be prompted for your `email` and `password` from your [FaunaDB Cloud](https://dashboard.fauna.com/) account.
 
+If you would like to use 3rd party identity providers like Github or Netlify, please refer to [this guide](https://docs.fauna.com/fauna/current/start/cloud-github.html)
+
 Now that we have an endpoint to connect to we can try to create a database to start playing with FaunaDB. See [connecting to different endpoints](#connecting-to-different-endpoints).
 
 This is how you can create a database called `my_app`:


### PR DESCRIPTION
# Hi! :D

When I'm trying out fauna shell, I was attempting to login through netlify, as I was following this README file for guidance I didn't see such option clearly outlined.  Though, good news for me, I found your official [documentation](https://docs.fauna.com/fauna/current/start/cloud-github.html) and I think its quite useful.

Since Netlify and FaunaDB goes so well together, I think I'm not alone in using netlify as identity provider to login to FaunaDB, I think its logical and fluent to put a reference to the guide in the README. :D