### PR TITLE
Add project config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,7 @@
       }
     ]
   },
+  "ignorePatterns": ["dist/**/*"],
   "overrides": [
     {
       "files": ["*.test.js", "*.spec.js"],

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "build": "rm -rf dist && tsc -b",
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "yarn build && oclif manifest",
-    "pretest": "npm run fixlint",
+    "pretest": "yarn fixlint",
     "local-test": "export $(cat .env | xargs); nyc mocha --forbid-only \"test/**/*.test.{js,ts}\"",
     "test": "export $(cat .env.test | xargs); nyc mocha --forbid-only \"test/**/*.test.{js,ts}\"",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "lint": "eslint .",
     "fixlint": "eslint . --fix",
     "version": "oclif-dev readme && git add README.md",
-    "fmt": "prettier -w ."
+    "fmt": "prettier -w src"
   },
   "husky": {
     "hooks": {

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -260,10 +260,12 @@ export class ShellConfig {
 
   lookupEndpoint = (): EndpointConfig => {
     let database = this.stack?.database ?? "";
-    if (this.stack !== undefined && this.args.scope !== undefined) {
-      database += "/";
+    if (this.args.scope !== undefined) {
+      if (this.stack !== undefined) {
+        database += "/";
+      }
+      database += this.args.scope;
     }
-    database += this.args.scope;
 
     return this.endpoint.makeScopedEndpoint(database, this.args.role);
   };

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -1,0 +1,296 @@
+// Manages ~/.fauna-shell
+
+import fs from "fs";
+import os from "os";
+import path from "path";
+const ini = require("ini");
+
+import { ProjectConfig, Stack } from "./project-config";
+import { RootConfig, Endpoint } from "./root-config";
+
+export { RootConfig, ProjectConfig, Endpoint, Stack };
+
+export class InvalidConfigError extends Error {}
+
+// Wraps an `ini` file with helpers to get typed values out
+export class Config {
+  keyName: string;
+  private config: { [key: string]: unknown };
+
+  constructor(keyName: string, config: { [key: string]: unknown }) {
+    this.keyName = keyName;
+    this.config = config;
+  }
+
+  strOpt(key: string): string | undefined {
+    const v = this.config[key];
+    if (v === undefined || typeof v === "string") {
+      return v;
+    } else {
+      throw new InvalidConfigError(
+        `Expected string for ${this.keyName} ${key}, got ${typeof v}`
+      );
+    }
+  }
+
+  numberOpt(key: string): number | undefined {
+    const v = this.config[key];
+    if (v === undefined || typeof v === "number") {
+      return v;
+    } else if (typeof v === "string") {
+      try {
+        return parseInt(v);
+      } catch (_) {
+        throw new InvalidConfigError(
+          `Invalid number for ${this.keyName} ${key}`
+        );
+      }
+    } else {
+      throw new InvalidConfigError(
+        `Expected number for ${this.keyName} ${key}, got ${typeof v}`
+      );
+    }
+  }
+
+  object(key: string): Config {
+    const v = this.config[key];
+    if (v === undefined) {
+      throw new InvalidConfigError(
+        `Missing value for required ${this.keyName} ${key}`
+      );
+    } else if (v !== null && typeof v === "object") {
+      return new Config(this.keyName, v as any);
+    } else {
+      throw new InvalidConfigError(
+        `Expected object for ${this.keyName} ${key}, got ${typeof v}`
+      );
+    }
+  }
+
+  str(key: string): string {
+    return this.require(key, this.strOpt(key));
+  }
+
+  number(key: string): number {
+    return this.require(key, this.numberOpt(key));
+  }
+
+  require<T>(key: string, value: T | undefined): T {
+    if (value === undefined) {
+      throw new InvalidConfigError(
+        `Missing value for required ${this.keyName} ${key}`
+      );
+    } else {
+      return value;
+    }
+  }
+
+  // Returns a list of all keys that match `pred`.
+  allObjectsWhere(pred: (key: string) => boolean): [string, Config][] {
+    return Object.keys(this.config).flatMap((k) =>
+      pred(k) ? [[k, this.object(k)]] : []
+    );
+  }
+
+  // Returns a list of all child objects of the given `key`.
+  objectsIn(key: string) {
+    const obj = this.object(key);
+    return obj.allObjectsWhere((_) => true);
+  }
+}
+
+/**
+ * Builds the options provided to the faunajs client.
+ * Tries to load the ~/.fauna-shell file and read the default endpoint from there.
+ *
+ * Assumes that if the file exists, it would have been created by fauna-shell,
+ * therefore it would have a defined endpoint.
+ *
+ * Flags like --host, --port, etc., provided by the CLI take precedence over what's
+ * stored in ~/.fauna-shell.
+ *
+ * The --endpoint flag overries the default endpoint from fauna-shell.
+ *
+ * If ~/.fauna-shell doesn't exist, tries to build the connection options from the
+ * flags passed to the script.
+ *
+ * It always expect a secret key to be set in ~/.fauna-shell or provided via CLI
+ * arguments.
+ *
+ * TODO: Remove and store a ShellConfig in `fauna-command`
+ */
+export const lookupEndpoint = (flags: any, scope: string, role: string) => {
+  return ShellConfig.read(flags, scope, role).lookupEndpoint();
+};
+
+export type ShellOpts = {
+  flags?: { [key: string]: any };
+  rootConfig?: { [key: string]: any };
+  projectConfig?: { [key: string]: any };
+  scope?: string;
+  role?: string;
+};
+
+export type EndpointConfig = {
+  secret: string;
+  url: string;
+  graphqlHost: string;
+  graphqlPort: number;
+};
+
+export class ShellConfig {
+  // fields from CLI and files
+  flags: Config;
+  rootConfig: RootConfig;
+  projectConfig: ProjectConfig | undefined;
+  args: {
+    scope?: string;
+    role?: string;
+  };
+
+  // The selected stack from the project config. If there is a project config, this will also be set.
+  stack: Stack | undefined;
+  // The fully configured endpoint, including command line flags that override things like the URL.
+  endpoint: Endpoint;
+
+  static read(flags: any, scope: string, role: string) {
+    const rootConfig = ini.parse(readFileOpt(getRootConfigFile()));
+    const projectConfigPath = getProjectConfigPath();
+    const projectConfig = projectConfigPath
+      ? ini.parse(fs.readFileSync(projectConfigPath, "utf8"))
+      : undefined;
+
+    return new ShellConfig({
+      flags,
+      rootConfig,
+      projectConfig,
+      scope,
+      role,
+    });
+  }
+
+  constructor(opts: ShellOpts) {
+    this.flags = new Config("flag", opts.flags ?? {});
+
+    this.rootConfig = new RootConfig(
+      new Config("config key", opts.rootConfig ?? {})
+    );
+    this.projectConfig = opts.projectConfig
+      ? new ProjectConfig(new Config("config key", opts.projectConfig))
+      : undefined;
+
+    this.projectConfig?.validate(this.rootConfig);
+
+    this.args = {
+      scope: opts.scope,
+      role: opts.role,
+    };
+
+    const urlFlag = Endpoint.getURLFromConfig(this.flags);
+    if (urlFlag !== undefined) {
+      try {
+        new URL(urlFlag);
+      } catch (e) {
+        throw new Error(`Invalid database URL: ${urlFlag}`);
+      }
+    }
+
+    if (this.projectConfig === undefined) {
+      const stackName = this.flags.strOpt("stack");
+      if (stackName !== undefined) {
+        throw new Error(
+          `No .fauna-project was found, so stack '${stackName}' cannot be used`
+        );
+      }
+    } else {
+      const stackName =
+        this.flags.strOpt("stack") ?? this.projectConfig.defaultStack;
+
+      if (stackName === undefined) {
+        throw new Error(
+          `A stack must be chosen. Use \`fauna stack default\` or pass --stack to select one`
+        );
+      }
+
+      this.stack = this.projectConfig.stacks[stackName];
+      if (this.stack === undefined) {
+        throw new Error(`No such stack '${stackName}'`);
+      }
+    }
+
+    // An endpoint must be chosen as well. The endpoint may come from (in order)
+    // the `--endpoint` flag, the `endpoint` key in the project config, or the
+    // `default` key in the root config.
+    const endpointName =
+      this.flags.strOpt("endpoint") ??
+      this.stack?.endpoint ??
+      this.rootConfig.defaultEndpoint;
+
+    const secretFlag = this.flags.strOpt("secret");
+
+    if (endpointName === undefined) {
+      // No `~/.fauna-shell` was found, so `--secret` is required, and then fill in some defaults.
+      if (secretFlag === undefined) {
+        throw new Error(
+          "No endpoint or secret set. Set an endpoint in ~/.fauna-shell, .fauna-project, or pass --endpoint"
+        );
+      }
+
+      this.endpoint = new Endpoint({
+        secret: secretFlag,
+        url: urlFlag,
+        graphqlHost: this.flags.strOpt("graphqlHost"),
+        graphqlPort: this.flags.numberOpt("graphqlPort"),
+      });
+    } else {
+      this.endpoint = this.rootConfig.endpoints[endpointName];
+      if (this.endpoint === undefined) {
+        throw new Error(`No such endpoint '${endpointName}'`);
+      }
+
+      // override endpoint with values from flags.
+      this.endpoint.url = urlFlag ?? this.endpoint.url;
+      this.endpoint.graphqlHost =
+        this.flags.strOpt("graphqlHost") ?? this.endpoint.graphqlHost;
+      this.endpoint.graphqlPort =
+        this.flags.numberOpt("graphqlHost") ?? this.endpoint.graphqlPort;
+    }
+  }
+
+  lookupEndpoint = (): EndpointConfig => {
+    return this.endpoint.makeScopedEndpoint(
+      this.args.scope ?? this.stack?.database,
+      this.args.role
+    );
+  };
+}
+
+const readFileOpt = (fileName: string) => {
+  try {
+    return fs.readFileSync(fileName, "utf8");
+  } catch (err) {
+    if (isFileNotFound(err)) {
+      return "";
+    } else {
+      throw err;
+    }
+  }
+};
+
+const getRootConfigFile = () => {
+  return path.join(os.homedir(), ".fauna-shell");
+};
+
+// TODO: Search upwards for a `.fauna-project` file
+const getProjectConfigPath = () => {
+  const projectConfigPath = path.join(process.cwd(), ".fauna-project");
+  if (fs.existsSync(projectConfigPath)) {
+    return projectConfigPath;
+  } else {
+    return undefined;
+  }
+};
+
+const isFileNotFound = (err: any) => {
+  return err.code === "ENOENT" && err.syscall === "open";
+};

--- a/src/lib/config/project-config.ts
+++ b/src/lib/config/project-config.ts
@@ -1,0 +1,51 @@
+import { RootConfig, Config, InvalidConfigError } from ".";
+
+// Represents `.fauna-project`
+export class ProjectConfig {
+  defaultStack?: string;
+  stacks: { [key: string]: Stack };
+
+  constructor(config: Config) {
+    this.defaultStack = config.strOpt("default");
+    this.stacks = Object.fromEntries(
+      config.objectsIn("stack").map(([k, v]) => [k, new Stack(v)])
+    );
+
+    if (this.defaultStack === "default") {
+      throw new InvalidConfigError("Default stack cannot be named 'default'");
+    } else if (
+      this.defaultStack &&
+      this.stacks[this.defaultStack] === undefined
+    ) {
+      throw new InvalidConfigError(
+        `Default stack '${this.defaultStack}' was not found`
+      );
+    }
+  }
+
+  validate(rootConfig: RootConfig) {
+    for (const stack of Object.values(this.stacks)) {
+      if (rootConfig.endpoints[stack.endpoint] === undefined) {
+        throw new InvalidConfigError(
+          `Endpoint '${stack.endpoint}' not found in ~/.fauna-shell`
+        );
+      }
+    }
+  }
+}
+
+export class Stack {
+  /**
+   * The endpoint name to use as a base.
+   */
+  endpoint: string;
+  /**
+   * The database path to use.
+   */
+  database?: string;
+
+  constructor(config: Config) {
+    this.endpoint = config.str("endpoint");
+    this.database = config.str("database");
+  }
+}

--- a/src/lib/config/project-config.ts
+++ b/src/lib/config/project-config.ts
@@ -11,12 +11,7 @@ export class ProjectConfig {
       config.objectsIn("stack").map(([k, v]) => [k, new Stack(v)])
     );
 
-    if (this.defaultStack === "default") {
-      throw new InvalidConfigError("Default stack cannot be named 'default'");
-    } else if (
-      this.defaultStack &&
-      this.stacks[this.defaultStack] === undefined
-    ) {
+    if (this.defaultStack && this.stacks[this.defaultStack] === undefined) {
       throw new InvalidConfigError(
         `Default stack '${this.defaultStack}' was not found`
       );

--- a/src/lib/config/project-config.ts
+++ b/src/lib/config/project-config.ts
@@ -37,7 +37,7 @@ export class Stack {
   /**
    * The database path to use.
    */
-  database?: string;
+  database: string;
 
   constructor(config: Config) {
     this.endpoint = config.str("endpoint");

--- a/src/lib/config/root-config.ts
+++ b/src/lib/config/root-config.ts
@@ -1,0 +1,108 @@
+import { Config, InvalidConfigError } from ".";
+
+// Represents `~/.fauna-shell`
+export class RootConfig {
+  defaultEndpoint?: string;
+  endpoints: { [key: string]: Endpoint };
+
+  constructor(config: Config) {
+    this.defaultEndpoint = config.strOpt("default");
+    this.endpoints = Object.fromEntries(
+      config
+        .allObjectsWhere((k) => k !== "default")
+        .map(([k, v]) => [k, Endpoint.fromConfig(v)])
+    );
+
+    if (this.defaultEndpoint === "default") {
+      throw new InvalidConfigError(
+        "Default endpoint cannot be named 'default'"
+      );
+    } else if (
+      this.defaultEndpoint &&
+      this.endpoints[this.defaultEndpoint] === undefined
+    ) {
+      throw new InvalidConfigError(
+        `Default endpoint '${this.defaultEndpoint}' was not found`
+      );
+    }
+  }
+}
+
+/**
+ * Represents an endpoint, or a section of `~/.fauna-shell`.
+ *
+ * An endpoint contains:
+ * - A secret. This is the accout secret for this database.
+ * - An optional URL. This is the URL of the database. It defaults to `https://db.fauna.com`.
+ * - An optional GraphQL host. This is the host to use for GraphQL requests. It defaults to `graphql.fauna.com`.
+ * - An optional GraphQL port. This is the port to use for GraphQL requests. It defaults to `443`.
+ */
+export class Endpoint {
+  secret: string;
+  url: string;
+
+  graphqlHost: string;
+  graphqlPort: number;
+
+  static fromConfig(config: Config) {
+    return new Endpoint({
+      secret: config.str("secret"),
+      url: Endpoint.getURLFromConfig(config),
+
+      graphqlHost: config.strOpt("graphqlHost"),
+      graphqlPort: config.numberOpt("graphqlPort"),
+    });
+  }
+
+  constructor(opts: {
+    secret: string;
+    url?: string;
+    graphqlHost?: string;
+    graphqlPort?: number;
+  }) {
+    this.secret = opts.secret;
+    this.url = opts.url ?? "https://db.fauna.com";
+
+    this.graphqlHost = opts.graphqlHost ?? "graphql.fauna.com";
+    this.graphqlPort = opts.graphqlPort ?? 443;
+  }
+
+  makeScopedEndpoint(
+    scope?: string,
+    role?: string
+  ): {
+    secret: string;
+    url: string;
+    graphqlHost: string;
+    graphqlPort: number;
+  } {
+    const secret =
+      this.secret + (scope ? `:${scope}` : "") + ":" + (role ?? "admin");
+
+    return {
+      secret,
+      url: this.url,
+      graphqlHost: this.graphqlHost,
+      graphqlPort: this.graphqlPort,
+    };
+  }
+
+  static getURLFromConfig = (config: Config): string | undefined => {
+    const url = config.strOpt("url");
+    const scheme = config.strOpt("scheme");
+    const domain = config.strOpt("domain");
+    const port = config.numberOpt("port");
+
+    if (
+      url === undefined &&
+      (domain !== undefined || port !== undefined || scheme !== undefined)
+    ) {
+      const scheme0 = scheme ?? "https";
+      const domain0 = domain ?? "db.fauna.com";
+      const port0 = port ? `:${port}` : "";
+      return `${scheme0}://${domain0}${port0}`;
+    } else {
+      return url;
+    }
+  };
+}

--- a/src/lib/config/root-config.ts
+++ b/src/lib/config/root-config.ts
@@ -77,7 +77,7 @@ export class Endpoint {
     graphqlPort: number;
   } {
     const secret =
-      this.secret + (scope ? `:${scope}` : "") + ":" + (role ?? "admin");
+      this.secret + (scope ? `:${scope}` : "") + (role ? `:${role}` : "");
 
     return {
       secret,

--- a/src/lib/schema-command.js
+++ b/src/lib/schema-command.js
@@ -12,12 +12,12 @@ class SchemaCommand extends FaunaCommand {
 
   async fetchsetup() {
     const {
-      connectionOptions: { domain, port, scheme, secret },
+      connectionOptions: { url, secret },
     } = await this.getClient();
 
     return {
-      urlbase: `${scheme ?? "https"}://${domain}${port ? `:${port}` : ""}`,
-      secret: secret,
+      urlbase: url,
+      secret,
     };
   }
 

--- a/test/commands/eval.test.js
+++ b/test/commands/eval.test.js
@@ -17,7 +17,7 @@ describe("eval", () => {
       ])
     )
     .it("runs eval on root db", (ctx) => {
-      expect(JSON.parse(ctx.stdout).data[0].targetDb).to.equal("root");
+      expect(JSON.parse(ctx.stdout).data[0].targetDb).to.equal("admin");
     });
 
   test
@@ -112,7 +112,7 @@ function mockQuery(api) {
         resource: {
           data: [
             {
-              targetDb: auth[1] || "root",
+              targetDb: auth[1] ?? "root",
             },
           ],
         },

--- a/test/commands/eval.test.js
+++ b/test/commands/eval.test.js
@@ -17,7 +17,7 @@ describe("eval", () => {
       ])
     )
     .it("runs eval on root db", (ctx) => {
-      expect(JSON.parse(ctx.stdout).data[0].targetDb).to.equal("admin");
+      expect(JSON.parse(ctx.stdout).data[0].targetDb).to.equal("root");
     });
 
   test

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -264,4 +264,51 @@ describe("local config with flags", () => {
       url: "http://somewhere-else:10443",
     });
   });
+
+  it("scope from args works", () => {
+    expect(
+      lookupEndpoint({
+        flags: {},
+        rootConfig: {
+          default: "my-endpoint",
+          "my-endpoint": {
+            secret: "fn1234",
+            url: "http://localhost:8443",
+          },
+        },
+        scope: "my-scope",
+      })
+    ).to.deep.contain({
+      secret: "fn1234:my-scope:admin",
+      url: "http://localhost:8443",
+    });
+  });
+
+  it("concats scope from args and stack", () => {
+    expect(
+      lookupEndpoint({
+        flags: {},
+        rootConfig: {
+          default: "my-endpoint",
+          "my-endpoint": {
+            secret: "fn1234",
+            url: "http://localhost:8443",
+          },
+        },
+        projectConfig: {
+          default: "my-app",
+          stack: {
+            "my-app": {
+              endpoint: "my-endpoint",
+              database: "my-db",
+            },
+          },
+        },
+        scope: "my-scope",
+      })
+    ).to.deep.contain({
+      secret: "fn1234:my-db/my-scope:admin",
+      url: "http://localhost:8443",
+    });
+  });
 });

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -1,0 +1,267 @@
+import { expect } from "chai";
+import { ShellConfig, ShellOpts } from "../../src/lib/config";
+
+const lookupEndpoint = (opts: ShellOpts) => {
+  return new ShellConfig(opts).lookupEndpoint();
+};
+
+describe("root config", () => {
+  it("works", () => {
+    expect(
+      lookupEndpoint({
+        rootConfig: {
+          default: "my-endpoint",
+          "my-endpoint": {
+            secret: "fn1234",
+            url: "http://localhost:8443",
+          },
+        },
+      })
+    ).to.deep.contain({
+      secret: "fn1234:admin",
+      url: "http://localhost:8443",
+    });
+  });
+
+  it("defaults endpoint", () => {
+    expect(
+      lookupEndpoint({
+        rootConfig: {
+          default: "my-endpoint",
+          "my-endpoint": {
+            secret: "fn1234",
+          },
+        },
+      })
+    ).to.deep.contain({
+      secret: "fn1234:admin",
+      url: "https://db.fauna.com",
+    });
+  });
+
+  it("supports old domain args", () => {
+    expect(
+      lookupEndpoint({
+        rootConfig: {
+          default: "my-endpoint",
+          "my-endpoint": {
+            secret: "fn1234",
+            scheme: "http",
+            domain: "localhost",
+            port: "8443",
+          },
+        },
+      })
+    ).to.deep.contain({
+      secret: "fn1234:admin",
+      url: "http://localhost:8443",
+    });
+  });
+});
+
+describe("root config with flags", () => {
+  it("allows overriding endpoint with --endpoint", () => {
+    expect(
+      lookupEndpoint({
+        flags: {
+          endpoint: "my-endpoint-2",
+        },
+        rootConfig: {
+          default: "my-endpoint",
+          "my-endpoint": {
+            secret: "fn1234",
+          },
+          "my-endpoint-2": {
+            secret: "fn555",
+          },
+        },
+      })
+    ).to.deep.contain({
+      secret: "fn555:admin",
+      url: "https://db.fauna.com",
+    });
+  });
+});
+
+describe("local config", () => {
+  it("allows choosing the endpoint through project config", () => {
+    expect(
+      lookupEndpoint({
+        rootConfig: {
+          default: "my-endpoint",
+          "my-endpoint": {
+            secret: "fn1234",
+            url: "http://localhost:8443",
+          },
+          "my-endpoint-2": {
+            secret: "fn555",
+          },
+        },
+        projectConfig: {
+          default: "my-app",
+          stack: {
+            "my-app": {
+              endpoint: "my-endpoint-2",
+              database: "foo",
+            },
+          },
+        },
+      })
+    ).to.deep.contain({
+      secret: "fn555:foo:admin",
+      url: "https://db.fauna.com",
+    });
+  });
+
+  it("allows adding a db scope", () => {
+    expect(
+      lookupEndpoint({
+        rootConfig: {
+          default: "my-endpoint",
+          "my-endpoint": {
+            secret: "fn1234",
+            url: "http://localhost:8443",
+          },
+          "my-endpoint-2": {
+            secret: "fn555",
+          },
+        },
+        projectConfig: {
+          default: "my-app",
+          stack: {
+            "my-app": {
+              endpoint: "my-endpoint-2",
+              database: "my-db",
+            },
+          },
+        },
+      })
+    ).to.deep.contain({
+      secret: "fn555:my-db:admin",
+      url: "https://db.fauna.com",
+    });
+  });
+});
+
+describe("local config with flags", () => {
+  it("allows overriding project endpoint through --endpoint", () => {
+    expect(
+      lookupEndpoint({
+        flags: {
+          endpoint: "my-endpoint-3",
+        },
+        rootConfig: {
+          default: "my-endpoint",
+          "my-endpoint": {
+            secret: "fn1234",
+            url: "http://localhost:8443",
+          },
+          "my-endpoint-2": {
+            secret: "fn555",
+          },
+          "my-endpoint-3": {
+            secret: "fn888",
+            url: "http://localhost:10443",
+          },
+        },
+        projectConfig: {
+          default: "my-app",
+          stack: {
+            "my-app": {
+              endpoint: "my-endpoint-2",
+              database: "foo",
+            },
+          },
+        },
+      })
+    ).to.deep.contain({
+      secret: "fn888:foo:admin",
+      url: "http://localhost:10443",
+    });
+  });
+
+  it("allows overriding stack through --stack", () => {
+    expect(
+      lookupEndpoint({
+        flags: {
+          stack: "my-app-3",
+        },
+        rootConfig: {
+          default: "my-endpoint",
+          "my-endpoint": {
+            secret: "fn1234",
+            url: "http://localhost:8443",
+          },
+          "my-endpoint-2": {
+            secret: "fn555",
+          },
+          "my-endpoint-3": {
+            secret: "fn888",
+            url: "http://localhost:10443",
+          },
+        },
+        projectConfig: {
+          default: "my-app",
+          stack: {
+            "my-app": {
+              endpoint: "my-endpoint-2",
+              database: "foo",
+            },
+            "my-app-3": {
+              endpoint: "my-endpoint-3",
+              database: "bar",
+            },
+          },
+        },
+      })
+    ).to.deep.contain({
+      secret: "fn888:bar:admin",
+      url: "http://localhost:10443",
+    });
+  });
+
+  it("allows overriding endpoint and database through flags", () => {
+    expect(
+      lookupEndpoint({
+        flags: {
+          stack: "my-app-3",
+          endpoint: "my-endpoint-4",
+        },
+        rootConfig: {
+          default: "my-endpoint",
+          "my-endpoint": {
+            secret: "fn1234",
+            url: "http://localhost:8443",
+          },
+          "my-endpoint-2": {
+            secret: "fn555",
+          },
+          "my-endpoint-3": {
+            secret: "fn888",
+            url: "http://localhost:10443",
+          },
+          "my-endpoint-4": {
+            secret: "fn999",
+            url: "http://somewhere-else:10443",
+          },
+        },
+        projectConfig: {
+          default: "my-app",
+          stack: {
+            "my-app": {
+              endpoint: "my-endpoint-2",
+              database: "somethin",
+            },
+            "my-app-3": {
+              endpoint: "my-endpoint-3",
+              database: "my-db-3",
+            },
+          },
+        },
+      })
+    ).to.deep.contain({
+      secret: "fn999:my-db-3:admin",
+      url: "http://somewhere-else:10443",
+    });
+  });
+});

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -18,7 +18,7 @@ describe("root config", () => {
         },
       })
     ).to.deep.contain({
-      secret: "fn1234:admin",
+      secret: "fn1234",
       url: "http://localhost:8443",
     });
   });
@@ -34,7 +34,7 @@ describe("root config", () => {
         },
       })
     ).to.deep.contain({
-      secret: "fn1234:admin",
+      secret: "fn1234",
       url: "https://db.fauna.com",
     });
   });
