### PR TITLE
Improved rate limiting on importer

### DIFF
--- a/src/commands/import.js
+++ b/src/commands/import.js
@@ -9,7 +9,7 @@ const p = require('path')
 const q = faunadb.query
 const getFaunaImportWriter = require('../lib/fauna-import-writer')
 const { parse } = require('csv-parse')
-const ImportLimits = require('../lib/import-limits')
+const { ImportLimits } = require('../lib/import-limits')
 
 class ImportCommand extends FaunaCommand {
   supportedExt = ['.csv', '.json', '.jsonl']

--- a/src/lib/fauna-import-writer.js
+++ b/src/lib/fauna-import-writer.js
@@ -240,9 +240,9 @@ input file '${inputFile}' failed to persist in Fauna due to: '${subMessage}' - C
     let isFirstRequest = true
 
     const processItems = async () => {
-      console.log(`Index estimation ${indexEstimation}`)
-      console.log(`num items ${items.length}`)
-      console.log(`dataSize ${dataSize}`)
+      /* console.log(`Index estimation ${indexEstimation}`)
+       * console.log(`num items ${items.length}`)
+       * console.log(`dataSize ${dataSize}`) */
       const [estimatedBytes, estimatedWriteOps, estimatedWriteOpsNoIndex] = [
         RateEstimator.estimateWriteOpsAsBytes(dataSize, indexEstimation),
         RateEstimator.estimateWriteOps(dataSize, indexEstimation),
@@ -257,9 +257,9 @@ input file '${inputFile}' failed to persist in Fauna due to: '${subMessage}' - C
         // writeData has side effect of clearing out items and itemNumbers
         await writeData(items, itemNumbers)
       )
-      console.log(`actualWriteOps ${actualWriteOps}`)
-      console.log(`estimatedWriteOps ${estimatedWriteOps}`)
-      console.log(`estimatedWriteOpsNoIndex ${estimatedWriteOpsNoIndex}`)
+      /* console.log(`actualWriteOps ${actualWriteOps}`)
+       * console.log(`estimatedWriteOps ${estimatedWriteOps}`)
+       * console.log(`estimatedWriteOpsNoIndex ${estimatedWriteOpsNoIndex}`) */
       if (actualWriteOps > 0) {
         if (actualWriteOps < estimatedWriteOps && isFirstRequest) {
           indexEstimation =

--- a/src/lib/fauna-import-writer.js
+++ b/src/lib/fauna-import-writer.js
@@ -5,6 +5,7 @@ const { backOff } = require('exponential-backoff')
 const FaunaHTTPError = require('faunadb').errors.FaunaHTTPError
 const { RateLimiterMemory, RateLimiterQueue } = require('rate-limiter-flexible')
 const { ImportPenalty } = require('./import-penalty')
+const { RateEstimator } = require('./import-limits')
 
 /**
  * Creates a function that consumes a stream of objects and writes creates each object
@@ -15,8 +16,8 @@ const { ImportPenalty } = require('./import-penalty')
  * @param {string} inputFile - the path to the input file.
  * @param {object} options - object containing optional arguments.
  * @param {boolean} options.isDryRun - if true dry run the import - committing no documents. to Fauna. Otherwise, write documents to Fauna. Defaults to false.
- * @param {function} options.logger - the logger to be used, defaults to console.log.
- * @param {number} options.bytesPerSecondLimit - the rate at which data can be written to Fauna, defaults to 400000 bytes per second.
+ * @param {(string) => any} options.logger - the logger to be used to issue warnings
+ * @param {(string) => any} options.infoLogger - the logger to be used to issue informational messages
  * @param {number} options.writeOpsPerSecondLimit - the rate at which data can be written to Fauna, defaults to 100 write ops per second.
  * @param {number} options.requestsPerSecondLimit - the rate at which data can be written to Fauna, defaults to 10 requests per second.
  * @param {number} options.maxParallelRequests - the maximum number of parallel requests to issue to Fauna, defaults to 10.
@@ -34,12 +35,16 @@ function getFaunaImportWriter(
   {
     isDryRun = false,
     logger = console.log,
-    bytesPerSecondLimit = 400000,
+    infoLogger = console.log,
     writeOpsPerSecondLimit = 100,
     requestsPerSecondLimit = 1000,
     maxParallelRequests = 10,
+    indexEstimation = 10,
   }
 ) {
+  const BYTES_PER_WRITE_OP = 1000
+  let bytesPerSecondLimit = writeOpsPerSecondLimit * BYTES_PER_WRITE_OP
+
   class BatchError extends Error {
     statusCode
 
@@ -53,7 +58,6 @@ function getFaunaImportWriter(
 
   const penalties = {
     bytes: new ImportPenalty(0, bytesPerSecondLimit),
-    writeOps: new ImportPenalty(0, writeOpsPerSecondLimit),
     requests: new ImportPenalty(0, requestsPerSecondLimit),
   }
 
@@ -62,12 +66,6 @@ function getFaunaImportWriter(
       new RateLimiterMemory({
         duration: 1, // seconds
         points: bytesPerSecondLimit,
-      })
-    ),
-    writeOps: new RateLimiterQueue(
-      new RateLimiterMemory({
-        duration: 1, // seconds
-        points: writeOpsPerSecondLimit,
       })
     ),
     requests: new RateLimiterQueue(
@@ -80,37 +78,27 @@ function getFaunaImportWriter(
 
   const applyPenalties = () => {
     const nextBytesLimit = penalties.bytes.getNextPenalty(bytesPerSecondLimit)
-    const nextWriteOpsLimit = penalties.writeOps.getNextPenalty(
-      writeOpsPerSecondLimit
-    )
     const nextRequestsLimit = penalties.requests.getNextPenalty(
       requestsPerSecondLimit
     )
-
     bytesPerSecondLimit = nextBytesLimit
-    writeOpsPerSecondLimit = nextWriteOpsLimit
     requestsPerSecondLimit = nextRequestsLimit
 
     rateLimiters.bytes.points = nextBytesLimit
-    rateLimiters.writeOps.points = nextWriteOpsLimit
     rateLimiters.requests.points = nextRequestsLimit
   }
 
   const reducePenalties = () => {
-    const nextBytesLimit = penalties.bytes.getNextIncrement(bytesPerSecondLimit)
-    const nextWriteOpsLimit = penalties.writeOps.getNextIncrement(
-      writeOpsPerSecondLimit
-    )
+    const nextBytesOpsLimit =
+      penalties.bytes.getNextIncrement(bytesPerSecondLimit)
     const nextRequestsLimit = penalties.requests.getNextIncrement(
       requestsPerSecondLimit
     )
 
-    bytesPerSecondLimit = nextBytesLimit
-    writeOpsPerSecondLimit = nextWriteOpsLimit
+    bytesPerSecondLimit = nextBytesOpsLimit
     requestsPerSecondLimit = nextRequestsLimit
 
-    rateLimiters.bytes.points = nextBytesLimit
-    rateLimiters.writeOps.points = nextWriteOpsLimit
+    rateLimiters.bytes.points = nextBytesOpsLimit
     rateLimiters.requests.points = nextRequestsLimit
   }
 
@@ -243,26 +231,45 @@ input file '${inputFile}' failed to persist in Fauna due to: '${subMessage}' - C
   }
 
   const streamConsumer = async (inputStream) => {
+    infoLogger('Starting Import!')
     let dataSize = 0
     let items = []
     let itemNumbers = []
     let itemNumber = -1
+    let nextItemToLog = 100
+    let isFirstRequest = true
 
     const processItems = async () => {
-      // writeData has side effect of clearing out items and itemNumbers
+      console.log(`Index estimation ${indexEstimation}`)
+      console.log(`num items ${items.length}`)
+      console.log(`dataSize ${dataSize}`)
+      const [estimatedBytes, estimatedWriteOps, estimatedWriteOpsNoIndex] = [
+        RateEstimator.estimateWriteOpsAsBytes(dataSize, indexEstimation),
+        RateEstimator.estimateWriteOps(dataSize, indexEstimation),
+        RateEstimator.estimateWriteOps(dataSize, 0),
+      ]
       await waitForRateLimiter(
         rateLimiters.bytes,
-        dataSize,
+        estimatedBytes,
         bytesPerSecondLimit
       )
-      const writeOps = await processSettlements(
+      const actualWriteOps = await processSettlements(
+        // writeData has side effect of clearing out items and itemNumbers
         await writeData(items, itemNumbers)
       )
-      await waitForRateLimiter(
-        rateLimiters.writeOps,
-        writeOps,
-        writeOpsPerSecondLimit
-      )
+      console.log(`actualWriteOps ${actualWriteOps}`)
+      console.log(`estimatedWriteOps ${estimatedWriteOps}`)
+      console.log(`estimatedWriteOpsNoIndex ${estimatedWriteOpsNoIndex}`)
+      if (actualWriteOps > 0) {
+        if (actualWriteOps < estimatedWriteOps && isFirstRequest) {
+          indexEstimation =
+            Math.ceil(actualWriteOps / estimatedWriteOpsNoIndex) - 1
+          isFirstRequest = false
+        } else if (actualWriteOps > estimatedWriteOps) {
+          indexEstimation =
+            Math.ceil(actualWriteOps / estimatedWriteOpsNoIndex) - 1
+        }
+      }
       dataSize = 0
     }
 
@@ -281,8 +288,22 @@ this item and continuing.`
       }
       if (thisItem !== undefined) {
         const thisItemSize = sizeof(thisItem)
-        if (dataSize + thisItemSize > bytesPerSecondLimit && !isDryRun) {
+        if (
+          RateEstimator.estimateWriteOpsAsBytes(
+            dataSize + thisItemSize,
+            indexEstimation
+          ) > bytesPerSecondLimit &&
+          !isDryRun
+        ) {
           await processItems()
+        }
+        if (itemNumber >= nextItemToLog) {
+          infoLogger(`${itemNumber} items processed`)
+          if (itemNumber < 1000) {
+            nextItemToLog += 100
+          } else {
+            nextItemToLog += 1000
+          }
         }
         items.push(thisItem)
         itemNumbers.push(itemNumber)

--- a/src/lib/import-limits.js
+++ b/src/lib/import-limits.js
@@ -29,6 +29,16 @@ class RateEstimator {
     }
     return Math.ceil((totalBytes * (1 + numberOfIndexes)) / 1000)
   }
+
+  static estimateNumberOfIndexes(actualWriteOps, estimatedWriteOpsNoIndex) {
+    if (actualWriteOps <= 0) {
+      throw new Error('Invalid argument actualWriteOps must be > 0')
+    }
+    if (estimatedWriteOpsNoIndex <= 0) {
+      throw new Error('Invalid argument estimatedWriteOpsNoIndex must be > 0')
+    }
+    return Math.ceil(actualWriteOps / estimatedWriteOpsNoIndex) - 1
+  }
 }
 
 module.exports.ImportLimits = ImportLimits

--- a/src/lib/import-limits.js
+++ b/src/lib/import-limits.js
@@ -9,4 +9,27 @@ class ImportLimits {
   }
 }
 
-module.exports = ImportLimits
+class RateEstimator {
+  static estimateWriteOpsAsBytes(totalBytes, numberOfIndexes) {
+    if (totalBytes < 0) {
+      throw new Error('Invalid argument totalBytes must be >= 0')
+    }
+    if (numberOfIndexes < 0) {
+      throw new Error('Invalid argument numberOfIndexes must be >= 0')
+    }
+    return totalBytes * (1 + numberOfIndexes)
+  }
+
+  static estimateWriteOps(totalBytes, numberOfIndexes) {
+    if (totalBytes < 0) {
+      throw new Error('Invalid argument totalBytes must be >= 0')
+    }
+    if (numberOfIndexes < 0) {
+      throw new Error('Invalid argument numberOfIndexes must be >= 0')
+    }
+    return Math.ceil((totalBytes * (1 + numberOfIndexes)) / 1000)
+  }
+}
+
+module.exports.ImportLimits = ImportLimits
+module.exports.RateEstimator = RateEstimator

--- a/test/commands/import.test.js
+++ b/test/commands/import.test.js
@@ -1,7 +1,7 @@
 const { expect, test } = require('@oclif/test')
 const { withOpts } = require('../helpers/utils.js')
 const { Client, query } = require('faunadb')
-const ImportLimits = require('../../src/lib/import-limits')
+const { ImportLimits } = require('../../src/lib/import-limits')
 
 const client = new Client({
   secret: 'secret',

--- a/test/lib/fauna-import-writer.test.js
+++ b/test/lib/fauna-import-writer.test.js
@@ -20,20 +20,16 @@ describe('FaunaImportWriter', () => {
     let mockClient
     let myImportWriter
     let myFailingImportWriter
-    let mySlowImportWriterBytes
     let mySlowImportWriterWriteOps
     let mySlowImportWriterRequests
     let myDryRunWriter
     let logHistory = []
     let originalConsoleLog = console.log
+    let mockInfoLogger = jestMock.fn()
     console.log = function (message) {
       logHistory.push(message)
       originalConsoleLog(message)
     }
-    const tiniestSize = sizeof([
-      { goodField: '1', numberField: '0' },
-      { goodField: '1', numberField: '0' },
-    ])
     const tinySize = sizeof([
       { goodField: '1', numberField: '0' },
       { goodField: '1', numberField: '0' },
@@ -44,10 +40,11 @@ describe('FaunaImportWriter', () => {
     const defaultOptions = {
       isDryRun: false,
       logger: console.log,
-      bytesPerSecondLimit: tinySize,
-      writeOpsPerSecondLimit: 100,
+      infoLogger: mockInfoLogger,
+      writeOpsPerSecondLimit: tinySize / 1000,
       requestsPerSecondLimit: 10,
       maxParallelRequests: 2,
+      indexEstimation: 0,
     }
     const responseWithMetrics = () => {
       return {
@@ -90,21 +87,18 @@ describe('FaunaImportWriter', () => {
         { numberFailedRows: 0 },
         defaultOptions
       )
-      mySlowImportWriterBytes = getFaunaImportWriter(
-        ['numberField::number'],
-        mockClient,
-        'the-collection',
-        'my-file',
-        { numberFailedRows: 0 },
-        { ...defaultOptions, bytesPerSecondLimit: tiniestSize }
-      )
       mySlowImportWriterWriteOps = getFaunaImportWriter(
         ['numberField::number'],
         mockClient,
         'the-collection',
         'my-file',
         { numberFailedRows: 0 },
-        { ...defaultOptions, writeOpsPerSecondLimit: 1 }
+        {
+          ...defaultOptions,
+          // 3 items per second
+          writeOpsPerSecondLimit:
+            (sizeof({ goodField: '1', numberField: '0' }) * 3) / 1000,
+        }
       )
       mySlowImportWriterRequests = getFaunaImportWriter(
         ['numberField::number'],
@@ -146,6 +140,24 @@ describe('FaunaImportWriter', () => {
       )
       await myFailingImportWriter(myAsyncIterable)
       expect(failingRows.numberFailedRows).toEqual(10)
+    })
+
+    it('Logs informational messages about progress', async () => {
+      let longIterator = {
+        async *[Symbol.asyncIterator]() {
+          for (let i = 1; i <= 2002; i++) {
+            yield { goodField: '1', numberField: '0' }
+          }
+        },
+      }
+      await myDryRunWriter(longIterator)
+      expect(mockInfoLogger).toHaveBeenCalledTimes(12)
+      expect(mockInfoLogger.mock.calls[0][0]).toBe('Starting Import!')
+      for (let i = 1; i < 9; i++) {
+        expect(mockInfoLogger.mock.calls[i][0]).toBe(`${i}00 items processed`)
+      }
+      expect(mockInfoLogger.mock.calls[10][0]).toBe('1000 items processed')
+      expect(mockInfoLogger.mock.calls[11][0]).toBe('2000 items processed')
     })
 
     it('Logs the line numbers of items that fail to translate or persist to the DB', async () => {
@@ -210,13 +222,14 @@ to a number. Skipping this item and continuing."
 
     it('Retries and cuts rate limits for 409 status codes', async () => {
       // retry limit is 3
-      // initial max parallel requests is 2, with payload limit for a batch of 5 items
+      // initial max parallel requests is 2, with payload limit due to the
+      // write-ops limit for a batch of 5 items
       // after the first failure:
       // 1. the first batch will have 2 requests of 2-3 items each. these will both
       //    retry twice - leading to 6 requests.
       // 2. Due to the status code, a penalty will be applied. This penalty will cut
-      //    the size down to 2.5 items based on payload,  the max parallel requests to 1,
-      //    and the requests per second to 5. This will cause the next batch to be 2
+      //    the size down to 2.5 items based on payload via write-ops,
+      //    the max parallel requests to 1, this will cause the next batch to be 2
       //    items in one request tried a total of 3 times.
       // 3. Now we'll get cut down to 1 item at a time for the remaining 3 items. Leading
       //    9 total requests
@@ -225,13 +238,14 @@ to a number. Skipping this item and continuing."
 
     it('Retries and cuts rate limits for 429 status codes', async () => {
       // retry limit is 3
-      // initial max parallel requests is 2, with payload limit for a batch of 5 items
+      // initial max parallel requests is 2, with payload limit due to the
+      // write-ops limit for a batch of 5 items
       // after the first failure:
       // 1. the first batch will have 2 requests of 2-3 items each. these will both
       //    retry twice - leading to 6 requests.
       // 2. Due to the status code, a penalty will be applied. This penalty will cut
-      //    the size down to 2.5 items based on payload,  the max parallel requests to 1,
-      //    and the requests per second to 5. This will cause the next batch to be 2
+      //    the size down to 2.5 items based on payload via write-ops,
+      //    the max parallel requests to 1, this will cause the next batch to be 2
       //    items in one request tried a total of 3 times.
       // 3. Now we'll get cut down to 1 item at a time for the remaining 3 items. Leading
       //    9 total requests
@@ -279,15 +293,6 @@ to a number. Skipping this item and continuing."
       }
     }).timeout(10000)
 
-    it('Rate limits requests by byte throughput', async () => {
-      myMock.mockResolvedValue(responseWithMetrics())
-      let start = new Date()
-      await mySlowImportWriterBytes(myAsyncIterable)
-      let end = new Date()
-      let differenceSeconds = (end.getTime() - start.getTime()) / 1000
-      expect(differenceSeconds).toBeGreaterThanOrEqual(5)
-    }).timeout(10000)
-
     it('Rate limits requests by write ops', async () => {
       myMock.mockResolvedValue(responseWithMetrics())
       let start = new Date()
@@ -295,7 +300,41 @@ to a number. Skipping this item and continuing."
       let end = new Date()
       let differenceSeconds = (end.getTime() - start.getTime()) / 1000
       expect(differenceSeconds).toBeGreaterThanOrEqual(3)
-    }).timeout(5000)
+    }).timeout(20000)
+
+    it('Estimates number of indexes to rate limit write ops', async () => {
+      myMock
+        .mockResolvedValue(responseWithMetrics())
+        .mockResolvedValueOnce(responseWithMetrics())
+        .mockResolvedValueOnce({
+          value: true,
+          metrics: {
+            'x-compute-ops': 1,
+            'x-byte-read-ops': 1,
+            'x-byte-write-ops': 2,
+            'x-query-time': 1,
+            'x-txn-retries': 0,
+          },
+        })
+      let start = new Date()
+      const estimationWriter = getFaunaImportWriter(
+        [],
+        mockClient,
+        'the-collection',
+        'my-file',
+        { ...defaultOptions, indexEstimation: 10 }
+      )
+      await estimationWriter(myAsyncIterable)
+      let end = new Date()
+      let differenceSeconds = (end.getTime() - start.getTime()) / 1000
+      console.log(differenceSeconds)
+      // first reqeust - 1 item, will wait 1 second
+      // second request - new estimate 0 indexes; will do 5 items
+      // third reqeust - new estimate 1 index; will do 2 items
+      // fourth reqeust - new estimate 1 index; will do 2 items
+      expect(differenceSeconds).toBeGreaterThanOrEqual(4)
+      expect(myMock).toHaveBeenCalledTimes(8)
+    }).timeout(20000)
 
     it('Rate limits by the number of requests', async () => {
       myMock.mockResolvedValue(responseWithMetrics())

--- a/test/lib/fauna-import-writer.test.js
+++ b/test/lib/fauna-import-writer.test.js
@@ -25,7 +25,7 @@ describe('FaunaImportWriter', () => {
     let myDryRunWriter
     let logHistory = []
     let originalConsoleLog = console.log
-    let mockInfoLogger = jestMock.fn()
+    let mockInfoLogger
     console.log = function (message) {
       logHistory.push(message)
       originalConsoleLog(message)
@@ -76,6 +76,7 @@ describe('FaunaImportWriter', () => {
       }
       logHistory = []
       myMock = jestMock.fn()
+      mockInfoLogger = jestMock.fn()
       mockClient = {
         queryWithMetrics: myMock,
       }
@@ -322,6 +323,7 @@ to a number. Skipping this item and continuing."
         mockClient,
         'the-collection',
         'my-file',
+        { numberFailedRows: 0 },
         { ...defaultOptions, indexEstimation: 10 }
       )
       await estimationWriter(myAsyncIterable)

--- a/test/lib/import-limits.test.js
+++ b/test/lib/import-limits.test.js
@@ -33,4 +33,57 @@ describe('RateEstimator', () => {
       expect(RateEstimator.estimateWriteOpsAsBytes(2000, 3)).toBe(8000)
     })
   })
+
+  describe('estimateWriteOps', () => {
+    it('rejects numberOfIndexes < 0', () => {
+      expect(() => RateEstimator.estimateWriteOps(-1, 100)).toThrow(
+        new Error('Invalid argument totalBytes must be >= 0')
+      )
+    })
+
+    it('rejects totalBytes < 0', () => {
+      expect(() => RateEstimator.estimateWriteOps(10, -1)).toThrow(
+        new Error('Invalid argument numberOfIndexes must be >= 0')
+      )
+    })
+
+    it('estimtes the write ops to be (1  + numIndexes) * (1 per KB of write)', () => {
+      expect(RateEstimator.estimateWriteOps(1000, 0)).toBe(1)
+      expect(RateEstimator.estimateWriteOps(1100, 0)).toBe(2)
+      expect(RateEstimator.estimateWriteOps(100, 0)).toBe(1)
+      expect(RateEstimator.estimateWriteOps(1000, 3)).toBe(4)
+      expect(RateEstimator.estimateWriteOps(1100, 3)).toBe(5)
+      expect(RateEstimator.estimateWriteOps(100, 3)).toBe(1)
+      expect(RateEstimator.estimateWriteOps(2000, 3)).toBe(8)
+    })
+  })
+
+  describe('estimateNumberOfIndexes', () => {
+    it('rejects actualWriteOps <= 0', () => {
+      expect(() => RateEstimator.estimateNumberOfIndexes(-1, 100)).toThrow(
+        new Error('Invalid argument actualWriteOps must be > 0')
+      )
+      expect(() => RateEstimator.estimateNumberOfIndexes(0, 100)).toThrow(
+        new Error('Invalid argument actualWriteOps must be > 0')
+      )
+    })
+
+    it('rejects totalBytes <= 0', () => {
+      expect(() => RateEstimator.estimateNumberOfIndexes(10, -1)).toThrow(
+        new Error('Invalid argument estimatedWriteOpsNoIndex must be > 0')
+      )
+      expect(() => RateEstimator.estimateNumberOfIndexes(10, 0)).toThrow(
+        new Error('Invalid argument estimatedWriteOpsNoIndex must be > 0')
+      )
+    })
+
+    it('estimtes the write ops to be (1  + numIndexes) * (1 per KB of write)', () => {
+      expect(RateEstimator.estimateNumberOfIndexes(1, 1)).toBe(0)
+      expect(RateEstimator.estimateNumberOfIndexes(2, 1)).toBe(1)
+      expect(RateEstimator.estimateNumberOfIndexes(10, 1)).toBe(9)
+      expect(RateEstimator.estimateNumberOfIndexes(1, 5)).toBe(0)
+      expect(RateEstimator.estimateNumberOfIndexes(1, 2)).toBe(0)
+      expect(RateEstimator.estimateNumberOfIndexes(1, 1000)).toBe(0)
+    })
+  })
 })

--- a/test/lib/import-limits.test.js
+++ b/test/lib/import-limits.test.js
@@ -1,0 +1,36 @@
+const { ImportLimits, RateEstimator } = require('../../src/lib/import-limits')
+const expect = require('expect')
+
+describe('ImportLimits', () => {
+  describe('maximumImportSize', () => {
+    it('returns 10000 for max size', () => {
+      expect(ImportLimits.maximumImportSize()).toBe(10000)
+    })
+  })
+})
+
+describe('RateEstimator', () => {
+  describe('estimateWriteOpsAsBytes', () => {
+    it('rejects numberOfIndexes < 0', () => {
+      expect(() => RateEstimator.estimateWriteOpsAsBytes(-1, 100)).toThrow(
+        new Error('Invalid argument totalBytes must be >= 0')
+      )
+    })
+
+    it('rejects totalBytes < 0', () => {
+      expect(() => RateEstimator.estimateWriteOpsAsBytes(10, -1)).toThrow(
+        new Error('Invalid argument numberOfIndexes must be >= 0')
+      )
+    })
+
+    it('estimtes the write ops to be (1  + numIndexes) * (1 per KB of write)', () => {
+      expect(RateEstimator.estimateWriteOpsAsBytes(1000, 0)).toBe(1000)
+      expect(RateEstimator.estimateWriteOpsAsBytes(1100, 0)).toBe(1100)
+      expect(RateEstimator.estimateWriteOpsAsBytes(100, 0)).toBe(100)
+      expect(RateEstimator.estimateWriteOpsAsBytes(1000, 3)).toBe(4000)
+      expect(RateEstimator.estimateWriteOpsAsBytes(1100, 3)).toBe(4400)
+      expect(RateEstimator.estimateWriteOpsAsBytes(100, 3)).toBe(400)
+      expect(RateEstimator.estimateWriteOpsAsBytes(2000, 3)).toBe(8000)
+    })
+  })
+})


### PR DESCRIPTION
### Notes

Changes:

- estimate the write ops ahead of time by estimating number of indexes.
- adding progress logging
- fix a bug where we were applying penalties and rewards multiple times for a single batch


### Testing

Ran these tests - now trying zee's workload