### PR TITLE
Add error handling

### DIFF
--- a/src/commands/schema/cat.js
+++ b/src/commands/schema/cat.js
@@ -18,7 +18,11 @@ class CatSchemaCommand extends FaunaCommand {
         }
       );
       const json = await res.json();
-      this.log(json.content);
+      if (json.error) {
+        this.error(json.error.message);
+      } else {
+        this.log(json.content);
+      }
     } catch (err) {
       this.error(err);
     }

--- a/src/commands/schema/ls.js
+++ b/src/commands/schema/ls.js
@@ -15,15 +15,13 @@ class ListSchemaCommand extends FaunaCommand {
       const json = await res.json();
       if (json.error) {
         this.error(json.error.message);
+      } else if (json.files.length > 0) {
+        this.log("Schema files:\n");
+        json.files.forEach((file) => {
+          this.log(file.filename);
+        });
       } else {
-        if (json.files.length > 0) {
-          this.log("Schema files:\n");
-          json.files.forEach((file) => {
-            this.log(file.filename);
-          });
-        } else {
-          this.log("No schema files");
-        }
+        this.log("No schema files");
       }
     } catch (err) {
       this.error(err);

--- a/src/commands/schema/ls.js
+++ b/src/commands/schema/ls.js
@@ -13,13 +13,17 @@ class ListSchemaCommand extends FaunaCommand {
         headers: { Authorization: `Bearer ${secret}` },
       });
       const json = await res.json();
-      if (json.files.length > 0) {
-        this.log("Schema files:\n");
-        json.files.forEach((file) => {
-          this.log(file.filename);
-        });
+      if (json.error) {
+        this.error(json.error.message);
       } else {
-        this.log("No schema files");
+        if (json.files.length > 0) {
+          this.log("Schema files:\n");
+          json.files.forEach((file) => {
+            this.log(file.filename);
+          });
+        } else {
+          this.log("No schema files");
+        }
       }
     } catch (err) {
       this.error(err);

--- a/src/commands/schema/push.js
+++ b/src/commands/schema/push.js
@@ -19,38 +19,57 @@ class PushSchemaCommand extends FaunaCommand {
       return fd;
     };
 
-    if (this.flags.force) {
-      // Just push.
-      return fetch(`${scheme}://${domain}:${port}/schema/1/update?force=true`, {
-        method: "POST",
-        headers: { AUTHORIZATION: `Bearer ${secret}` },
-        body: body(),
-      }).catch((err) => this.error(err));
-    } else {
-      // Confirm diff, then push it.
-      return fetch(`${scheme}://${domain}:${port}/schema/1/validate`, {
-        method: "POST",
-        headers: { AUTHORIZATION: `Bearer ${secret}` },
-        body: body(),
-      })
-        .then(async (res) => {
-          const json = await res.json();
-          this.log(`Proposed diff for ${filename}:\n`);
-          this.log(json.diff);
-          if (await ux.confirm("Accept and push the changes?")) {
-            await fetch(
-              `${scheme}://${domain}:${port}/schema/1/update?version=${json.version}`,
-              {
-                method: "POST",
-                headers: { AUTHORIZATION: `Bearer ${secret}` },
-                body: body(),
-              }
-            );
-          } else {
-            this.log("Change cancelled");
+    try {
+      if (this.flags.force) {
+        // Just push.
+        const res = await fetch(
+          `${scheme}://${domain}:${port}/schema/1/update?force=true`,
+          {
+            method: "POST",
+            headers: { AUTHORIZATION: `Bearer ${secret}` },
+            body: body(),
           }
-        })
-        .catch((err) => this.error(err));
+        );
+        const json = await res.json();
+        if (json.error) {
+          this.error(json.error.message);
+        }
+      } else {
+        // Confirm diff, then push it.
+        const res = await fetch(
+          `${scheme}://${domain}:${port}/schema/1/validate`,
+          {
+            method: "POST",
+            headers: { AUTHORIZATION: `Bearer ${secret}` },
+            body: body(),
+          }
+        );
+        const json = await res.json();
+        if (json.error) {
+          this.error(json.error.message);
+          return;
+        }
+        this.log(`Proposed diff for ${filename}:\n`);
+        this.log(json.diff);
+        if (await ux.confirm("Accept and push the changes?")) {
+          const res = await fetch(
+            `${scheme}://${domain}:${port}/schema/1/update?version=${json.version}`,
+            {
+              method: "POST",
+              headers: { AUTHORIZATION: `Bearer ${secret}` },
+              body: body(),
+            }
+          );
+          const json = await res.json();
+          if (json.error) {
+            this.error(json.error.message);
+          }
+        } else {
+          this.log("Change cancelled");
+        }
+      }
+    } catch (err) {
+      this.error(err);
     }
   }
 }

--- a/src/commands/schema/push.js
+++ b/src/commands/schema/push.js
@@ -60,9 +60,9 @@ class PushSchemaCommand extends FaunaCommand {
               body: body(),
             }
           );
-          const json = await res.json();
-          if (json.error) {
-            this.error(json.error.message);
+          const json0 = await res.json();
+          if (json0.error) {
+            this.error(json0.error.message);
           }
         } else {
           this.log("Change cancelled");


### PR DESCRIPTION
Ticket(s): FE-###

Adds error handling to schema commands.

I'm a bit confused about the `/validate` endpoint. No matter what I do, I get this error back:
```json
{
  "error": "Missing or invalid schema version provided"
}
```

Aside from that, all the endpoints handle errors now.
