### PR TITLE
OSS-803: wrap query if it's object

### DIFF
--- a/src/commands/shell.js
+++ b/src/commands/shell.js
@@ -80,7 +80,7 @@ class ShellCommand extends FaunaCommand {
       originalEval(cmd, ctx, filename, async (_err, result) => {
         try {
           if (_err) throw _err
-          const res = esprima.parseScript(cmd)
+          const res = esprima.parseScript(`(${cmd})`)
           await this.executeFql({ ctx, fql: res.body }).then(cb)
         } catch (error) {
           if (error.name === 'SyntaxError') {

--- a/test/commands/shell.test.js
+++ b/test/commands/shell.test.js
@@ -97,7 +97,7 @@ describe('shell', () => {
     )
   })
 
-  it('run not valid JS', async () => {
+  it('run value FQL which is not valid JS', async () => {
     await new Promise((resolve, reject) => {
       shell.repl.eval(
         "{ name: 'Hen Wen', age: Add(100, 10) }",

--- a/test/commands/shell.test.js
+++ b/test/commands/shell.test.js
@@ -97,6 +97,23 @@ describe('shell', () => {
     )
   })
 
+  it('run not valid JS', async () => {
+    await new Promise((resolve, reject) => {
+      shell.repl.eval(
+        "{ name: 'Hen Wen', age: Add(100, 10) }",
+        repl.context,
+        '',
+        (err) => {
+          if (err) return reject(err)
+          expect(consoleLog.lastCall.args[0]).to.string(
+            '{"object":{"name":"Hen Wen","age":{"add":[100,10]}}}'
+          )
+          resolve()
+        }
+      )
+    })
+  })
+
   it('run fql that return an error', async () => {
     const fql = q.Divide(10, 0)
 


### PR DESCRIPTION
### Notes
[Syntax for objects does not work as expecte](https://faunadb.atlassian.net/browse/OSS-803)

When query is not a valid JS code (like: `{ name: 'Hen Wen', age: Add(100, 10) }`), but valid FQL, shell throw an error