@@ -53,7 +53,7 @@ describe("root config", () => {
         },
       })
     ).to.deep.contain({
-      secret: "fn1234:admin",
+      secret: "fn1234",
       url: "http://localhost:8443",
     });
   });
@@ -77,7 +77,7 @@ describe("root config with flags", () => {
         },
       })
     ).to.deep.contain({
-      secret: "fn555:admin",
+      secret: "fn555",
       url: "https://db.fauna.com",
     });
   });
@@ -108,7 +108,7 @@ describe("local config", () => {
         },
       })
     ).to.deep.contain({
-      secret: "fn555:foo:admin",
+      secret: "fn555:foo",
       url: "https://db.fauna.com",
     });
   });
@@ -137,7 +137,7 @@ describe("local config", () => {
         },
       })
     ).to.deep.contain({
-      secret: "fn555:my-db:admin",
+      secret: "fn555:my-db",
       url: "https://db.fauna.com",
     });
   });
@@ -175,7 +175,7 @@ describe("local config with flags", () => {
         },
       })
     ).to.deep.contain({
-      secret: "fn888:foo:admin",
+      secret: "fn888:foo",
       url: "http://localhost:10443",
     });
   });
@@ -215,7 +215,7 @@ describe("local config with flags", () => {
         },
       })
     ).to.deep.contain({
-      secret: "fn888:bar:admin",
+      secret: "fn888:bar",
       url: "http://localhost:10443",
     });
   });
@@ -260,7 +260,7 @@ describe("local config with flags", () => {
         },
       })
     ).to.deep.contain({
-      secret: "fn999:my-db-3:admin",
+      secret: "fn999:my-db-3",
       url: "http://somewhere-else:10443",
     });
   });
@@ -279,7 +279,7 @@ describe("local config with flags", () => {
         scope: "my-scope",
       })
     ).to.deep.contain({
-      secret: "fn1234:my-scope:admin",
+      secret: "fn1234:my-scope",
       url: "http://localhost:8443",
     });
   });
@@ -307,7 +307,7 @@ describe("local config with flags", () => {
         scope: "my-scope",
       })
     ).to.deep.contain({
-      secret: "fn1234:my-db/my-scope:admin",
+      secret: "fn1234:my-db/my-scope",
       url: "http://localhost:8443",
     });
   });


### PR DESCRIPTION
Ticket(s): ENG-5276

Reads `.fauna-project` files, and adds a new config system that should allow us to access the config more easily.

One side affect of this PR is that all secrets must be admin secrets. This was not required before, but now it is, for consistency with schema commands (which will always require admin secrets).