### PR TITLE
add comment about database reliance on X-Fauna-Source

### DIFF
--- a/src/commands/cloud-login.js
+++ b/src/commands/cloud-login.js
@@ -265,6 +265,12 @@ class CloudLoginCommand extends FaunaCommand {
       secret: data.secret,
       domain: url.parse(dbUrl).hostname,
       headers: {
+        /**
+         * The database currently relies on this value to be able to turn off the data importer for a specific
+         * customer while still allowing them to use the SDKs for traffic (where there production workloads are likely
+         * to originate from).  This is done to ensure that traffic from the data importer tool doesn't overload the
+         * system. Please consult the database team before changing this header value.
+         */
         'X-Fauna-Source': 'Fauna Shell',
       },
     })

--- a/src/lib/fauna-command.js
+++ b/src/lib/fauna-command.js
@@ -62,6 +62,12 @@ class FaunaCommand extends Command {
       const client = new faunadb.Client({
         ...clientOptions,
         headers: {
+          /**
+           * The database currently relies on this value to be able to turn off the data importer for a specific
+           * customer while still allowing them to use the SDKs for traffic (where there production workloads are likely
+           * to originate from).  This is done to ensure that traffic from the data importer tool doesn't overload the
+           * system. Please consult the database team before changing this header value.
+           */
           'X-Fauna-Source': 'Fauna Shell',
         },
       })
@@ -97,6 +103,12 @@ class FaunaCommand extends Command {
       const client = new faunadb.Client({
         ...clientOptions,
         headers: {
+          /**
+           * The database currently relies on this value to be able to turn off the data importer for a specific
+           * customer while still allowing them to use the SDKs for traffic (where there production workloads are likely
+           * to originate from).  This is done to ensure that traffic from the data importer tool doesn't overload the
+           * system. Please consult the database team before changing this header value.
+           */
           'X-Fauna-Source': 'Fauna Shell',
         },
       })


### PR DESCRIPTION
As part of a recent lse where a customer overloaded us with traffic using the data import tool, the database team has taken an AI to provide the ability to turn off a customer's data import tool traffic while still allowing other production traffic using the SDKs.  The implementation of this change will prevent all customer traffic coming from the fauna shell (web shell will still be allowed).  This depends on the X-Fauna-Source header containing the exact string 'Fauna Shell'.

https://faunadb.atlassian.net/browse/ENG-3117
https://github.com/fauna/core/pull/8253