### PR TITLE
Move schema-command.js so it doesn't show up in help

### DIFF
--- a/src/commands/schema/cat.js
+++ b/src/commands/schema/cat.js
@@ -1,4 +1,4 @@
-const SchemaCommand = require("./schema-command.js");
+const SchemaCommand = require("../../lib/schema-command.js");
 const { Args } = require("@oclif/core");
 const fetch = require("node-fetch");
 

--- a/src/commands/schema/ls.js
+++ b/src/commands/schema/ls.js
@@ -1,4 +1,4 @@
-const SchemaCommand = require("./schema-command.js");
+const SchemaCommand = require("../../lib/schema-command.js");
 const fetch = require("node-fetch");
 
 class ListSchemaCommand extends SchemaCommand {

--- a/src/commands/schema/pull.js
+++ b/src/commands/schema/pull.js
@@ -1,4 +1,4 @@
-const SchemaCommand = require("./schema-command.js");
+const SchemaCommand = require("../../lib/schema-command.js");
 const fetch = require("node-fetch");
 const fs = require("fs");
 const path = require("path");

--- a/src/commands/schema/push.js
+++ b/src/commands/schema/push.js
@@ -1,4 +1,4 @@
-const SchemaCommand = require("./schema-command.js");
+const SchemaCommand = require("../../lib/schema-command.js");
 const fetch = require("node-fetch");
 const fs = require("fs");
 const path = require("path");

--- a/src/lib/schema-command.js
+++ b/src/lib/schema-command.js
@@ -1,4 +1,4 @@
-const FaunaCommand = require("../../lib/fauna-command.js");
+const FaunaCommand = require("./fauna-command.js");
 
 class SchemaCommand extends FaunaCommand {
   async fetchsetup() {


### PR DESCRIPTION
Ticket(s): ENG-5466

Makes `schema-command` not show up in help.
