### PR TITLE
Fix concourse pipeline

### DIFF
--- a/concourse/tasks/integration.yml
+++ b/concourse/tasks/integration.yml
@@ -3,7 +3,7 @@ version: "3.3"
 services:
   faunadb:
     image: fauna/faunadb
-    container_name: faunadb
+    container_name: core
     healthcheck:
       test: ["CMD", "curl", "http://faunadb:8443/ping"]
       interval: 1s

--- a/concourse/tasks/integration.yml
+++ b/concourse/tasks/integration.yml
@@ -23,4 +23,4 @@ services:
     volumes:
       - "../../:/tmp/app"
     working_dir: "/tmp/app"
-    command: [sh, -c, "npm install && npm run test"]
+    command: [sh, -c, "yarn install && yarn run test"]


### PR DESCRIPTION
Fixes container name so that tests can talk to core, and replaces `npm` calls with `yarn`.

I left the `npm publish` alone, as I think yarn does that a little differently. Not sure if we should mix these or what, but building with yarn and publishing with npm seemed reasonable to me.
