### PR TITLE
[FE-2102] Add rate limiter on write ops

### DIFF
--- a/src/commands/import.js
+++ b/src/commands/import.js
@@ -144,8 +144,7 @@ class ImportCommand extends FaunaCommand {
           this.client,
           collection,
           path,
-          Boolean(this.flags['dry-run']),
-          this.warn
+          { isDryRun: Boolean(this.flags['dry-run']), logger: this.warn }
         ),
         (error) => {
           if (error) return reject(error)


### PR DESCRIPTION
### Notes
[Jira Ticket](https://faunadb.atlassian.net/browse/FE-2102)

Add a second rate limiter to rate limit on write ops.

We still need to:
- Set a sane writeOps/sec default
- Rate limit on requests/sec
- Add rate limit penalty on certain error codes
- Utilize the `Union` functionality of the rate limiter to clean up the code (optional)

### Notes
Ran tests locally