### PR TITLE
Bump version to 0.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fauna-shell",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fauna-shell",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@oclif/command": "^1.5.19",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fauna-shell",
   "description": "faunadb shell",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "author": "Fauna",
   "bin": {
     "fauna": "./bin/run"


### PR DESCRIPTION
### Notes
Release 0.15.0

Improvements to `import` command.
Update `exec` command to exit with non-zero code for failures.

### Testing

npm run test
