### PR TITLE
Add eval v10

### DIFF
--- a/src/commands/eval.js
+++ b/src/commands/eval.js
@@ -147,12 +147,15 @@ class EvalCommand extends FaunaCommand {
   }
 
   /**
-   * @param flags should be an object with
-   * {
-   *   version: "4" | "10";
-   *   format: "json" | "json-tagged" | "shell";
-   *   typecheck?: boolean;
-   * }
+   * Perform a v4 or v10 query, depending on the FQL version
+   *
+   * @param {Object} client - An instance of the client used to execute the query.
+   * @param {string} fqlQuery - The FQL v4 query to be executed.
+   * @param {string} outputFile - Target filename
+   * @param {Object} flags - Options for the query execution.
+   * @param {("4" | "10")} flags.version - FQL version number
+   * @param {("json" | "json-tagged" | "shell")} flags.format - Result format
+   * @param {boolean} [flags.typecheck] - (Optional) Flag to enable typechecking
    */
   async performQuery(client, fqlQuery, outputFile, flags) {
     if (flags.version === "4") {

--- a/src/commands/eval.js
+++ b/src/commands/eval.js
@@ -147,7 +147,7 @@ class EvalCommand extends FaunaCommand {
   }
 
   /**
-   * Flags should be
+   * @param flags should be an object with
    * {
    *   version: "4" | "10";
    *   format: "json" | "json-tagged" | "shell";

--- a/src/commands/eval.js
+++ b/src/commands/eval.js
@@ -85,7 +85,7 @@ class EvalCommand extends FaunaCommand {
       // In v10, we check if its a TTY for shell/json format. In v4, default to json (to avoid breaking compatability).
       const format =
         this.flags.format ??
-        (this.flags.version == "10"
+        (this.flags.version === "10"
           ? process.stdout.isTTY
             ? "shell"
             : "json"
@@ -98,7 +98,7 @@ class EvalCommand extends FaunaCommand {
         {
           format: format,
           version: this.flags.version,
-          typecheck: this.flags.typecheck
+          typecheck: this.flags.typecheck,
         }
       );
 
@@ -153,7 +153,7 @@ class EvalCommand extends FaunaCommand {
   //   typecheck?: boolean;
   // }
   async performQuery(client, fqlQuery, outputFile, flags) {
-    if (flags.version == "4") {
+    if (flags.version === "4") {
       await this.performV4Query(client, fqlQuery, outputFile, flags);
     } else {
       await this.performV10Query(client, fqlQuery, outputFile, flags);
@@ -163,9 +163,9 @@ class EvalCommand extends FaunaCommand {
   async performV10Query(client, fqlQuery, outputFile, flags) {
     try {
       let format;
-      if (flags.format == "shell") {
+      if (flags.format === "shell") {
         format = "decorated";
-      } else if (flags.format == "json-tagged") {
+      } else if (flags.format === "json-tagged") {
         format = "tagged";
       } else {
         format = "simple";
@@ -180,7 +180,7 @@ class EvalCommand extends FaunaCommand {
   }
 
   async performV4Query(client, fqlQuery, outputFile, flags) {
-    if (flags.format == "json-tagged") {
+    if (flags.format === "json-tagged") {
       flags.format = "json";
     }
 

--- a/src/commands/eval.js
+++ b/src/commands/eval.js
@@ -146,12 +146,14 @@ class EvalCommand extends FaunaCommand {
     }
   }
 
-  // Flags should be
-  // {
-  //   version: "4" | "10";
-  //   format: "json" | "json-tagged" | "shell";
-  //   typecheck?: boolean;
-  // }
+  /**
+   * Flags should be
+   * {
+   *   version: "4" | "10";
+   *   format: "json" | "json-tagged" | "shell";
+   *   typecheck?: boolean;
+   * }
+   */
   async performQuery(client, fqlQuery, outputFile, flags) {
     if (flags.version === "4") {
       await this.performV4Query(client, fqlQuery, outputFile, flags);

--- a/src/lib/fauna-client.js
+++ b/src/lib/fauna-client.js
@@ -22,7 +22,9 @@ module.exports = class FaunaClient {
           http2ResponseHeaders[http2.constants.HTTP2_HEADER_STATUS];
         let responseData = "";
 
-        req.on("data", (chunk) => (responseData += chunk));
+        req.on("data", (chunk) => {
+          responseData += chunk;
+        });
 
         req.on("end", () => {
           resolvePromise({

--- a/src/lib/fauna-client.js
+++ b/src/lib/fauna-client.js
@@ -1,0 +1,68 @@
+const http2 = require("http2");
+
+// Copied from the fauna-js driver:
+// https://github.com/fauna/fauna-js/blob/main/src/http-client/node-http2-client.ts
+
+module.exports = class FaunaClient {
+  constructor(endpoint, secret) {
+    this.session = http2
+      .connect(endpoint, {
+        peerMaxConcurrentStreams: 50,
+      })
+      .once("error", () => this.close())
+      .once("goaway", () => this.close());
+    this.secret = secret;
+  }
+
+  async query(query, format = "simple") {
+    return new Promise((resolvePromise, rejectPromise) => {
+      let req;
+      const onResponse = (http2ResponseHeaders) => {
+        const status =
+          http2ResponseHeaders[http2.constants.HTTP2_HEADER_STATUS];
+        let responseData = "";
+
+        req.on("data", (chunk) => (responseData += chunk));
+
+        req.on("end", () => {
+          resolvePromise({
+            status,
+            body: JSON.parse(responseData),
+            headers: http2ResponseHeaders,
+          });
+        });
+      };
+
+      try {
+        const httpRequestHeaders = {
+          Authorization: `Bearer ${this.secret}`,
+          "x-format": format,
+          "X-Fauna-Source": "Fauna Shell",
+          [http2.constants.HTTP2_HEADER_PATH]: "/query/1",
+          [http2.constants.HTTP2_HEADER_METHOD]: "POST",
+        };
+
+        req = this.session
+          .request(httpRequestHeaders)
+          .setEncoding("utf8")
+          .on("error", (error) => rejectPromise(error))
+          .on("response", onResponse);
+
+        req.write(JSON.stringify({ query }), "utf8");
+
+        // req.setTimeout must be called before req.end()
+        req.setTimeout(5000, () => {
+          req.destroy(new Error(`Client timeout`));
+        });
+
+        req.end();
+      } catch (error) {
+        rejectPromise(error);
+      }
+    });
+  }
+
+  async close() {
+    this.session.close();
+  }
+};

--- a/src/lib/fauna-client.js
+++ b/src/lib/fauna-client.js
@@ -14,7 +14,7 @@ module.exports = class FaunaClient {
     this.secret = secret;
   }
 
-  async query(query, format = "simple") {
+  async query(query, format = "simple", typecheck = undefined) {
     return new Promise((resolvePromise, rejectPromise) => {
       let req;
       const onResponse = (http2ResponseHeaders) => {
@@ -40,6 +40,7 @@ module.exports = class FaunaClient {
           "X-Fauna-Source": "Fauna Shell",
           [http2.constants.HTTP2_HEADER_PATH]: "/query/1",
           [http2.constants.HTTP2_HEADER_METHOD]: "POST",
+          ...(typecheck && { "x-typecheck": typecheck }),
         };
 
         req = this.session

--- a/src/lib/fauna-command.js
+++ b/src/lib/fauna-command.js
@@ -128,7 +128,7 @@ class FaunaCommand extends Command {
         const client = new FaunaClient(
           endpoint,
           connectionOptions.secret,
-          this.flags.timeout ? parseInt(this.flags.timeout) : undefined
+          this.flags.timeout ? parseInt(this.flags.timeout, 10) : undefined
         );
 
         // validate the client settings

--- a/src/lib/fauna-command.js
+++ b/src/lib/fauna-command.js
@@ -125,7 +125,11 @@ class FaunaCommand extends Command {
         const endpoint = new URL(
           `${connectionOptions.scheme}://${connectionOptions.domain}:${connectionOptions.port}`
         );
-        const client = new FaunaClient(endpoint, connectionOptions.secret);
+        const client = new FaunaClient(
+          endpoint,
+          connectionOptions.secret,
+          this.flags.timeout ? parseInt(this.flags.timeout) : undefined
+        );
 
         // validate the client settings
         await client.query("0");

--- a/src/lib/fauna-command.js
+++ b/src/lib/fauna-command.js
@@ -86,7 +86,7 @@ class FaunaCommand extends Command {
   }
 
   async getClient({ dbScope, role, version } = {}) {
-    if (version == "4") {
+    if (version === "4" || version === undefined) {
       // construct v4 client
       let connectionOptions;
       try {

--- a/test/commands/eval.test.js
+++ b/test/commands/eval.test.js
@@ -39,6 +39,63 @@ describe("eval", () => {
     .it("It pretty-prints an error message the command fails");
 });
 
+describe("eval in v10", () => {
+  test
+    .stdout()
+    .command(
+      withOpts([
+        "eval",
+        "--version",
+        "10",
+        "{ exists: Collection.byName('doesnt_exist').exists() }",
+      ])
+    )
+    .it("runs eval", (ctx) => {
+      expect(ctx.stdout).to.equal("{\n  exists: false\n}\n");
+    });
+
+  test
+    .stdout()
+    .command(
+      withOpts([
+        "eval",
+        "--version",
+        "10",
+        "{ exists: Collection.byName('doesnt_exist').exists() }",
+        "--format",
+        "json",
+      ])
+    )
+    .it("runs eval in json format", (ctx) => {
+      expect(JSON.parse(ctx.stdout)).to.deep.equal({ exists: false });
+    });
+
+  test
+    .stdout()
+    .command(
+      withOpts(["eval", "--version", "10", "{ two: 2 }", "--format", "json"])
+    )
+    .it("runs eval in json simple format", (ctx) => {
+      expect(JSON.parse(ctx.stdout)).to.deep.equal({ two: 2 });
+    });
+
+  test
+    .stdout()
+    .command(
+      withOpts([
+        "eval",
+        "--version",
+        "10",
+        "{ two: 2 }",
+        "--format",
+        "json-tagged",
+      ])
+    )
+    .it("runs eval in json tagged format", (ctx) => {
+      expect(JSON.parse(ctx.stdout)).to.deep.equal({ two: { "@int": "2" } });
+    });
+});
+
 function mockQuery(api) {
   api
     .persist()


### PR DESCRIPTION
Ticket: FE-3712

Adds `--version 4/10` to `fauna eval`. This should not break existing usage of the command.

When `--version 10` is set, the following behavior is changed:
- the `format` now defaults to "shell" when in a tty, and "json" when piping to another command
- the query string is sent to the v10 endpoint instead of being evaled
  - the "shell" format will set the query format to "decorated"
  - the "json" format will set the query format to "simple"
- a new `json-tagged` format has been added. this does the same thing as `json` in v4, but returns the tagged value in v10 (instead of the simple value).