### PR TITLE
[FE-2099] emit our own error object from each batch request in the importer - allowing us to do more advanced rate limiting

### DIFF
--- a/src/lib/fauna-import-writer.js
+++ b/src/lib/fauna-import-writer.js
@@ -2,6 +2,7 @@ const q = require('faunadb').query
 const { FaunaObjectTranslator } = require('./fauna-object-translator')
 const sizeof = require('object-sizeof')
 const RateLimiter = require('limiter').RateLimiter
+const FaunaHTTPError = require('faunadb').errors.FaunaHTTPError
 
 /**
  * Creates a function that consumes a stream of objects and writes creates each object
@@ -27,6 +28,14 @@ function getFaunaImportWriter(
   bytesPerSecondLimit = 400000,
   maxParallelRequests = 10
 ) {
+  class BatchError extends Error {
+    statusCode
+
+    constructor(message, statusCode) {
+      super(message)
+      this.statusCode = statusCode
+    }
+  }
   const faunaObjectTranslator = new FaunaObjectTranslator(typeTranslations)
 
   const waitForRateLimitTokens = (tokens, rateLimiter) => {
@@ -57,9 +66,17 @@ function getFaunaImportWriter(
       const currentItemNumbers = itemNumbers.splice(0, batchSize)
       promiseBatches.push(
         requestBatch(itemsToBatch.splice(0, batchSize)).catch((e) => {
-          throw new Error(`item numbers: ${currentItemNumbers} \
-(zero-indexed) in your input file '${inputFile}' failed to persist in Fauna due to: \
-${e.message}. Continuing ...`)
+          const getMessage = (
+            subMessage
+          ) => `item numbers: ${currentItemNumbers} (zero-indexed) in your \
+input file '${inputFile}' failed to persist in Fauna due to: '${subMessage}' - Continuing ...`
+          if (e instanceof FaunaHTTPError) {
+            throw new BatchError(
+              getMessage(e.description),
+              e.requestResult.statusCode
+            )
+          }
+          throw new Error(getMessage(e.message))
         })
       )
     }
@@ -69,7 +86,7 @@ ${e.message}. Continuing ...`)
   const logSettlements = (settlements) => {
     for (let settlement of settlements) {
       if (settlement.status === 'rejected') {
-        logger(settlement.reason)
+        logger(settlement.reason.message)
       }
     }
   }

--- a/test/lib/fauna-import-writer.test.js
+++ b/test/lib/fauna-import-writer.test.js
@@ -2,6 +2,7 @@ const expect = require('expect')
 const getFaunaImportWriter = require('../../src/lib/fauna-import-writer')
 const jestMock = require('jest-mock')
 const sizeof = require('object-sizeof')
+const { TooManyRequests } = require('faunadb').errors
 
 describe('FaunaImportWriter', () => {
   describe('Error handling', () => {
@@ -80,7 +81,14 @@ describe('FaunaImportWriter', () => {
         )
         .mockReturnValueOnce(Promise.resolve())
         .mockReturnValueOnce(
-          Promise.reject(new Error('Transaction failure two'))
+          Promise.reject(
+            new TooManyRequests({
+              statusCode: 429,
+              responseContent: {
+                errors: [{ description: 'Too many pending requests.' }],
+              },
+            })
+          )
         )
       await myImportWriter(myAsyncIterable)
       expect(logHistory.length).toBe(4)
@@ -89,22 +97,18 @@ describe('FaunaImportWriter', () => {
 into the requested format due to: Invalid number 'foo' cannot be translated to a \
 number. Skipping this item and continuing."
       )
-      expect(logHistory[1]).toMatchObject(
-        new Error(
-          "item numbers: 3,4 (zero-indexed) in your input file 'my-file' failed to persist in Fauna due to: \
-Transaction failure one. Continuing ..."
-        )
+      expect(logHistory[1]).toContain(
+        "item numbers: 3,4 (zero-indexed) in your input file 'my-file' failed to persist in Fauna due to: \
+'Transaction failure one' - Continuing ..."
       )
       expect(logHistory[2]).toContain(
         "item number 7 (zero-indexed) in your input file 'my-file' could not be translated \
 into the requested format due to: Invalid number 'bar' cannot be translated \
 to a number. Skipping this item and continuing."
       )
-      expect(logHistory[3]).toMatchObject(
-        new Error(
-          "item numbers: 8,9 (zero-indexed) in your input file 'my-file' failed to persist in Fauna due to: \
-Transaction failure two. Continuing ..."
-        )
+      expect(logHistory[3]).toContain(
+        "item numbers: 8,9 (zero-indexed) in your input file 'my-file' failed to persist in Fauna due to: \
+'Too many pending requests.' - Continuing ..."
       )
       expect(myMock).toHaveBeenCalledTimes(4)
     })


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-2099)

Emit our own custom error when doing each batch request in the importer.

Why?

- this will allow us to examine our status codes to do more advanced rate limiting and retry on the client side.
- 
### How to test

`npm run test`

