### PR TITLE
Discover .fauna-project in parent directories

### DIFF
--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -298,7 +298,7 @@ export const getProjectConfigPath = (): string | undefined => {
     return undefined;
   }
 
-  for (let i = 0; i < 2048; i++) {
+  while (true) {
     const projPath = path.join(current, ".fauna-project");
     let stat;
     stat = fs.statSync(projPath, {
@@ -317,13 +317,7 @@ export const getProjectConfigPath = (): string | undefined => {
     current = currPath.dir;
   }
 
-  // if we got here, it means:
-  // - there was no `.fauna-project` file.
-  // - `path.dirname` never got us to the root.
-  // - the cwd has more than 2048 elements. linux caps the path length at 4096
-  //   bytes, and windows caps it at 260 characters. so that is unlikely to say
-  //   the least.
-  //
-  // in any case, we give up.
+  // if we got here, it means that there was no `.fauna-project` file, so we
+  // give up.
   return undefined;
 };

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -287,7 +287,7 @@ const getRootConfigPath = () => {
   return path.join(os.homedir(), ".fauna-shell");
 };
 
-const getProjectConfigPath = (): string | undefined => {
+export const getProjectConfigPath = (): string | undefined => {
   let current;
   try {
     current = process.cwd();


### PR DESCRIPTION
Ticket(s): ENG-5535

Searches upwards from the current working directory for a `.fauna-project` file.

Things to note about this behavior:
- It will search upwards until it finds the root. So a `.fauna-project` in `/home` is valid, even if `.fauna-shell` is located in `/home/macmv`.
- It will immediately fail silently if fetching the CWD returns an error.
- It will ignore any directories or symlinks to directories named `.fauna-project`.
- It will consider the first file or symlink named `.fauna-project` "the project file." If this file is then unreadable, the shell will print an error and exit.