### PR TITLE
ENG-5275: Implement fauna schema {push,pull}

### DIFF
--- a/main.fsl
+++ b/main.fsl
@@ -1,3 +1,0 @@
-function x2(x) {
-  x + x + x
-}

--- a/src/commands/schema/cat.js
+++ b/src/commands/schema/cat.js
@@ -1,0 +1,41 @@
+const SchemaCommand = require("./schema-command.js");
+const { Args } = require("@oclif/core");
+const fetch = require("node-fetch");
+
+class CatSchemaCommand extends SchemaCommand {
+  async run() {
+    const filename = this.args.filename;
+    const { urlbase, secret } = await this.fetchsetup();
+
+    try {
+      const res = await fetch(`${urlbase}/schema/1/files/${filename}`, {
+        method: "GET",
+        headers: { AUTHORIZATION: `Bearer ${secret}` },
+      });
+      const json = await res.json();
+      if (json.error) {
+        this.error(json.error.message);
+      } else {
+        this.log(json.content);
+      }
+    } catch (err) {
+      this.error(err);
+    }
+  }
+}
+
+CatSchemaCommand.description = "Display the contents of a schema file";
+
+CatSchemaCommand.examples = ["$ fauna schema cat main.fsl"];
+
+CatSchemaCommand.args = {
+  filename: Args.string({
+    required: true,
+    description: "name of schema file",
+  }),
+};
+
+CatSchemaCommand.flags = {
+  ...SchemaCommand.flags,
+};
+module.exports = CatSchemaCommand;

--- a/src/commands/schema/ls.js
+++ b/src/commands/schema/ls.js
@@ -1,0 +1,39 @@
+const SchemaCommand = require("./schema-command.js");
+const fetch = require("node-fetch");
+
+class ListSchemaCommand extends SchemaCommand {
+  async run() {
+    const { urlbase, secret } = await this.fetchsetup();
+
+    try {
+      const res = await fetch(`${urlbase}/schema/1/files`, {
+        method: "GET",
+        headers: { Authorization: `Bearer ${secret}` },
+      });
+      const json = await res.json();
+      if (json.error) {
+        this.error(json.error.message);
+      } else if (json.files.length > 0) {
+        this.log("Schema files:\n");
+        json.files.forEach((file) => {
+          this.log(file.filename);
+        });
+      } else {
+        this.log("No schema files");
+      }
+    } catch (err) {
+      this.error(err);
+    }
+  }
+}
+
+ListSchemaCommand.description = "List database schema files";
+
+ListSchemaCommand.examples = ["$ fauna schema ls"];
+
+ListSchemaCommand.args = [];
+
+ListSchemaCommand.flags = {
+  ...SchemaCommand.flags,
+};
+module.exports = ListSchemaCommand;

--- a/src/commands/schema/pull.js
+++ b/src/commands/schema/pull.js
@@ -1,0 +1,79 @@
+const SchemaCommand = require("./schema-command.js");
+const fetch = require("node-fetch");
+const fs = require("fs");
+const path = require("path");
+const { Flags } = require("@oclif/core");
+
+class PullSchemaCommand extends SchemaCommand {
+  async run() {
+    const { urlbase, secret } = await this.fetchsetup();
+
+    const dir = this.flags.dir;
+
+    try {
+      const filesres = await fetch(`${urlbase}/schema/1/files`, {
+        method: "GET",
+        headers: { AUTHORIZATION: `Bearer ${secret}` },
+      });
+      const filesjson = await filesres.json();
+      if (filesjson.error) {
+        this.error(filesjson.error.message);
+      }
+      // Sort for consistent order. It's nice for tests.
+      const filenames = filesjson.files
+        .map((file) => file.filename)
+        .filter((name) => name.endsWith(".fsl"))
+        .sort();
+
+      // All of the below could be parallelized if necessary.
+      if (!this.flags.retain) {
+        // Delete all .fsl files (not directories).
+        for (const deleteme of fs.readdirSync(dir)) {
+          const fp = path.join(dir, deleteme);
+          if (deleteme.endsWith(".fsl") && !fs.statSync(fp).isDirectory()) {
+            fs.unlinkSync(fp);
+          }
+        }
+      }
+
+      for (const filename of filenames) {
+        const fileres = await fetch(`${urlbase}/schema/1/files/${filename}`, {
+          method: "GET",
+          headers: { AUTHORIZATION: `Bearer ${secret}` },
+        });
+        const filejson = await fileres.json();
+        if (filejson.error) {
+          this.error(filejson.error.message);
+        }
+        const fp = path.join(dir, filename);
+        fs.mkdirSync(path.dirname(fp), { recursive: true });
+        fs.writeFileSync(fp, filejson.content);
+      }
+    } catch (err) {
+      this.error(err);
+    }
+  }
+}
+
+PullSchemaCommand.description =
+  "Pull a database schema's .fsl files into a directory";
+
+PullSchemaCommand.examples = [
+  "$ fauna schema pull --dir schemas/myschema --retain",
+];
+
+PullSchemaCommand.flags = {
+  ...SchemaCommand.flags,
+  retain: Flags.boolean({
+    description:
+      "Retain .fsl files in the target directory that are not part of the database schema",
+    default: false,
+  }),
+  // NB: Required as a flag because it will become optional eventually,
+  //     once project configuration is implemented.
+  dir: Flags.string({
+    required: true,
+    description: "The target directory",
+  }),
+};
+module.exports = PullSchemaCommand;

