### PR TITLE
Fix integ test to have needed env vars

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,4 @@
+FAUNA_DOMAIN="localhost"
+FAUNA_SCHEME="http"
+FAUNA_PORT="8443"
+FAUNA_SECRET="secret"

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "oclif-dev manifest && oclif-dev readme",
     "pretest": "npm run fixlint",
-    "test": "export $(cat .env | xargs); nyc mocha --forbid-only \"test/**/*.test.js\"",
+    "test": "export $(cat .env.test | xargs); nyc mocha --forbid-only \"test/**/*.test.js\"",
     "lint": "eslint .",
     "fixlint": "eslint . --fix",
     "version": "oclif-dev readme && git add README.md"


### PR DESCRIPTION
### Notes

Tests in release pipeline are failing because the environmental variables are not being correctly set.

### Testing

npm run test