### PR TITLE
ENG-5273: Implement fauna schema:pull

### DIFF
--- a/src/commands/schema/pull.js
+++ b/src/commands/schema/pull.js
@@ -1,0 +1,43 @@
+const FaunaCommand = require('../../lib/fauna-command.js')
+const fetch = require('node-fetch')
+const { errorOut } = require('../../lib/misc.js')
+
+class PullSchemaCommand extends FaunaCommand {
+  async run() {
+    const log = this.log
+    const filename = this.args.filename
+    const {
+      connectionOptions: { domain, port, scheme, secret },
+    } = await this.getClient()
+
+    return fetch(`${scheme}://${domain}:${port}/schema/1/files/${filename}`, {
+      method: 'GET',
+      headers: { AUTHORIZATION: `Bearer ${secret}` },
+    })
+      .then(async function (res) {
+        const json = await res.json()
+        log(json.content)
+      })
+      .catch(function (err) {
+        errorOut(err)
+      })
+  }
+}
+
+PullSchemaCommand.description =
+  'Pull a database schema file and display its contents'
+
+PullSchemaCommand.examples = ['$ fauna schema:pull main.fsl']
+
+PullSchemaCommand.args = [
+  {
+    name: 'filename',
+    required: true,
+    description: 'name of schema file',
+  },
+]
+
+PullSchemaCommand.flags = {
+  ...FaunaCommand.flags,
+}
+module.exports = PullSchemaCommand

--- a/test/commands/schema.test.js
+++ b/test/commands/schema.test.js
@@ -11,6 +11,11 @@ const files = {
   ],
 }
 
+const main = {
+  version: 0,
+  content: 'collection foo {}\n\nfunction bar(x, y) { x + y }\n',
+}
+
 describe('fauna schema:ls test', () => {
   test
     .nock(getEndpoint(), { allowUnmocked: false }, (api) =>
@@ -27,5 +32,22 @@ describe('fauna schema:ls test', () => {
       expect(ctx.stdout).to.contain(
         'Schema files:\n\nmain.fsl\nfunctions.fsl\nlegacy.json'
       )
+    })
+})
+
+describe('fauna schema:pull test', () => {
+  test
+    .nock(getEndpoint(), { allowUnmocked: false }, (api) =>
+      api
+        .persist()
+        .post('/', matchFqlReq(q.Now()))
+        .reply(200, new Date())
+        .get('/schema/1/files/main.fsl')
+        .reply(200, main)
+    )
+    .stdout()
+    .command(withOpts(['schema:pull', 'main.fsl']))
+    .it('runs schema:pull', (ctx) => {
+      expect(ctx.stdout).to.contain(`${main.content}`)
     })
 })


### PR DESCRIPTION
This implements fauna schema pull, but it prints the contents of the file to stdout instead of saving them in the CWD. I think this is better for a single schema file because stdout can be redirected to send the file's contents elsewhere.

We can change it later when we support multiple files in a tree.