### PR TITLE
Rename pull to cat

### DIFF
--- a/src/commands/schema/cat.js
+++ b/src/commands/schema/cat.js
@@ -2,7 +2,7 @@ const FaunaCommand = require("../../lib/fauna-command.js");
 const { Args } = require("@oclif/core");
 const fetch = require("node-fetch");
 
-class PullSchemaCommand extends FaunaCommand {
+class CatSchemaCommand extends FaunaCommand {
   async run() {
     const filename = this.args.filename;
     const {
@@ -25,19 +25,18 @@ class PullSchemaCommand extends FaunaCommand {
   }
 }
 
-PullSchemaCommand.description =
-  "Pull a database schema file and display its contents";
+CatSchemaCommand.description = "Display the contents of a schema file";
 
-PullSchemaCommand.examples = ["$ fauna schema:pull main.fsl"];
+CatSchemaCommand.examples = ["$ fauna schema:cat main.fsl"];
 
-PullSchemaCommand.args = {
+CatSchemaCommand.args = {
   filename: Args.string({
     required: true,
     description: "name of schema file",
   }),
 };
 
-PullSchemaCommand.flags = {
+CatSchemaCommand.flags = {
   ...FaunaCommand.flags,
 };
-module.exports = PullSchemaCommand;
+module.exports = CatSchemaCommand;

--- a/test/commands/schema.test.js
+++ b/test/commands/schema.test.js
@@ -35,7 +35,7 @@ describe("fauna schema:ls test", () => {
     });
 });
 
-describe("fauna schema:pull test", () => {
+describe("fauna schema:cat test", () => {
   test
     .nock(getEndpoint(), { allowUnmocked: false }, (api) =>
       api
@@ -46,8 +46,8 @@ describe("fauna schema:pull test", () => {
         .reply(200, main)
     )
     .stdout()
-    .command(withOpts(["schema:pull", "main.fsl"]))
-    .it("runs schema:pull", (ctx) => {
+    .command(withOpts(["schema:cat", "main.fsl"]))
+    .it("runs schema:cat", (ctx) => {
       expect(ctx.stdout).to.contain(`${main.content}`);
     });
 });


### PR DESCRIPTION
This name makes more sense based on what was implemented for the demo of the steel thread. Git-like pull will be implemented later.
