### PR TITLE
Set read timeout (for client waiting for data from server) > queryTimeout (basically server side timeout - how long it will wait before giving up on request). Retry ECONNRESET to account for networking errors that do not indicate any data written

### DIFF
--- a/src/lib/fauna-import-writer.js
+++ b/src/lib/fauna-import-writer.js
@@ -131,8 +131,6 @@ function getFaunaImportWriter(
   * [503] Timeout - do not retry
   */
   const retryHandler = (e) => {
-    /* logger(new Date().toISOString())
-     * logger(e) */
     if (e.code === 'ECONNRESET') {
       return true
     }


### PR DESCRIPTION
### Notes
Set timeout > queryTimeout - timeout (to address ETIMEDOUT) is the read timeout of the client waiting for the server to send data. We need that > queryTimeout to avoid hanging up early.

Retry ECONNRESET which indicate a connection was reset by the server - this is retryable as no data was transmitted.

[JIRA](https://faunadb.atlassian.net/browse/FE-2136)

### Testing

Ran Zee's workload to completion.