### PR TITLE
chore: Updated npm token location for concourse pipeline

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -26,4 +26,4 @@ jobs:
       - task: publish
         file: fauna-shell-repository/concourse/tasks/publish.yml
         params:
-          NPM_TOKEN: ((fauna/npm.token))
+          NPM_TOKEN: ((npm_token))


### PR DESCRIPTION
### Notes
The location of npm token has changed in the vault, so this PR updated that location for concourse pipeline