### PR TITLE
ENG-5464: Make fauna schema push recursive

### DIFF
--- a/test/commands/schema.test.js
+++ b/test/commands/schema.test.js
@@ -24,6 +24,11 @@ const functions = {
   content: "function id(x) { x }",
 };
 
+const myrole = {
+  version: 0,
+  content: "role myrole { }",
+};
+
 const diff = {
   version: 0,
   diff: "main.fsl ADD collection foo",
@@ -31,7 +36,11 @@ const diff = {
 
 const pullfiles = {
   version: 0,
-  files: [{ filename: "main.fsl" }, { filename: "functions.fsl" }],
+  files: [
+    { filename: "main.fsl" },
+    { filename: "functions.fsl" },
+    { filename: "roles/myrole.fsl" },
+  ],
 };
 
 const updated = { version: 1 };
@@ -97,6 +106,7 @@ const testdir = "test/testdata";
 const setup = () => {
   try {
     fs.unlinkSync(path.join(testdir, "functions.fsl"));
+    fs.rmSync(path.join(testdir, "roles"), { recursive: true, force: true });
   } catch (err) {
     // 2023 technology.
     if (err.code === "ENOENT") {
@@ -128,6 +138,8 @@ for (const retain of [true, false]) {
           .reply(200, functions)
           .get("/schema/1/files/main.fsl")
           .reply(200, main)
+          .get("/schema/1/files/roles/myrole.fsl")
+          .reply(200, myrole)
       )
       .stdout()
       .command(withOpts(cmd))
@@ -139,6 +151,9 @@ for (const retain of [true, false]) {
         expect(
           fs.readFileSync(path.join(testdir, "main.fsl"), "utf8")
         ).to.equal(main.content);
+        expect(
+          fs.readFileSync(path.join(testdir, "roles", "myrole.fsl"), "utf8")
+        ).to.equal(myrole.content);
         expect(
           fs.statSync(path.join(testdir, "no.fsl")).isDirectory()
         ).to.equal(true);


### PR DESCRIPTION
This got missed before. `fauna schema push` will now recur into all subdirectories and push all fsl files with a name equal to the relative path to the .fsl file. So, `fauna schema push --dir=/foo/bar` will push `/foo/bar/a/b/functions.fsl` as an FSL file named "a/b/functions.fsl".

It isn't amenable to the unit tests but I tested manually that the recursive traversal works to multiple levels of depth.
