### PR TITLE
We don't use yarn locally - don't use it in the pipeline. Use node compatible with eslint

### DIFF
--- a/concourse/scripts/publish.sh
+++ b/concourse/scripts/publish.sh
@@ -5,7 +5,7 @@ set -eou
 cd ./fauna-shell-repository
 
 mkdir dist
-yarn install
+npm install
 
 PACKAGE_VERSION=$(node -p -e "require('./package.json').version")
 NPM_LATEST_VERSION=$(npm view fauna-shell version)

--- a/concourse/tasks/integration.yml
+++ b/concourse/tasks/integration.yml
@@ -23,4 +23,4 @@ services:
     volumes:
       - "../../:/tmp/app"
     working_dir: "/tmp/app"
-    command: [sh, -c, "yarn install && yarn test"]
+    command: [sh, -c, "npm install && npm test"]

--- a/concourse/tasks/integration.yml
+++ b/concourse/tasks/integration.yml
@@ -23,4 +23,4 @@ services:
     volumes:
       - "../../:/tmp/app"
     working_dir: "/tmp/app"
-    command: [sh, -c, "npm install && npm test"]
+    command: [sh, -c, "npm install && npm run test"]

--- a/concourse/tasks/publish.yml
+++ b/concourse/tasks/publish.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: node
-    tag: 15.14.0-alpine3.10
+    tag: 16.14.2-alpine3.14
 
 params:
   NPM_TOKEN:


### PR DESCRIPTION
### Notes
More pipeline problems - another image we're using is not compatible with eslint.

Fixed that.

Also moved the pipeline to use npm like we do locally rather than yarn.

### Testing

N/A