### PR TITLE
Fix parse error

### DIFF
--- a/src/commands/cloud-login.js
+++ b/src/commands/cloud-login.js
@@ -72,19 +72,9 @@ async function emailStrategy(email) {
     return saveEndpointOrError(newEndpoint, alias, secret)
   })
   .catch(async function (error) {
-    let parsedError
-    try {
-      parsedError = JSON.parse(error.error)
-    } catch (_) {
-      throw error
-    }
+    if (!error.statusCode || !error.error || JSON.parse(error.error).code !== OTP_REQUIRED) throw error
 
-    // Check if call failed due to missing OTP code
-    if (error.error && parsedError.code === OTP_REQUIRED) {
-      return multiFactorVerification(formData)
-    }
-
-    throw error
+    return multiFactorVerification(formData)
   })
 }
 


### PR DESCRIPTION
### Notes
[https://faunadb.atlassian.net/browse/DRV-388](DRV-388)

shell failed to parse if the error comes not from fauna (for example connectivity issue)
Result before the fix:
```
(node:625) UnhandledPromiseRejectionWarning: SyntaxError: Unexpected token E in JSON at position 0
    at JSON.parse (<anonymous>)
    at /home/ben/node_modules/fauna-shell/src/commands/cloud-login.js:76:29
    at tryCatcher (/home/ben/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/home/ben/node_modules/bluebird/js/release/promise.js:547:31)
    at Promise._settlePromise (/home/ben/node_modules/bluebird/js/release/promise.js:604:18)
    at Promise._settlePromise0 (/home/ben/node_modules/bluebird/js/release/promise.js:649:10)
    at Promise._settlePromises (/home/ben/node_modules/bluebird/js/release/promise.js:725:18)
    at _drainQueueStep (/home/ben/node_modules/bluebird/js/release/async.js:93:12)
    at _drainQueue (/home/ben/node_modules/bluebird/js/release/async.js:86:9)
    at Async._drainQueues (/home/ben/node_modules/bluebird/js/release/async.js:102:5)
    at Immediate.Async.drainQueues (/home/ben/node_modules/bluebird/js/release/async.js:15:14)
    at runCallback (timers.js:705:18)
    at tryOnImmediate (timers.js:676:5)
    at processImmediate (timers.js:658:5)
```
Result after fix:
```
(node:6767) UnhandledPromiseRejectionWarning: RequestError: Error: getaddrinfo ENOTFOUND auth.console.fauna.com
    at new RequestError (/Users/szinkevych/projects/faunadb/fauna-shell/node_modules/request-promise-core/lib/errors.js:14:15)
    at Request.plumbing.callback (/Users/szinkevych/projects/faunadb/fauna-shell/node_modules/request-promise-core/lib/plumbing.js:87:29)
    at Request.RP$callback [as _callback] (/Users/szinkevych/projects/faunadb/fauna-shell/node_modules/request-promise-core/lib/plumbing.js:46:31)
    at self.callback (/Users/szinkevych/projects/faunadb/fauna-shell/node_modules/request/request.js:185:22)
    at Request.emit (events.js:315:20)
    at Request.EventEmitter.emit (domain.js:482:12)
    at Request.onRequestError (/Users/szinkevych/projects/faunadb/fauna-shell/node_modules/request/request.js:881:8)
    at ClientRequest.emit (events.js:315:20)
    at ClientRequest.EventEmitter.emit (domain.js:482:12)
    at TLSSocket.socketErrorListener (_http_client.js:426:9)
    at TLSSocket.emit (events.js:315:20)
    at TLSSocket.EventEmitter.emit (domain.js:482:12)
    at emitErrorNT (internal/streams/destroy.js:92:8)
    at emitErrorAndCloseNT (internal/streams/destroy.js:60:3)
    at processTicksAndRejections (internal/process/task_queues.js:84:21)
```

So fix allow to send the core error rather than parsing one. Probably still need to enhance error messaging, but at least this error log would be more useful for debugging if a user comes to us with an issue.

### How to test
1. disable internet connection
2. run
```
fauna cloud-login
```
3. enter any email
4. enter any password