### PR TITLE
chain the promise of output being written

### DIFF
--- a/src/commands/eval.js
+++ b/src/commands/eval.js
@@ -71,7 +71,7 @@ function performQuery(client, fqlQuery, outputFile, outputFormat) {
   let res = esprima.parseScript(fqlQuery)
   return runQueries(res.body, client)
   .then(function (response) {
-    writeFormattedOutput(outputFile, response, outputFormat)
+    return writeFormattedOutput(outputFile, response, outputFormat)
   })
   .catch(function (err) {
     errorOut(infoMessage(err), 1)


### PR DESCRIPTION
In my project I am programmatically calling fauna-shell's `eval` command and then parsing the file generated by using the `--output` option.

**The problem is that it sometimes start reading the content of the output file even before it is written by the eval command**.

As far as I can tell, it could be solved by chaining the promises involved in the generation of the output files. More specifically, it would be enough to add a return to the currently non chained promise at https://github.com/fauna/fauna-shell/blob/26cc017a925f21da7390be3b4de42f7247de921b/src/commands/eval.js#L73:L75

**Related:**

* https://github.com/zvictor/faugra/issues/4

* https://github.com/zvictor/faugra/commit/1399542a5627ea398625830de20e7d1bdbb7bd59