### PR TITLE
Pass role and scope in to lookupEndpoint instead of ShellConfig

### DIFF
--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -7,8 +7,13 @@ import {
 } from "../../src/lib/config";
 import sinon from "sinon";
 
-const lookupEndpoint = (opts: ShellOpts) => {
-  return new ShellConfig(opts).lookupEndpoint();
+const lookupEndpoint = (
+  opts: ShellOpts & { role?: string; scope?: string }
+) => {
+  return new ShellConfig(opts).lookupEndpoint({
+    role: opts.role,
+    scope: opts.scope,
+  });
 };
 
 describe("root config", () => {


### PR DESCRIPTION
Ticket(s): FE-###

Removes the `scope` and `role` args, so that we can create a `ShellConfig` directly in the constructor of `FaunaCommand`.
