### PR TITLE
Switch everything in lib/ to a module

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,9 @@
           "@jest/globals"
         ]
       }
-    ]
+    ],
+    // we use typescript so dynamic imports are fine
+    "node/no-unsupported-features": "off"
   },
   "ignorePatterns": ["dist/**/*"],
   "overrides": [

--- a/src/commands/add-endpoint.js
+++ b/src/commands/add-endpoint.js
@@ -1,7 +1,7 @@
 const { cli } = require("cli-ux");
 const { Flags, Args } = require("@oclif/core");
 const { saveEndpointOrError } = require("../lib/misc.js");
-const FaunaCommand = require("../lib/fauna-command.js");
+const FaunaCommand = require("../lib/fauna-command.js").default;
 const url = require("url");
 
 class AddEndpointCommand extends FaunaCommand {

--- a/src/commands/cloud-login.js
+++ b/src/commands/cloud-login.js
@@ -1,4 +1,4 @@
-const FaunaCommand = require("../lib/fauna-command.js");
+const FaunaCommand = require("../lib/fauna-command.js").default;
 const inquirer = require("inquirer");
 const fetch = require("node-fetch");
 const faunadb = require("faunadb");

--- a/src/commands/create-database.js
+++ b/src/commands/create-database.js
@@ -1,4 +1,4 @@
-const FaunaCommand = require("../lib/fauna-command.js");
+const FaunaCommand = require("../lib/fauna-command.js").default;
 const { Args } = require("@oclif/core");
 const faunadb = require("faunadb");
 const q = faunadb.query;

--- a/src/commands/create-key.js
+++ b/src/commands/create-key.js
@@ -1,4 +1,4 @@
-const FaunaCommand = require("../lib/fauna-command.js");
+const FaunaCommand = require("../lib/fauna-command.js").default;
 const { Args } = require("@oclif/core");
 const faunadb = require("faunadb");
 const q = faunadb.query;

--- a/src/commands/default-endpoint.js
+++ b/src/commands/default-endpoint.js
@@ -1,6 +1,6 @@
 const { setDefaultEndpoint } = require("../lib/misc.js");
 const { Args } = require("@oclif/core");
-const FaunaCommand = require("../lib/fauna-command.js");
+const FaunaCommand = require("../lib/fauna-command.js").default;
 
 class DefaultEndpointCommand extends FaunaCommand {
   async run() {

--- a/src/commands/delete-database.js
+++ b/src/commands/delete-database.js
@@ -1,4 +1,4 @@
-const FaunaCommand = require("../lib/fauna-command.js");
+const FaunaCommand = require("../lib/fauna-command.js").default;
 const { Args } = require("@oclif/core");
 const faunadb = require("faunadb");
 const q = faunadb.query;

--- a/src/commands/delete-endpoint.js
+++ b/src/commands/delete-endpoint.js
@@ -1,6 +1,6 @@
 const { deleteEndpointOrError } = require("../lib/misc.js");
 const { Args } = require("@oclif/core");
-const FaunaCommand = require("../lib/fauna-command.js");
+const FaunaCommand = require("../lib/fauna-command.js").default;
 
 class DeleteEndpoint extends FaunaCommand {
   async run() {

--- a/src/commands/delete-key.js
+++ b/src/commands/delete-key.js
@@ -1,4 +1,4 @@
-const FaunaCommand = require("../lib/fauna-command.js");
+const FaunaCommand = require("../lib/fauna-command.js").default;
 const { Args } = require("@oclif/core");
 const faunadb = require("faunadb");
 const q = faunadb.query;

--- a/src/commands/eval.js
+++ b/src/commands/eval.js
@@ -3,7 +3,7 @@ const fs = require("fs");
 const esprima = require("esprima");
 const { Flags, Args } = require("@oclif/core");
 const faunadb = require("faunadb");
-const FaunaCommand = require("../lib/fauna-command.js");
+const FaunaCommand = require("../lib/fauna-command.js").default;
 const { readFile, runQueries, writeFile } = require("../lib/misc.js");
 
 const EVAL_OUTPUT_FORMATS = ["json", "json-tagged", "shell"];

--- a/src/commands/import.js
+++ b/src/commands/import.js
@@ -1,13 +1,13 @@
 const fs = require("fs");
 
 const { Flags } = require("@oclif/core");
-const FaunaCommand = require("../lib/fauna-command.js");
-const StreamJson = require("../lib/json-stream");
+const FaunaCommand = require("../lib/fauna-command.js").default;
+const StreamJson = require("../lib/json-stream").default;
 const faunadb = require("faunadb");
 const { pipeline } = require("stream");
 const p = require("path");
 const q = faunadb.query;
-const getFaunaImportWriter = require("../lib/fauna-import-writer");
+const getFaunaImportWriter = require("../lib/fauna-import-writer").default;
 const { parse } = require("csv-parse");
 const { ImportLimits } = require("../lib/import-limits");
 

--- a/src/commands/list-endpoints.js
+++ b/src/commands/list-endpoints.js
@@ -1,5 +1,5 @@
 const { loadEndpoints } = require("../lib/misc.js");
-const FaunaCommand = require("../lib/fauna-command.js");
+const FaunaCommand = require("../lib/fauna-command.js").default;
 
 class ListEndpointsCommand extends FaunaCommand {
   async run() {

--- a/src/commands/list-keys.js
+++ b/src/commands/list-keys.js
@@ -1,4 +1,4 @@
-const FaunaCommand = require("../lib/fauna-command.js");
+const FaunaCommand = require("../lib/fauna-command.js").default;
 const faunadb = require("faunadb");
 const q = faunadb.query;
 const Table = require("cli-table");

--- a/src/commands/run-queries.js
+++ b/src/commands/run-queries.js
@@ -1,5 +1,5 @@
 const { Flags } = require("@oclif/core");
-const FaunaCommand = require("../lib/fauna-command.js");
+const FaunaCommand = require("../lib/fauna-command.js").default;
 const EvalCommand = require("./eval");
 
 const DEPRECATED_MSG =

--- a/src/commands/schema/diff.js
+++ b/src/commands/schema/diff.js
@@ -1,4 +1,4 @@
-const SchemaCommand = require("../../lib/schema-command.js");
+const SchemaCommand = require("../../lib/schema-command.js").default;
 const fetch = require("node-fetch");
 const { Flags } = require("@oclif/core");
 

--- a/src/commands/schema/pull.js
+++ b/src/commands/schema/pull.js
@@ -1,4 +1,4 @@
-const SchemaCommand = require("../../lib/schema-command.js");
+const SchemaCommand = require("../../lib/schema-command.js").default;
 const fetch = require("node-fetch");
 const fs = require("fs");
 const path = require("path");

--- a/src/commands/schema/push.js
+++ b/src/commands/schema/push.js
@@ -1,4 +1,4 @@
-const SchemaCommand = require("../../lib/schema-command.js");
+const SchemaCommand = require("../../lib/schema-command.js").default;
 const fetch = require("node-fetch");
 const { Flags, ux } = require("@oclif/core");
 

--- a/src/commands/shell.js
+++ b/src/commands/shell.js
@@ -1,4 +1,4 @@
-const FaunaCommand = require("../lib/fauna-command.js");
+const FaunaCommand = require("../lib/fauna-command.js").default;
 const { runQueries, stringifyEndpoint } = require("../lib/misc.js");
 const faunadb = require("faunadb");
 const { Flags, Args } = require("@oclif/core");

--- a/src/commands/upload-graphql-schema.js
+++ b/src/commands/upload-graphql-schema.js
@@ -1,4 +1,4 @@
-const FaunaCommand = require("../lib/fauna-command.js");
+const FaunaCommand = require("../lib/fauna-command.js").default;
 const { Flags, Args } = require("@oclif/core");
 const fetch = require("node-fetch");
 const fs = require("fs");

--- a/src/lib/fauna-client.js
+++ b/src/lib/fauna-client.js
@@ -1,14 +1,13 @@
-const http2 = require("http2");
+import { connect, constants } from "http2";
 
 // Copied from the fauna-js driver:
 // https://github.com/fauna/fauna-js/blob/main/src/http-client/node-http2-client.ts
 
-module.exports = class FaunaClient {
+export default class FaunaClient {
   constructor(endpoint, secret, timeout) {
-    this.session = http2
-      .connect(endpoint, {
-        peerMaxConcurrentStreams: 50,
-      })
+    this.session = connect(endpoint, {
+      peerMaxConcurrentStreams: 50,
+    })
       .once("error", () => this.close())
       .once("goaway", () => this.close());
     this.secret = secret;
@@ -19,8 +18,7 @@ module.exports = class FaunaClient {
     return new Promise((resolvePromise, rejectPromise) => {
       let req;
       const onResponse = (http2ResponseHeaders) => {
-        const status =
-          http2ResponseHeaders[http2.constants.HTTP2_HEADER_STATUS];
+        const status = http2ResponseHeaders[constants.HTTP2_HEADER_STATUS];
         let responseData = "";
 
         req.on("data", (chunk) => {
@@ -41,8 +39,8 @@ module.exports = class FaunaClient {
           Authorization: `Bearer ${this.secret}`,
           "x-format": format,
           "X-Fauna-Source": "Fauna Shell",
-          [http2.constants.HTTP2_HEADER_PATH]: "/query/1",
-          [http2.constants.HTTP2_HEADER_METHOD]: "POST",
+          [constants.HTTP2_HEADER_PATH]: "/query/1",
+          [constants.HTTP2_HEADER_METHOD]: "POST",
           ...(typecheck && { "x-typecheck": typecheck }),
           ...(this.timeout && { "x-query-timeout-ms": this.timeout }),
         };
@@ -70,4 +68,4 @@ module.exports = class FaunaClient {
   async close() {
     this.session.close();
   }
-};
+}

--- a/src/lib/fauna-command.js
+++ b/src/lib/fauna-command.js
@@ -1,11 +1,10 @@
-const { Command, Flags } = require("@oclif/core");
-const { lookupEndpoint } = require("../lib/config/index.ts");
-const { stringifyEndpoint } = require("../lib/misc.js");
-const faunadb = require("faunadb");
-const chalk = require("chalk");
-const q = faunadb.query;
-const FaunaClient = require("./fauna-client.js");
-const fetch = require("node-fetch");
+import { Command, Flags } from "@oclif/core";
+import { lookupEndpoint } from "./config";
+import { stringifyEndpoint } from "./misc";
+import { query as q, errors } from "faunadb";
+import { green } from "chalk";
+import FaunaClient from "./fauna-client.js";
+import fetch from "node-fetch";
 
 /**
  * This is the base class for all fauna-shell commands.
@@ -35,7 +34,7 @@ class FaunaCommand extends Command {
   }
 
   success(msg) {
-    const bang = chalk.green(process.platform === "win32" ? "»" : "›");
+    const bang = green(process.platform === "win32" ? "»" : "›");
     console.info(` ${bang}   Success: ${msg}`);
   }
 
@@ -80,7 +79,7 @@ class FaunaCommand extends Command {
   }
 
   mapConnectionError({ err, connectionOptions }) {
-    if (err instanceof faunadb.errors.Unauthorized) {
+    if (err instanceof errors.Unauthorized) {
       return this.error(
         `Could not Connect to ${stringifyEndpoint(
           connectionOptions
@@ -222,4 +221,4 @@ FaunaCommand.flags = {
   }),
 };
 
-module.exports = FaunaCommand;
+export default FaunaCommand;

--- a/src/lib/fauna-command.js
+++ b/src/lib/fauna-command.js
@@ -1,7 +1,7 @@
 import { Command, Flags } from "@oclif/core";
 import { lookupEndpoint } from "./config";
 import { stringifyEndpoint } from "./misc";
-import { query as q, errors } from "faunadb";
+import { query as q, errors, Client } from "faunadb";
 import { green } from "chalk";
 import FaunaClient from "./fauna-client.js";
 import fetch from "node-fetch";
@@ -57,7 +57,7 @@ class FaunaCommand extends Command {
 
       const { hostname, port, protocol } = new URL(connectionOptions.url);
 
-      const client = new faunadb.Client({
+      const client = new Client({
         domain: hostname,
         port,
         scheme: protocol?.replace(/:$/, ""),
@@ -98,7 +98,7 @@ class FaunaCommand extends Command {
 
         const { hostname, port, protocol } = new URL(connectionOptions.url);
 
-        const client = new faunadb.Client({
+        const client = new Client({
           domain: hostname,
           port,
           scheme: protocol?.replace(/:$/, ""),
@@ -181,9 +181,9 @@ class FaunaCommand extends Command {
   }
 
   dbExists(dbName, callback) {
-    return this.withClient(function (testDbClient, _) {
-      return testDbClient.query(q.Exists(q.Database(dbName))).then(callback);
-    });
+    return this.withClient((testDbClient, _) =>
+      testDbClient.query(q.Exists(q.Database(dbName))).then(callback)
+    );
   }
 }
 

--- a/src/lib/fauna-import-writer.js
+++ b/src/lib/fauna-import-writer.js
@@ -1,14 +1,11 @@
-const q = require("faunadb").query;
-const { FaunaObjectTranslator } = require("./fauna-object-translator");
-const sizeof = require("object-sizeof");
-const { backOff } = require("exponential-backoff");
+import { query as q } from "faunadb";
+import { FaunaObjectTranslator } from "./fauna-object-translator";
+import sizeof from "object-sizeof";
+import { backOff } from "exponential-backoff";
 const FaunaHTTPError = require("faunadb").errors.FaunaHTTPError;
-const {
-  RateLimiterMemory,
-  RateLimiterQueue,
-} = require("rate-limiter-flexible");
-const { ImportPenalty } = require("./import-penalty");
-const { RateEstimator } = require("./import-limits");
+import { RateLimiterMemory, RateLimiterQueue } from "rate-limiter-flexible";
+import { ImportPenalty } from "./import-penalty";
+import { RateEstimator } from "./import-limits";
 
 /**
  * Creates a function that consumes a stream of objects and writes creates each object
@@ -329,4 +326,4 @@ this item and continuing.`
   return streamConsumer;
 }
 
-module.exports = getFaunaImportWriter;
+export default getFaunaImportWriter;

--- a/src/lib/fauna-object-translator.js
+++ b/src/lib/fauna-object-translator.js
@@ -1,10 +1,10 @@
-const q = require("faunadb").query;
-const moment = require("moment");
+import { query as q } from "faunadb";
+import { utc, ISO_8601, RFC_2822, unix } from "moment";
 
 /**
  * An error translating an object with a {FaunaObjectTranslater}.
  */
-class TranslationError extends Error {}
+export class TranslationError extends Error {}
 
 /**
  * Helper class for cleaning objects prior to persistence in Fauna.
@@ -12,7 +12,7 @@ class TranslationError extends Error {}
  *   - trim input strings to remove unneeded whitespace
  *   - cast types as specified by input
  **/
-class FaunaObjectTranslator {
+export class FaunaObjectTranslator {
   static #NUMBER_REGEX = /(^\s*[+|-]?\d+\s*$)|(^\s*[+|-]?\d*\.\d+\s*$)/;
 
   static #TRULY = ["true", "t", "yes", "1", 1, true];
@@ -117,10 +117,10 @@ class FaunaObjectTranslator {
         )}' to a date.`
       );
     }
-    let theDate = moment.utc(val, moment.ISO_8601);
+    let theDate = utc(val, ISO_8601);
     if (!theDate.isValid()) {
       // fallback to other date formats
-      theDate = moment.utc(val, moment.RFC_2822);
+      theDate = utc(val, RFC_2822);
       if (!theDate.isValid()) {
         theDate = new Date(val);
         if (Number.isNaN(theDate.getTime())) {
@@ -139,8 +139,7 @@ Making a best-effort translation to '${theDate}'`);
   #epochMillisDate(val) {
     try {
       return q.Time(
-        moment
-          .unix(this.#getNumber(val) / 1000)
+        unix(this.#getNumber(val) / 1000)
           .utc()
           .toISOString()
       );
@@ -155,7 +154,7 @@ Making a best-effort translation to '${theDate}'`);
 
   #epochSecondsDate(val) {
     try {
-      return q.Time(moment.unix(this.#getNumber(val)).utc().toISOString());
+      return q.Time(unix(this.#getNumber(val)).utc().toISOString());
     } catch (e) {
       throw new TranslationError(
         `Cannot convert '${FaunaObjectTranslator.#getErrorValue(
@@ -189,6 +188,3 @@ Making a best-effort translation to '${theDate}'`);
     }, obj);
   }
 }
-
-exports.FaunaObjectTranslator = FaunaObjectTranslator;
-exports.TranslationError = TranslationError;

--- a/src/lib/import-limits.js
+++ b/src/lib/import-limits.js
@@ -1,6 +1,6 @@
 // these functions are present to make testing the import function easy.
 
-class ImportLimits {
+export class ImportLimits {
   /**
    * @return the maximum import size limit in MB
    **/
@@ -9,7 +9,7 @@ class ImportLimits {
   }
 }
 
-class RateEstimator {
+export class RateEstimator {
   static estimateWriteOpsAsBytes(totalBytes, numberOfIndexes) {
     if (totalBytes < 0) {
       throw new Error("Invalid argument totalBytes must be >= 0");
@@ -40,6 +40,3 @@ class RateEstimator {
     return Math.ceil(actualWriteOps / estimatedWriteOpsNoIndex) - 1;
   }
 }
-
-module.exports.ImportLimits = ImportLimits;
-module.exports.RateEstimator = RateEstimator;

--- a/src/lib/import-penalty.js
+++ b/src/lib/import-penalty.js
@@ -1,4 +1,4 @@
-class ImportPenalty {
+export class ImportPenalty {
   constructor(floor, ceiling) {
     this.floor = floor;
     this.ceiling = ceiling;
@@ -17,5 +17,3 @@ class ImportPenalty {
     return next;
   }
 }
-
-exports.ImportPenalty = ImportPenalty;

--- a/src/lib/json-stream.js
+++ b/src/lib/json-stream.js
@@ -1,6 +1,6 @@
 "use strict";
-const StreamBase = require("stream-json/streamers/StreamBase");
-const withParser = require("stream-json/utils/withParser");
+import StreamBase from "stream-json/streamers/StreamBase";
+import withParser from "stream-json/utils/withParser";
 
 class StreamJson extends StreamBase {
   static make(options) {
@@ -66,4 +66,4 @@ class StreamJson extends StreamBase {
 StreamJson.StreamJson = StreamJson.make;
 StreamJson.make.Constructor = StreamJson;
 
-module.exports = StreamJson;
+export default StreamJson;

--- a/src/lib/schema-command.js
+++ b/src/lib/schema-command.js
@@ -1,7 +1,7 @@
-const FaunaCommand = require("./fauna-command.js");
-const fs = require("fs");
-const path = require("path");
-const FormData = require("form-data");
+import FaunaCommand from "./fauna-command";
+import { readFileSync, readdirSync, statSync } from "fs";
+import { join } from "path";
+import FormData from "form-data";
 
 class SchemaCommand extends FaunaCommand {
   static flags = (() => {
@@ -39,8 +39,8 @@ class SchemaCommand extends FaunaCommand {
     const curr = [];
     var totalsize = 0;
     for (const relp of relpaths) {
-      const fp = path.join(basedir, relp);
-      const content = fs.readFileSync(fp);
+      const fp = join(basedir, relp);
+      const content = readFileSync(fp);
       totalsize += content.length;
       if (totalsize > FILESIZE_LIMIT_BYTES) {
         this.error(
@@ -58,12 +58,12 @@ class SchemaCommand extends FaunaCommand {
   gather(basedir) {
     const FILE_LIMIT = 256;
     const go = (rel, curr) => {
-      const names = fs.readdirSync(path.join(basedir, rel));
+      const names = readdirSync(join(basedir, rel));
       const subdirs = [];
       for (const n of names) {
-        const fp = path.join(basedir, rel, n);
-        const relp = path.join(rel, n);
-        const isDir = fs.statSync(fp).isDirectory();
+        const fp = join(basedir, rel, n);
+        const relp = join(rel, n);
+        const isDir = statSync(fp).isDirectory();
         if (n.endsWith(".fsl") && !isDir) {
           curr.push(relp);
         }
@@ -84,4 +84,4 @@ class SchemaCommand extends FaunaCommand {
   }
 }
 
-module.exports = SchemaCommand;
+export default SchemaCommand;

--- a/test/lib/fauna-import-writer.test.js
+++ b/test/lib/fauna-import-writer.test.js
@@ -1,5 +1,5 @@
 const expect = require("expect");
-const getFaunaImportWriter = require("../../src/lib/fauna-import-writer");
+const getFaunaImportWriter = require("../../src/lib/fauna-import-writer").default;
 const jestMock = require("jest-mock");
 const sizeof = require("object-sizeof");
 const { UnavailableError, FaunaHTTPError } = require("faunadb").errors;

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -3,7 +3,5 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "references": [
-    { "path": ".." }
-  ]
+  "references": [{ "path": ".." }]
 }


### PR DESCRIPTION
Ticket(s): ENG-5539

Because I added `config.ts`, we can't actually `require` it correctly. In dev, it needs to be `require("config.ts")`, whereas once its compiled, it needs to be `require("config.js")` (note the file extension changed). Using proper `import` statements lets us remove the file extension, which fixes the problem. Imports are only availible to modules though, so I went ahead and converted everything in `lib` to be a module. This also gives us the much clearer `export` keyword, instead of needing to use `module.exports`.
