### PR TITLE
Bump to 1.1.0

### DIFF
--- a/concourse/scripts/publish.sh
+++ b/concourse/scripts/publish.sh
@@ -16,7 +16,7 @@ if [ "$PACKAGE_VERSION" \> "$NPM_LATEST_VERSION" ]
 then
   echo "Publishing a new version..."
   echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
-  npm publish --tag beta
+  npm publish
   rm .npmrc
 else
   echo "NPM package already published on npm with version ${NPM_LATEST_VERSION}" 1>&2

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fauna-shell",
   "description": "faunadb shell",
-  "version": "1.1.0-beta2",
+  "version": "1.1.0",
   "author": "Fauna",
   "bin": {
     "fauna": "./bin/run"


### PR DESCRIPTION
Ticket(s): FE-###

Bumps to 1.1.0 and removes the `--tag beta` from the publish script.
