### PR TITLE
FE-913 | chore: update cloud-login prompt

### DIFF
--- a/src/commands/cloud-login.js
+++ b/src/commands/cloud-login.js
@@ -32,7 +32,7 @@ class CloudLoginCommand extends FaunaCommand {
 
 async function cloudStrategy({log}) {
   log('For email login, enter your email below, and then your password.')
-  log('For login with 3rd-party identity providers like Github or Netlify, please acquire a key from Dashboard > Security and enter it below instead.')
+  log('For login with 3rd-party identity providers like Github or Netlify, please acquire a key from Home > [database] > Security and enter it below instead.')
   log('')
 
   const credential = await cli.prompt('Email or secret key')


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-913)

In [this Dashboard PR](https://github.com/fauna/console2/pull/882), we updated our breadcrumbs. To match that new pattern, we are now updating the `cloud-login` prompt in Shell to reflect that change.

### How to test
1. Go to `/fauna-shell` in your terminal
2. Run `bin/run cloud-login`
3. Confirm you see the proper prompt

### Screenshots
<img width="1233" alt="image" src="https://user-images.githubusercontent.com/4997781/100155866-fe740600-2e75-11eb-9013-6f0e938684c4.png">