--- a/src/commands/schema/push.js
+++ b/src/commands/schema/push.js
@@ -1,0 +1,122 @@
+const SchemaCommand = require("./schema-command.js");
+const fetch = require("node-fetch");
+const fs = require("fs");
+const path = require("path");
+const { Flags, ux } = require("@oclif/core");
+const FormData = require("form-data");
+
+const FILE_LIMIT = 256;
+const FILESIZE_LIMIT_BYTES = 32 * 1024 * 1024;
+
+class PushSchemaCommand extends SchemaCommand {
+  async run() {
+    const { urlbase, secret } = await this.fetchsetup();
+    const dir = this.flags.dir;
+    const filenames = fs.readdirSync(dir);
+    var totalsize = 0;
+    const files = filenames
+      .filter(
+        (filename) =>
+          filename.endsWith(".fsl") &&
+          !fs.statSync(path.join(dir, filename)).isDirectory()
+      )
+      .map((filename) => {
+        const content = fs.readFileSync(path.join(dir, filename));
+        totalsize += content.length;
+        if (totalsize > FILESIZE_LIMIT_BYTES) {
+          this.error(
+            `Too many bytes: at most ${FILESIZE_LIMIT_BYTES} may be pushed`
+          );
+        }
+        return {
+          name: filename,
+          content: content,
+        };
+      });
+    if (files.length > FILE_LIMIT) {
+      this.error(`Too many files: ${files.length} > ${FILE_LIMIT}`);
+    }
+    const body = () => {
+      const fd = new FormData();
+      for (const file of files) {
+        fd.append(file.name, Buffer.from(file.content));
+      }
+      return fd;
+    };
+
+    try {
+      if (this.flags.force) {
+        // Just push.
+        const res = await fetch(`${urlbase}/schema/1/update?force=true`, {
+          method: "POST",
+          headers: { AUTHORIZATION: `Bearer ${secret}` },
+          body: body(),
+        });
+        const json = await res.json();
+        if (json.error) {
+          this.error(json.error.message);
+        }
+      } else {
+        // Confirm diff, then push it.
+        let vurl = `${urlbase}/schema/1/validate?force=true`;
+        if (this.flags.version) {
+          vurl = `${urlbase}/schema/1/validate?version=${this.flags.version}`;
+        }
+        const res = await fetch(vurl, {
+          method: "POST",
+          headers: { AUTHORIZATION: `Bearer ${secret}` },
+          body: body(),
+        });
+        const json = await res.json();
+        if (json.error) {
+          this.error(json.error.message);
+          return;
+        }
+        this.log(`Proposed diff:\n`);
+        this.log(json.diff);
+        if (await ux.confirm("Accept and push the changes?")) {
+          let purl = `${urlbase}/schema/1/update?version=${json.version}`;
+          if (this.flags.version) {
+            purl = `${urlbase}/schema/1/update?version=${this.flags.version}`;
+          }
+          const res = await fetch(purl, {
+            method: "POST",
+            headers: { AUTHORIZATION: `Bearer ${secret}` },
+            body: body(),
+          });
+          const json0 = await res.json();
+          if (json0.error) {
+            this.error(json0.error.message);
+          }
+        } else {
+          this.log("Change cancelled");
+        }
+      }
+    } catch (err) {
+      this.error(err);
+    }
+  }
+}
+
+PushSchemaCommand.description = "Push a directory of .fsl files to Fauna";
+
+PushSchemaCommand.examples = ["$ fauna schema push --dir schemas/myschema"];
+
+PushSchemaCommand.flags = {
+  ...SchemaCommand.flags,
+  force: Flags.boolean({
+    description: "Push the change without a diff or schema version check",
+    default: false,
+  }),
+  // NB: Required as a flag because it will become optional eventually,
+  //     once project configuration is implemented.
+  dir: Flags.string({
+    required: true,
+    description: "The directory of .fsl files to push",
+  }),
+  version: Flags.string({
+    required: false,
+    description: "The schema version expected in the database",
+  }),
+};
+module.exports = PushSchemaCommand;

