### PR TITLE
fix(oss-847): wrap json

### DIFF
--- a/.github/workflows/close-jira-ticket.yml
+++ b/.github/workflows/close-jira-ticket.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login
-        uses: atlassian/gajira-login@main
+        uses: atlassian/gajira-login@master
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
@@ -25,12 +25,12 @@ jobs:
 
       - name: Parse ticket number
         id: ticketNumber
-        uses: atlassian/gajira-find-issue-key@main
+        uses: atlassian/gajira-find-issue-key@master
         with:
           string: ${{ steps.botComment.outputs.comment-body }}
 
       - name: Close ticket
-        uses: atlassian/gajira-transition@main
+        uses: atlassian/gajira-transition@master
         with:
           issue: ${{ steps.ticketNumber.outputs.issue }}
           transition: "DONE"

--- a/.github/workflows/create-jira-ticket-on-issue.yml
+++ b/.github/workflows/create-jira-ticket-on-issue.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login
-        uses: atlassian/gajira-login@main
+        uses: atlassian/gajira-login@master
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
@@ -51,7 +51,7 @@ jobs:
 
       - name: Create ticket
         id: create
-        uses: atlassian/gajira-create@main
+        uses: atlassian/gajira-create@master
         if: ${{ steps.isOrgMember.outputs.result == 'false' }}
         with:
           project: DRV
@@ -62,7 +62,7 @@ jobs:
 
       - name: Set triage state
         if: ${{ steps.create.outputs.issue }}
-        uses: atlassian/gajira-transition@main
+        uses: atlassian/gajira-transition@master
         with:
           issue: ${{ steps.create.outputs.issue }}
           transition: "TRIAGE"

--- a/src/commands/eval.js
+++ b/src/commands/eval.js
@@ -49,7 +49,7 @@ function writeFormattedOutput(file, data, format) {
 }
 
 function performQuery(client, fqlQuery, outputFile, outputFormat) {
-  let res = esprima.parseScript(fqlQuery)
+  let res = esprima.parseScript(`(${fqlQuery})`)
   return runQueries(res.body, client)
     .then(function (response) {
       return writeFormattedOutput(outputFile, response, outputFormat)


### PR DESCRIPTION
### Notes
[OSS-847 eval command produces different results than interactive query](https://faunadb.atlassian.net/browse/OSS-847)

When I run `fauna-shell` interactively, this query provides the expected result:

```
> { terms: [ { binding: 'binding1' }, { field: ['data', 'field'] } ] }
{
  terms: [ { binding: 'binding1' }, { field: [ 'data', 'field' ] } ]
}
```
However, when I run fauna eval --file=test.shell (where the file test.shell contains the query above, the result is:

```
[ { binding: 'binding1' }, { field: [ 'data', 'field' ] } ]
```
Note that the outer object and field name are missing.