### PR TITLE
ENG-5277: Implement fauna schema:ls

### DIFF
--- a/src/commands/schema/ls.js
+++ b/src/commands/schema/ls.js
@@ -1,0 +1,44 @@
+const FaunaCommand = require('../../lib/fauna-command.js')
+const fetch = require('node-fetch')
+const { errorOut } = require('../../lib/misc.js')
+
+class ListSchemaCommand extends FaunaCommand {
+  async run() {
+    const log = this.log
+    const {
+      connectionOptions: { domain, port, scheme, secret },
+    } = await this.getClient()
+
+    return fetch(`${scheme}://${domain}:${port}/schema/1/files`, {
+      method: 'GET',
+      headers: { AUTHORIZATION: `Bearer ${secret}` },
+    })
+      .then(function (res) {
+        return res.json()
+      })
+      .then(function (json) {
+        if (json.files.length > 0) {
+          log('Schema files')
+          json.files.forEach(function (file) {
+            log(file.filename)
+          })
+        } else {
+          log('No schema files')
+        }
+      })
+      .catch(function (err) {
+        errorOut(err)
+      })
+  }
+}
+
+ListSchemaCommand.description = 'List database schema files'
+
+ListSchemaCommand.examples = ['$ fauna schema:ls']
+
+ListSchemaCommand.args = []
+
+ListSchemaCommand.flags = {
+  ...FaunaCommand.flags,
+}
+module.exports = ListSchemaCommand

--- a/test/commands/schema.test.js
+++ b/test/commands/schema.test.js
@@ -1,0 +1,31 @@
+const { expect, test } = require('@oclif/test')
+const { query: q } = require('faunadb')
+const { withOpts, getEndpoint, matchFqlReq } = require('../helpers/utils.js')
+
+const files = {
+  version: 0,
+  files: [
+    { filename: 'main.fsl' },
+    { filename: 'functions.fsl' },
+    { filename: 'legacy.json' },
+  ],
+}
+
+describe('fauna schema:ls test', () => {
+  test
+    .nock(getEndpoint(), { allowUnmocked: false }, (api) =>
+      api
+        .persist()
+        .post('/', matchFqlReq(q.Now()))
+        .reply(200, new Date())
+        .get('/schema/1/files')
+        .reply(200, files)
+    )
+    .stdout()
+    .command(withOpts(['schema:ls']))
+    .it('runs schema:ls', (ctx) => {
+      expect(ctx.stdout).to.contain(
+        'Schema files\nmain.fsl\nfunctions.fsl\nlegacy.json'
+      )
+    })
+})


### PR DESCRIPTION
This adds CLI support for listing schema files in a scope.

I would have liked the command to be `fauna schema ls`, but we are using a pre-v2 version of oclif, and it only supports : as the separator. Maybe we should upgrade?
