### PR TITLE
FE-812 | bump Driver to 4.0.0-preview.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fauna-shell",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -625,6 +625,14 @@
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.2.tgz",
       "integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg==",
       "dev": true
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
     },
     "acorn": {
       "version": "5.7.4",
@@ -1572,11 +1580,11 @@
       }
     },
     "cross-fetch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.5.tgz",
-      "integrity": "sha512-FFLcLtraisj5eteosnX1gf01qYDCOc4fDy0+euOt8Kn9YBY2NtXL/pCoYPavw24NIQkQqm5ZOLsGD5Zzj0gyew==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
       "requires": {
-        "node-fetch": "2.6.0"
+        "node-fetch": "2.6.1"
       }
     },
     "cross-spawn": {
@@ -2031,6 +2039,11 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
     "execa": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
@@ -2255,13 +2268,14 @@
       }
     },
     "faunadb": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/faunadb/-/faunadb-3.0.1.tgz",
-      "integrity": "sha512-WlfPjC0V9xHs4NTunOWmYZtJfbJ45Z1VAIKKka6+mRrmijWOFQzJVDY9CqS6X9kvepM36EjmtNkIvV0OJ1wTEA==",
+      "version": "4.0.0-preview.1",
+      "resolved": "https://registry.npmjs.org/faunadb/-/faunadb-4.0.0-preview.1.tgz",
+      "integrity": "sha512-xoE7tMqIiATPTCuzRRM9X3LrEouyn93F+Y5X+FsO1yEIDSq25gTYNYvPQe+41zhrLlIrqiVygsWpYYgPm0qF1w==",
       "requires": {
+        "abort-controller": "^3.0.0",
         "base64-js": "^1.2.0",
         "btoa-lite": "^1.0.0",
-        "cross-fetch": "^3.0.4",
+        "cross-fetch": "^3.0.6",
         "dotenv": "^8.2.0",
         "fn-annotate": "^1.1.3",
         "object-assign": "^4.1.0",
@@ -4032,9 +4046,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -4755,9 +4769,9 @@
       }
     },
     "querystringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "ramda": {
       "version": "0.26.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "cli-ux": "^4.8.0",
     "escodegen": "^1.12.0",
     "esprima": "^4.0.1",
-    "faunadb": "^3.0.1",
+    "faunadb": "^4.0.0-preview.1",
     "globby": "8",
     "heroku-cli-util": "^8.0.9",
     "ini": "^1.3.5",


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-812)

This PR upgrades the internal JS Driver dependency to `4.0.0-preview.1`

### Test
1. Pull down this branch
2. Test out normal shell functionality like this: `bin/run [COMMAND]`
3. Connect to an endpoint
4. Confirm the new API v4 functions are available/work