### PR TITLE
OSS-949: Improve the help text for the import command

### DIFF
--- a/src/commands/import.js
+++ b/src/commands/import.js
@@ -203,7 +203,7 @@ ImportCommand.flags = {
   }),
   collection: flags.string({
     description:
-      'Collection name. When not specified, the collection name is the filename when --path is file, otherwise folder name',
+      'Collection name. When not specified, the collection name is the filename when --path is file',
     required: false,
   }),
   type: flags.string({

--- a/src/commands/import.js
+++ b/src/commands/import.js
@@ -196,22 +196,22 @@ const { graphqlHost, graphqlPort, ...commonFlags } = FaunaCommand.flags
 ImportCommand.flags = {
   path: flags.string({
     required: true,
-    description: 'Path to .csv/.json file either to dir with .csv/.json files',
+    description: 'Path to .csv/.json file, or path to folder containing .csv/.json files',
   }),
   db: flags.string({
-    description: 'Child database name',
+    description: 'Child database name; imported documents are stored in this database',
   }),
   collection: flags.string({
     description:
-      'Collection name. By default filename if --source is file, otherwise omitted',
+      'Collection name. When not specified, the collection name is the filename when --path is file, otherwise folder name',
     required: false,
   }),
   type: flags.string({
-    description: 'Column type casting. Might be `number`, `bool` or `date`',
+    description: `Column type casting, converts the column value to a Fauna type.\nFormat: header_name|hdr<X>::<type>\nheader_name: apply cast to field name\n<X>: column offset (hdr1 means first column)\n<type>: one of 'number', 'bool', or 'date'.`,
     multiple: true,
   }),
   append: flags.boolean({
-    description: 'Allow append data to non empty collection',
+    description: 'Allows appending documents to a non-empty collection',
   }),
   ...commonFlags,
 }

--- a/src/commands/import.js
+++ b/src/commands/import.js
@@ -207,7 +207,7 @@ ImportCommand.flags = {
     required: false,
   }),
   type: flags.string({
-    description: `Column type casting, converts the column value to a Fauna type.\nFormat: header_name|hdr<X>::<type>\nheader_name: apply cast to field name\n<X>: column offset (hdr1 means first column)\n<type>: one of 'number', 'bool', or 'date'.`,
+    description: `Column type casting, converts the column value to a Fauna type.\nFormat: <column>::<type>\n<column>: the name of the column to cast values\n<type>: one of 'number', 'bool', or 'date'.`,
     multiple: true,
   }),
   append: flags.boolean({


### PR DESCRIPTION
### Notes

Expanded the description of the `--type` flag, clarified where the collection name comes from, and applied a bit of word smithing.

### How to test

`bin/run help import`

### Screenshots

N/A