### PR TITLE
chore: use driver patch 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2268,9 +2268,8 @@
       }
     },
     "faunadb": {
-      "version": "4.0.0-preview.1",
-      "resolved": "https://registry.npmjs.org/faunadb/-/faunadb-4.0.0-preview.1.tgz",
-      "integrity": "sha512-xoE7tMqIiATPTCuzRRM9X3LrEouyn93F+Y5X+FsO1yEIDSq25gTYNYvPQe+41zhrLlIrqiVygsWpYYgPm0qF1w==",
+      "version": "git+https://github.com/fauna/faunadb-js.git#135256ed60a8043201085f18ed6fd2032cc9dd88",
+      "from": "git+https://github.com/fauna/faunadb-js.git#triage/bearer-to-basic",
       "requires": {
         "abort-controller": "^3.0.0",
         "base64-js": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dotenv": "^8.2.0",
     "escodegen": "^1.12.0",
     "esprima": "^4.0.1",
-    "faunadb": "^4.0.0-preview.1",
+    "faunadb": "git+https://github.com/fauna/faunadb-js.git#triage/bearer-to-basic",
     "globby": "8",
     "heroku-cli-util": "^8.0.9",
     "ini": "^1.3.5",


### PR DESCRIPTION
### Notes

This PR patches the Shell to use the `Basic` not `Bearer` authorization header as per this PR: https://github.com/fauna/faunadb-js/pull/368