### PR TITLE
[FE-2135] Track number of failed rows during import

### DIFF
--- a/import_test_data/run_imports.sh
+++ b/import_test_data/run_imports.sh
@@ -92,20 +92,20 @@ run_type_tests () {
   
   cleanup_collection "date_type"
   $FAUNA_CMD import --endpoint data-import-test --type=birthday::dateString --path=type_tests/date_type.csv
-  if [ $? != 0 ];then
-    fail_test "date_type.csv didn't import with success"
+  if [ $? == 0 ];then
+    fail_test "date_type.csv didn't fail"
   fi
   
   cleanup_collection "bad_date_type"
   $FAUNA_CMD import --endpoint data-import-test --type=birthday::dateString --path=type_tests/bad_date_type.csv
-  if [ $? != 0 ];then
-    fail_test "bad_date_type.csv failed, but should succeed as it will skip bad rows"
+  if [ $? == 0 ];then
+    fail_test "bad_date_type.csv succeeded"
   fi
 
   cleanup_collection "bad_date_type"
   $FAUNA_CMD import --endpoint data-import-test --type=birthday::dateString --path=type_tests/bad_date_type.csv --dry-run
-  if [ $? != 0 ];then
-    fail_test "bad_date_type.csv imported in dry-run mode should have succeeded"
+  if [ $? == 0 ];then
+    fail_test "bad_date_type.csv imported in dry-run mode should have failed"
   fi
     
   cleanup_collection "number_type"
@@ -115,26 +115,26 @@ run_type_tests () {
   fi
 
   cleanup_collection "bad_number_type"
-  $FAUNA_CMD import --endpoint data-import-test --type=birthday::number --path=type_tests/bad_number_type.csv --dry-run
-  if [ $? != 0 ];then
-    fail_test "bad_number_type.csv imported in dry-run mode should have succeeded"
+  $FAUNA_CMD import --endpoint data-import-test --type=age::number --path=type_tests/bad_number_type.csv --dry-run
+  if [ $? == 0 ];then
+    fail_test "bad_number_type.csv imported in dry-run mode should have failed"
   fi
   
   cleanup_collection "bad_number_type"
   $FAUNA_CMD import --endpoint data-import-test --type=age::number --path=type_tests/bad_number_type.csv
-  if [ $? != 0 ];then
-    fail_test "bad_number_type.csv didn't didn't succeed, but should as it will skip bad rows"
+  if [ $? == 0 ];then
+    fail_test "bad_number_type.csv didn't fail"
   fi
 
   cleanup_collection "auto_type_translation"
   $FAUNA_CMD import --endpoint data-import-test --type=age::number --path=type_tests/auto_type_translation.csv
-  if [ $? == 1 ];then
+  if [ $? != 0 ];then
     fail_test "auto_type_translation.csv didn't import with success"
   fi
 
   cleanup_collection "default_null_inference"
   $FAUNA_CMD import --endpoint data-import-test --path=type_tests/default_null_inference.csv
-  if [ $? == 1 ];then
+  if [ $? != 0 ];then
     fail_test "default_null_inference.csv didn't import with success"
   fi
 }
@@ -160,8 +160,8 @@ short_row_tests () {
 
   cleanup_collection "short_rows_with_type_translations"
   $FAUNA_CMD import --endpoint data-import-test --allow-short-rows --type=number::number --type=date::dateString --type=boolean::bool --path=csv_row_len_tests/short_rows_with_type_translations.csv
-  if [ $? != 0 ];then
-    fail_test "short_rows_with_type_translations.csv import should have succeeded with --allow-short-rows flag"
+  if [ $? == 0 ];then
+    fail_test "short_rows_with_type_translations.csv import should have failed due to bad data"
   fi
 
   cleanup_collection "too_long_rows"
@@ -242,23 +242,23 @@ directory_tests() {
   cleanup_all_collections
   $FAUNA_CMD import --endpoint data-import-test --path=json
   if [ $? != 0 ];then
-    fail_test "directory import should always succeed even if files fail"
+    fail_test "directory should have succeeded"
   fi
   $FAUNA_CMD import --endpoint data-import-test --path=type_tests
   if [ $? != 0 ];then
-    fail_test "directory import should always succeed even if files fail"
+    fail_test "directory should have succeeded"
   fi
   $FAUNA_CMD import --endpoint data-import-test --path=csv_row_len_tests
-  if [ $? != 0 ];then
-    fail_test "directory import should always succeed even if files fail"
+  if [ $? == 0 ];then
+    fail_test "directory should have failed"
   fi
   $FAUNA_CMD import --endpoint data-import-test --path=header_tests
   if [ $? != 0 ];then
-    fail_test "directory import should always succeed even if files fail"
+    fail_test "directory should have succeeded"
   fi
   $FAUNA_CMD import --endpoint data-import-test --path=invalid_file_types
-  if [ $? != 0 ];then
-    fail_test "directory import should always succeed even if files fail"
+  if [ $? == 0 ];then
+    fail_test "directory should have failed"
   fi
   $FAUNA_CMD import --endpoint data-import-test --path=type_tests --collection=foo
 }

--- a/import_test_data/run_imports.sh
+++ b/import_test_data/run_imports.sh
@@ -47,10 +47,13 @@ ensure_db () {
 
   $FAUNA_CMD eval --stdin --endpoint data-import-test &> /dev/null << CMD
     If(
-      Exists(Database("db")),
-      "Database exists!",
-      CreateDatabase({name: "$DB"})
+      Exists(Database("$DB")),
+      Delete(Database("$DB")),
+      "already deleted"
     )
+CMD
+  $FAUNA_CMD eval --stdin --endpoint data-import-test &> /dev/null << CMD
+    CreateDatabase({name: "$DB"})
 CMD
 }
 

--- a/src/commands/import.js
+++ b/src/commands/import.js
@@ -85,13 +85,11 @@ class ImportCommand extends FaunaCommand {
 
     this.log('\n\nImport completed')
     if (failedFiles.length > 0) {
-      this.warn(`${failedFiles.length} files failed to import`)
       failedFiles.forEach((failed) =>
         this.warn(`${failed.file} => ${failed.warning}`)
       )
-    } else if (failedRows.numberFailedRows > 0) {
-      this.warn(
-        `Directory import finished incomplete. Total ${failedRows.numberFailedRows} rows/objects failed to import`
+      this.error(
+        `${failedFiles.length} files failed to import. Inspect each file message for the reason.`
       )
     } else {
       this.success('All files imported')
@@ -114,7 +112,7 @@ class ImportCommand extends FaunaCommand {
     const failedBeforeFile = failedRows.numberFailedRows
     await this.dataImport({ source, collection, path, failedRows })
     if (failedRows.numberFailedRows > failedBeforeFile) {
-      this.warn(
+      this.error(
         `File import from ${path} to ${collection} incomplete. ${failedRows.numberFailedRows} rows/object failed to import`
       )
     } else {
@@ -140,7 +138,7 @@ class ImportCommand extends FaunaCommand {
     const { name, ext } = p.parse(p.basename(path))
 
     if (!this.supportedExt.includes(ext)) {
-      throw new Error(`File (${path}) extension isn't supported`)
+      throw this.error(`File (${path}) extension isn't supported`)
     }
     return { name, ext, path }
   }

--- a/src/commands/import.js
+++ b/src/commands/import.js
@@ -34,10 +34,14 @@ class ImportCommand extends FaunaCommand {
       importFn = this.importFile
     }
 
-    return importFn.call(this, path).catch((error) => this.handleError(error))
+    const failedRows = { numberFailedRows: 0 }
+
+    return importFn
+      .call(this, path, failedRows)
+      .catch((error) => this.handleError(error))
   }
 
-  async importDir(path) {
+  async importDir(path, failedRows) {
     const files = fs.readdirSync(path)
 
     // check if folder size is approximately greater than 10GB
@@ -68,7 +72,7 @@ class ImportCommand extends FaunaCommand {
         continue
       }
       try {
-        await this.importFile(subPath)
+        await this.importFile(subPath, failedRows)
         if (this.flags.collection) {
           this.flags.append = true
         }
@@ -85,12 +89,16 @@ class ImportCommand extends FaunaCommand {
       failedFiles.forEach((failed) =>
         this.warn(`${failed.file} => ${failed.warning}`)
       )
+    } else if (failedRows.numberFailedRows > 0) {
+      this.warn(
+        `Directory import finished incomplete. Total ${failedRows.numberFailedRows} rows/objects failed to import`
+      )
     } else {
       this.success('All files imported')
     }
   }
 
-  async importFile(path) {
+  async importFile(path, failedRows) {
     // check if file size is approximately greater than 10GB
     if (this.calculateFileSize(path) > ImportLimits.maximumImportSize()) {
       throw new Error(
@@ -103,8 +111,15 @@ class ImportCommand extends FaunaCommand {
     if (!collection) {
       collection = source.name
     }
-    await this.dataImport({ source, collection, path })
-    this.success(`Import from ${path} to ${collection} completed`)
+    const failedBeforeFile = failedRows.numberFailedRows
+    await this.dataImport({ source, collection, path, failedRows })
+    if (failedRows.numberFailedRows > failedBeforeFile) {
+      this.warn(
+        `File import from ${path} to ${collection} incomplete. ${failedRows.numberFailedRows} rows/object failed to import`
+      )
+    } else {
+      this.success(`Import from ${path} to ${collection} completed`)
+    }
   }
 
   calculateFileSize(path) {
@@ -130,7 +145,7 @@ class ImportCommand extends FaunaCommand {
     return { name, ext, path }
   }
 
-  async dataImport({ source, collection, path }) {
+  async dataImport({ source, collection, path, failedRows }) {
     await this.ensureCollection({
       collection,
     })
@@ -144,6 +159,7 @@ class ImportCommand extends FaunaCommand {
           this.client,
           collection,
           path,
+          failedRows,
           { isDryRun: Boolean(this.flags['dry-run']), logger: this.warn }
         ),
         (error) => {

--- a/src/lib/fauna-import-writer.js
+++ b/src/lib/fauna-import-writer.js
@@ -180,6 +180,7 @@ function getFaunaImportWriter(
       const currentItemNumbers = itemNumbers.splice(0, batchSize)
       promiseBatches.push(
         requestBatch(itemsToBatch.splice(0, batchSize)).catch((e) => {
+          failedRowsObj.numberFailedRows += currentItemNumbers.length
           const getMessage = (
             subMessage
           ) => `item numbers: ${currentItemNumbers} (zero-indexed) in your \
@@ -225,7 +226,6 @@ input file '${inputFile}' failed to persist in Fauna due to: '${subMessage}' - C
       if (settlement.status === 'rejected') {
         settlementHandler(settlement)
         logger(settlement.reason.message)
-        failedRowsObj.numberFailedRows++
       } else {
         reducePenalties()
       }
@@ -266,6 +266,7 @@ input file '${inputFile}' failed to persist in Fauna due to: '${subMessage}' - C
       try {
         thisItem = faunaObjectTranslator.getRecord(chunk)
       } catch (e) {
+        failedRowsObj.numberFailedRows++
         logger(
           `item number ${itemNumber} (zero-indexed) in your input file '${inputFile}' could \
 not be translated into the requested format due to: ${e.message} Skipping \

--- a/src/lib/fauna-import-writer.js
+++ b/src/lib/fauna-import-writer.js
@@ -30,6 +30,7 @@ function getFaunaImportWriter(
   client,
   collection,
   inputFile,
+  failedRowsObj,
   {
     isDryRun = false,
     logger = console.log,
@@ -224,6 +225,7 @@ input file '${inputFile}' failed to persist in Fauna due to: '${subMessage}' - C
       if (settlement.status === 'rejected') {
         settlementHandler(settlement)
         logger(settlement.reason.message)
+        failedRowsObj.numberFailedRows++
       } else {
         reducePenalties()
       }

--- a/test/commands/import.test.js
+++ b/test/commands/import.test.js
@@ -290,10 +290,14 @@ describe('import', () => {
           '--type=age::number',
         ])
       )
+      .catch((err) => {
+        expect(err.message).to.contain('rows/object failed to import')
+        expect(err.oclif.exit).to.not.equal(0)
+      })
       .it(
         'creates a collection with type translations from a CSV; ignoring bad data',
         async (ctx) => {
-          expect(ctx.stdout).to.match(/Import from .* completed/)
+          expect(ctx.stdout).to.match(/Database connection established/)
           expect(ctx.stderr).to.match(/item number 1 \(zero-indexed\)/)
           const expected = [{ id: '1', name: 'mia', age: 14, sign: 'cancer' }]
           await doCollectionAssertions('zed', expected)
@@ -315,8 +319,12 @@ describe('import', () => {
           '--dry-run',
         ])
       )
+      .catch((err) => {
+        expect(err.message).to.contain('failed to import')
+        expect(err.oclif.exit).to.not.equal(0)
+      })
       .it('dry-run creates no collection but prints errors', async (ctx) => {
-        expect(ctx.stdout).to.match(/Import from .* completed/)
+        expect(ctx.stdout).to.match(/Database connection established/)
         expect(ctx.stderr).to.match(/item number 1 \(zero-indexed\)/)
         await assertCollectionDoesNotExist('nada')
       })

--- a/test/lib/fauna-import-writer.test.js
+++ b/test/lib/fauna-import-writer.test.js
@@ -19,6 +19,7 @@ describe('FaunaImportWriter', () => {
     let myMock
     let mockClient
     let myImportWriter
+    let myFailingImportWriter
     let mySlowImportWriterBytes
     let mySlowImportWriterWriteOps
     let mySlowImportWriterRequests
@@ -89,6 +90,14 @@ describe('FaunaImportWriter', () => {
         { numberFailedRows: 0 },
         defaultOptions
       )
+      myFailingImportWriter = getFaunaImportWriter(
+        ['numberField::number'],
+        mockClient,
+        'the-collection',
+        'my-file',
+        { numberFailedRows: 0 },
+        defaultOptions
+      )
       mySlowImportWriterBytes = getFaunaImportWriter(
         ['numberField::number'],
         mockClient,
@@ -125,6 +134,14 @@ describe('FaunaImportWriter', () => {
 
     afterEach(() => {
       console.log = originalConsoleLog
+    })
+
+    it('Logs number of failed transactions after parsing input', async () => {
+      myMock
+        .mockRejectedValueOnce(new Error('Transaction failure one'))
+        .mockRejectedValueOnce(new Error('Transaction failure two'))
+
+      await myFailingImportWriter(myAsyncIterable)
     })
 
     it('Logs the line numbers of items that fail to translate or persist to the DB', async () => {

--- a/test/lib/fauna-import-writer.test.js
+++ b/test/lib/fauna-import-writer.test.js
@@ -145,7 +145,7 @@ describe('FaunaImportWriter', () => {
         defaultOptions
       )
       await myFailingImportWriter(myAsyncIterable)
-      expect(failingRows.numberFailedRows).toEqual(4)
+      expect(failingRows.numberFailedRows).toEqual(10)
     })
 
     it('Logs the line numbers of items that fail to translate or persist to the DB', async () => {

--- a/test/lib/fauna-import-writer.test.js
+++ b/test/lib/fauna-import-writer.test.js
@@ -90,14 +90,6 @@ describe('FaunaImportWriter', () => {
         { numberFailedRows: 0 },
         defaultOptions
       )
-      myFailingImportWriter = getFaunaImportWriter(
-        ['numberField::number'],
-        mockClient,
-        'the-collection',
-        'my-file',
-        { numberFailedRows: 0 },
-        defaultOptions
-      )
       mySlowImportWriterBytes = getFaunaImportWriter(
         ['numberField::number'],
         mockClient,
@@ -136,12 +128,24 @@ describe('FaunaImportWriter', () => {
       console.log = originalConsoleLog
     })
 
-    it('Logs number of failed transactions after parsing input', async () => {
+    it('Correctly tracks number of failing rows', async () => {
       myMock
         .mockRejectedValueOnce(new Error('Transaction failure one'))
         .mockRejectedValueOnce(new Error('Transaction failure two'))
+        .mockRejectedValueOnce(new Error('Transaction failure three'))
+        .mockRejectedValueOnce(new Error('Transaction failure four'))
 
+      const failingRows = { numberFailedRows: 0 }
+      myFailingImportWriter = getFaunaImportWriter(
+        ['numberField::number'],
+        mockClient,
+        'the-collection',
+        'my-file',
+        failingRows,
+        defaultOptions
+      )
       await myFailingImportWriter(myAsyncIterable)
+      expect(failingRows.numberFailedRows).toEqual(4)
     })
 
     it('Logs the line numbers of items that fail to translate or persist to the DB', async () => {

--- a/test/lib/fauna-import-writer.test.js
+++ b/test/lib/fauna-import-writer.test.js
@@ -86,6 +86,7 @@ describe('FaunaImportWriter', () => {
         mockClient,
         'the-collection',
         'my-file',
+        { numberFailedRows: 0 },
         defaultOptions
       )
       mySlowImportWriterBytes = getFaunaImportWriter(
@@ -93,6 +94,7 @@ describe('FaunaImportWriter', () => {
         mockClient,
         'the-collection',
         'my-file',
+        { numberFailedRows: 0 },
         { ...defaultOptions, bytesPerSecondLimit: tiniestSize }
       )
       mySlowImportWriterWriteOps = getFaunaImportWriter(
@@ -100,6 +102,7 @@ describe('FaunaImportWriter', () => {
         mockClient,
         'the-collection',
         'my-file',
+        { numberFailedRows: 0 },
         { ...defaultOptions, writeOpsPerSecondLimit: 1 }
       )
       mySlowImportWriterRequests = getFaunaImportWriter(
@@ -107,6 +110,7 @@ describe('FaunaImportWriter', () => {
         mockClient,
         'the-collection',
         'my-file',
+        { numberFailedRows: 0 },
         { ...defaultOptions, requestsPerSecondLimit: 1 }
       )
       myDryRunWriter = getFaunaImportWriter(
@@ -114,6 +118,7 @@ describe('FaunaImportWriter', () => {
         mockClient,
         'the-collection',
         'my-file',
+        { numberFailedRows: 0 },
         { ...defaultOptions, isDryRun: true }
       )
     })


### PR DESCRIPTION
[FE-2135]

Currently, the importer reports a successful data import even when some rows/batches fail to resolve in the db. This PR updates the importer to track rows that fail to persist in the db and reports the failures at the end of the import.

### How to test
1. Start instance of faunadb
2. `npm run test`


[FE-2135]: https://faunadb.atlassian.net/browse/FE-2135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