--- a/src/commands/schema/schema-command.js
+++ b/src/commands/schema/schema-command.js
@@ -1,0 +1,16 @@
+const FaunaCommand = require("../../lib/fauna-command.js");
+
+class SchemaCommand extends FaunaCommand {
+  async fetchsetup() {
+    const {
+      connectionOptions: { domain, port, scheme, secret },
+    } = await this.getClient();
+
+    return {
+      urlbase: `${scheme}://${domain}:${port ? port : "4443"}`,
+      secret: secret,
+    };
+  }
+}
+
+module.exports = SchemaCommand;

--- a/src/commands/schema/schema-command.js
+++ b/src/commands/schema/schema-command.js
@@ -7,7 +7,7 @@ class SchemaCommand extends FaunaCommand {
     } = await this.getClient();
 
     return {
-      urlbase: `${scheme}://${domain}:${port ? port : "4443"}`,
+      urlbase: `${scheme ?? "https"}://${domain}${port ? `:${port}` : ""}`,
       secret: secret,
     };
   }

--- a/test/commands/schema.test.js
+++ b/test/commands/schema.test.js
@@ -1,0 +1,166 @@
+const fs = require("fs");
+const path = require("path");
+const { expect, test } = require("@oclif/test");
+const { query: q } = require("faunadb");
+const { withOpts, getEndpoint, matchFqlReq } = require("../helpers/utils.js");
+const { ux } = require("@oclif/core");
+
+const files = {
+  version: 0,
+  files: [
+    { filename: "main.fsl" },
+    { filename: "functions.fsl" },
+    { filename: "legacy.json" },
+  ],
+};
+
+const main = {
+  version: 0,
+  content: "collection foo {}\n\nfunction bar(x, y) { x + y }\n",
+};
+
+const functions = {
+  version: 0,
+  content: "function id(x) { x }",
+};
+
+const diff = {
+  version: 0,
+  diff: "main.fsl ADD collection foo",
+};
+
+const pullfiles = {
+  version: 0,
+  files: [{ filename: "main.fsl" }, { filename: "functions.fsl" }],
+};
+
+const updated = { version: 1 };
+
+describe("fauna schema ls test", () => {
+  test
+    .nock(getEndpoint(), { allowUnmocked: false }, (api) =>
+      api
+        .persist()
+        .post("/", matchFqlReq(q.Now()))
+        .reply(200, new Date())
+        .get("/schema/1/files")
+        .reply(200, files)
+    )
+    .stdout()
+    .command(withOpts(["schema ls"]))
+    .it("runs schema ls", (ctx) => {
+      expect(ctx.stdout).to.contain(
+        "Schema files:\n\nmain.fsl\nfunctions.fsl\nlegacy.json"
+      );
+    });
+});
+
+describe("fauna schema cat test", () => {
+  test
+    .nock(getEndpoint(), { allowUnmocked: false }, (api) =>
+      api
+        .persist()
+        .post("/", matchFqlReq(q.Now()))
+        .reply(200, new Date())
+        .get("/schema/1/files/main.fsl")
+        .reply(200, main)
+    )
+    .stdout()
+    .command(withOpts(["schema cat", "main.fsl"]))
+    .it("runs schema cat", (ctx) => {
+      expect(ctx.stdout).to.contain(`${main.content}`);
+    });
+});
+
+describe("fauna schema push test", () => {
+  test
+    .stub(ux, "confirm", () => async () => true)
+    .nock(getEndpoint(), { allowUnmocked: false }, (api) =>
+      api
+        .persist()
+        .post("/", matchFqlReq(q.Now()))
+        .reply(200, new Date())
+        .post("/schema/1/validate?force=true")
+        .reply(200, diff)
+        .post("/schema/1/update?version=0")
+        .reply(200, updated)
+    )
+    .stdout()
+    .command(withOpts(["schema push", "--dir=test/testdata"]))
+    .it("runs schema push", (ctx) => {
+      expect(ctx.stdout).to.contain(`${diff.diff}`);
+    });
+});
+
+const testdir = "test/testdata";
+
+const setup = () => {
+  try {
+    fs.unlinkSync(path.join(testdir, "functions.fsl"));
+  } catch (err) {
+    // 2023 technology.
+    if (err.code === "ENOENT") {
+      // OK.
+    } else {
+      throw err;
+    }
+  }
+  fs.writeFileSync(path.join(testdir, "main.fsl"), "collection Nope { }");
+  fs.writeFileSync(path.join(testdir, "extra.fsl"), "baaaaa");
+};
+
+for (const retain of [true, false]) {
+  describe(`fauna schema pull test (retain=${retain})`, () => {
+    let cmd = ["schema pull", `--dir=${testdir}`];
+    if (retain) {
+      cmd = ["schema pull", `--dir=${testdir}`, "--retain"];
+    }
+    setup();
+    test
+      .nock(getEndpoint(), { allowUnmocked: false }, (api) =>
+        api
+          .persist()
+          .post("/", matchFqlReq(q.Now()))
+          .reply(200, new Date())
+          .get("/schema/1/files")
+          .reply(200, pullfiles)
+          .get("/schema/1/files/functions.fsl")
+          .reply(200, functions)
+          .get("/schema/1/files/main.fsl")
+          .reply(200, main)
+      )
+      .stdout()
+      .command(withOpts(cmd))
+      .it("runs schema pull", (ctx) => {
+        expect(ctx.stdout).to.contain("");
+        expect(
+          fs.readFileSync(path.join(testdir, "functions.fsl"), "utf8")
+        ).to.equal(functions.content);
+        expect(
+          fs.readFileSync(path.join(testdir, "main.fsl"), "utf8")
+        ).to.equal(main.content);
+        expect(
+          fs.statSync(path.join(testdir, "no.fsl")).isDirectory()
+        ).to.equal(true);
+        expect(fs.statSync(path.join(testdir, "nofsl")).isDirectory()).to.equal(
+          true
+        );
+        expect(
+          fs.statSync(path.join(testdir, "main.notfsl")).isFile()
+        ).to.equal(true);
+        if (retain) {
+          expect(
+            fs.statSync(path.join(testdir, "extra.fsl")).isFile()
+          ).to.equal(true);
+        } else {
+          // 2023 error handling technology.
+          try {
+            fs.statSync(path.join(testdir, "extra.fsl"));
+            expect(0).to.equal(1);
+          } catch (err) {
+            expect(err.code).to.equal("ENOENT");
+          }
+        }
+      });
+  });
+}

--- a/test/testdata/functions.fsl
+++ b/test/testdata/functions.fsl
@@ -1,0 +1,1 @@
+function id(x) { x }

--- a/test/testdata/main.fsl
+++ b/test/testdata/main.fsl
@@ -1,0 +1,3 @@
+collection foo {}
+
+function bar(x, y) { x + y }

--- a/test/testdata/main.notfsl
+++ b/test/testdata/main.notfsl
@@ -1,0 +1,1 @@
+This isn't fsl.


### PR DESCRIPTION
This implements fauna schema push and fauna schema pull with the following semantics:

fauna schema push requires a directory set with --dir. It collects all .fsl files in the directory and submits them to the validation endpoint, displaying the diff to the user. If the user accepts the change, the files are pushed at the schema version returned by the validate call. Optionally, users may skip version checks and validation with --force, or specify their own schema version to check against with --version.

fauna schema pull requires a directory set with --dir. By default, it deletes all .fsl files (not directories ending in .fsl) and downloads the schema as .fsl files into the directory. Users may keep .fsl files that are not part of the download by setting --retain.

I also restored the fauna schema ls and fauna schema cat commands.

While there is an automated test for parts of the code, I also manually tested the file handling behavior with a local Fauna instance.
