### PR TITLE
Update concourse pipeline to use node 16 to be compatible with the latest linter version

### DIFF
--- a/concourse/tasks/integration.yml
+++ b/concourse/tasks/integration.yml
@@ -16,7 +16,7 @@ services:
       - FAUNA_DOMAIN
       - FAUNA_SCHEME
       - FAUNA_PORT
-    image: node:15.14.0-alpine3.10
+    image: node:16.14.2-alpine3.14
     container_name: mytests
     depends_on:
       - faunadb


### PR DESCRIPTION
### Notes

Concourse release is failing: https://concourse.faunadb.net/teams/devex/pipelines/fauna-shell-release/jobs/release/builds/6 because the newest linter is incompatible with the version of node we were using to execute integration tests.

Solution: bump node to a compatible version