### PR TITLE
FE-956 | Revert Driver dependency to 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2268,8 +2268,9 @@
       }
     },
     "faunadb": {
-      "version": "git+https://github.com/fauna/faunadb-js.git#135256ed60a8043201085f18ed6fd2032cc9dd88",
-      "from": "git+https://github.com/fauna/faunadb-js.git#triage/bearer-to-basic",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/faunadb/-/faunadb-4.0.0.tgz",
+      "integrity": "sha512-tXiGthGdbInZ6hzdmGFxnxqsQe2mKq+pnOc+zHZYXtD8TDgKWpK0F9M0tmRpD0uoQUrBHzXU7hxE24pJJxPdbQ==",
       "requires": {
         "abort-controller": "^3.0.0",
         "base64-js": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dotenv": "^8.2.0",
     "escodegen": "^1.12.0",
     "esprima": "^4.0.1",
-    "faunadb": "git+https://github.com/fauna/faunadb-js.git#triage/bearer-to-basic",
+    "faunadb": "^4.0.0",
     "globby": "8",
     "heroku-cli-util": "^8.0.9",
     "ini": "^1.3.5",


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-956)

This PR reverts the hotfix we made on release day for the JS Driver dependency: #71 

Now that Core has been updated, we can resume using Bearer for our authorization header.