### PR TITLE
fix(oss-808): error message for eval cmd

### DIFF
--- a/src/commands/eval.js
+++ b/src/commands/eval.js
@@ -68,8 +68,13 @@ function performQuery(client, fqlQuery, outputFile, outputFormat) {
     .then(function (response) {
       return writeFormattedOutput(outputFile, response, outputFormat)
     })
-    .catch(function (err) {
-      errorOut(infoMessage(err), 1)
+    .catch(function (error) {
+      console.log(
+        util.inspect(JSON.parse(error.faunaError.requestResult.responseRaw), {
+          depth: null,
+          compact: false,
+        })
+      )
     })
 }
 

--- a/src/commands/eval.js
+++ b/src/commands/eval.js
@@ -7,20 +7,6 @@ const { readFile, runQueries, errorOut, writeFile } = require('../lib/misc.js')
 
 const EVAL_OUTPUT_FORMATS = ['json', 'shell']
 
-function infoMessage(err) {
-  const fe = util.inspect(err.faunaError, { depth: null })
-  return `
-  The following query failed:
-    ${err.exp}
-
-  With error message:
-    ${fe}
-
-  Query number:
-    ${err.queryNumber}
-  `
-}
-
 /**
  * Write json encoded output
  *


### PR DESCRIPTION
### Notes
[The eval command produces different output for queries with Abort than the shell command](https://faunadb.atlassian.net/browse/OSS-808)