### PR TITLE
Store a ShellConfig in FaunaCommand

### DIFF
--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -99,30 +99,6 @@ export class Config {
   }
 }
 
-/**
- * Builds the options provided to the faunajs client.
- * Tries to load the ~/.fauna-shell file and read the default endpoint from there.
- *
- * Assumes that if the file exists, it would have been created by fauna-shell,
- * therefore it would have a defined endpoint.
- *
- * Flags like --host, --port, etc., provided by the CLI take precedence over what's
- * stored in ~/.fauna-shell.
- *
- * The --endpoint flag overries the default endpoint from fauna-shell.
- *
- * If ~/.fauna-shell doesn't exist, tries to build the connection options from the
- * flags passed to the script.
- *
- * It always expect a secret key to be set in ~/.fauna-shell or provided via CLI
- * arguments.
- *
- * TODO: Remove and store a ShellConfig in `fauna-command`
- */
-export const lookupEndpoint = (flags: any, scope: string, role: string) => {
-  return ShellConfig.read(flags).lookupEndpoint({ scope, role });
-};
-
 export type ShellOpts = {
   flags?: { [key: string]: any };
   rootConfig?: { [key: string]: any };

--- a/src/lib/fauna-command.js
+++ b/src/lib/fauna-command.js
@@ -1,5 +1,5 @@
 import { Command, Flags } from "@oclif/core";
-import { lookupEndpoint } from "./config";
+import { ShellConfig } from "./config";
 import { stringifyEndpoint } from "./misc";
 import { query as q, errors, Client } from "faunadb";
 import { green } from "chalk";
@@ -31,6 +31,7 @@ class FaunaCommand extends Command {
     const { flags: f, args: a } = await this.parse(this.constructor);
     this.flags = f;
     this.args = a;
+    this.shellConfig = ShellConfig.read(this.flags);
   }
 
   success(msg) {
@@ -53,7 +54,7 @@ class FaunaCommand extends Command {
   async withClient(f, dbScope, role) {
     let connectionOptions;
     try {
-      connectionOptions = lookupEndpoint(this.flags, dbScope, role);
+      connectionOptions = this.shellConfig.lookupEndpoint({ scope: dbScope, role });
 
       const { hostname, port, protocol } = new URL(connectionOptions.url);
 
@@ -94,7 +95,7 @@ class FaunaCommand extends Command {
       // construct v4 client
       let connectionOptions;
       try {
-        connectionOptions = lookupEndpoint(this.flags, dbScope, role);
+        connectionOptions = this.shellConfig.lookupEndpoint({ scope: dbScope, role });
 
         const { hostname, port, protocol } = new URL(connectionOptions.url);
 
@@ -129,7 +130,7 @@ class FaunaCommand extends Command {
       // construct v10 client
       let connectionOptions;
       try {
-        connectionOptions = lookupEndpoint(this.flags, dbScope, role);
+        connectionOptions = this.shellConfig.lookupEndpoint({ scope: dbScope, role });
         const client = new FaunaClient(
           connectionOptions.url,
           connectionOptions.secret,


### PR DESCRIPTION
Ticket(s): FE-###

Stores a `ShellConfig` in `FaunaCommand`, which will let us use the config in all the commands that need it.
