### PR TITLE
Update oclif prepack commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   "repository": "fauna/fauna-shell",
   "scripts": {
     "postpack": "rm -f oclif.manifest.json",
-    "prepack": "oclif-dev manifest && oclif-dev readme",
+    "prepack": "oclif manifest && oclif readme",
     "pretest": "npm run fixlint",
     "local-test": "export $(cat .env | xargs); nyc mocha --forbid-only \"test/**/*.test.js\"",
     "test": "export $(cat .env.test | xargs); nyc mocha --forbid-only \"test/**/*.test.js\"",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   "repository": "fauna/fauna-shell",
   "scripts": {
     "postpack": "rm -f oclif.manifest.json",
-    "prepack": "oclif manifest && oclif readme",
+    "prepack": "oclif manifest",
     "pretest": "npm run fixlint",
     "local-test": "export $(cat .env | xargs); nyc mocha --forbid-only \"test/**/*.test.js\"",
     "test": "export $(cat .env.test | xargs); nyc mocha --forbid-only \"test/**/*.test.js\"",


### PR DESCRIPTION
Ticket(s): FE-###

Replaces `oclif-dev` commands with `oclif`, and updates README to match `oclif readme`.
