### PR TITLE
Add `fauna stack add`

### DIFF
--- a/src/commands/eval.js
+++ b/src/commands/eval.js
@@ -174,7 +174,10 @@ class EvalCommand extends FaunaCommand {
         format = "simple";
       }
 
-      const res = await client.query(fqlQuery, format, flags.typecheck);
+      const res = await client.query(fqlQuery, {
+        format,
+        typecheck: flags.typecheck,
+      });
 
       return await this.writeFormattedOutputV10(outputFile, res, flags.format);
     } catch (error) {

--- a/src/commands/stack/add.ts
+++ b/src/commands/stack/add.ts
@@ -1,0 +1,185 @@
+import { Command, Flags, ux } from "@oclif/core";
+import { input, confirm } from "@inquirer/prompts";
+import { Endpoint, ShellConfig } from "../../lib/config";
+import FaunaClient from "../../lib/fauna-client";
+import { searchSelect } from "../../lib/search-select";
+
+export default class AddStackCommand extends Command {
+  static flags = {
+    name: Flags.string({
+      description: "New stack name",
+    }),
+    endpoint: Flags.string({
+      description: "Endpoint to use in this stack",
+    }),
+    database: Flags.string({
+      description: "Database path to use in this stack",
+    }),
+    "non-interactive": Flags.boolean({
+      description: "Disables interaction",
+      dependsOn: ["name", "endpoint", "database"],
+    }),
+    "set-default": Flags.boolean({
+      description: "Sets this stack as the default",
+    }),
+  };
+
+  static description = "Adds a new stack to the `.fauna-project`.";
+
+  static examples = [
+    "$ fauna stack add",
+    "$ fauna stack add --name my-app --endpoint dev --database my-database",
+    "$ fauna stack add --name my-app --endpoint dev --database my-database --set-default",
+  ];
+
+  async run() {
+    const config = ShellConfig.read({});
+
+    await this.execute(config);
+  }
+
+  async execute(config: ShellConfig) {
+    const { flags } = await this.parse();
+
+    if (config.projectConfig === undefined) {
+      this.error(
+        "No `.fauna-project` found. Create one with `fauna project init`."
+      );
+    }
+
+    const endpointName =
+      flags.endpoint ??
+      (await searchSelect({
+        message: "Select an endpoint",
+        choices: Object.keys(config.rootConfig.endpoints).map((endpoint) => ({
+          value: endpoint,
+        })),
+      }));
+    if (!Object.keys(config.rootConfig.endpoints).includes(endpointName)) {
+      this.error(`No such endpoint '${endpointName}'`);
+    }
+
+    let databaseName: string =
+      flags.database ??
+      (await this.promptDatabasePath(
+        config.rootConfig.endpoints[endpointName]
+      ));
+
+    const validateStackName = (input: string) => {
+      if (input.length === 0) {
+        return "Stack name cannot be empty";
+      } else if (
+        Object.keys(config.projectConfig?.stacks ?? {}).includes(input)
+      ) {
+        return `Stack ${input} already exists`;
+      } else {
+        return true;
+      }
+    };
+
+    const name =
+      flags.name ??
+      (await input({
+        message: "Stack name",
+        validate: validateStackName,
+      }));
+    const res = validateStackName(name);
+    if (res !== true) {
+      this.error(res);
+    }
+
+    const setDefault =
+      flags["set-default"] ??
+      (flags["non-interactive"]
+        ? false
+        : await confirm({
+            message: "Make this stack default",
+          }));
+
+    if (setDefault) {
+      config.projectConfig.defaultStack = name;
+    }
+
+    config.projectConfig.stacks[name] = {
+      endpoint: endpointName,
+      database: databaseName,
+    };
+    config.saveProjectConfig();
+    console.log(`Saved stack ${name} to ${config.projectConfigFile()}`);
+  }
+
+  promptDatabasePath = async (endpoint: Endpoint): Promise<string> => {
+    const { url, secret } = endpoint;
+    const client = new FaunaClient({ endpoint: url, secret });
+
+    const res = await client.query("0");
+    if (res.status != 200) {
+      this.error(`Error: ${res.body.error.code}`);
+    }
+
+    const databasePaths = await this.getDatabasePaths(client);
+
+    client.close();
+
+    return await searchSelect({
+      message: "Select a database",
+      choices: databasePaths.map((database) => ({
+        value: database,
+      })),
+    });
+  };
+
+  getDatabasePaths = async (client: FaunaClient): Promise<string[]> => {
+    // Limits: choose a limit of 100 databases at each depth, and a depth of 10.
+    // We will also add a limit if any databases are skiped.
+    const database_limit = 100;
+    const depth_limit = 10;
+
+    const allDatabases: string[] = [];
+    const paths: string[][] = [[]];
+
+    let overflowedLimit = false;
+    let overflowedDepth = false;
+
+    ux.action.start("Fetching databases");
+
+    while (true) {
+      const path = paths.pop();
+      if (path === undefined) {
+        break;
+      }
+      if (path.length > depth_limit) {
+        overflowedDepth = true;
+        continue;
+      }
+
+      const databases = await client.query<string[]>(
+        `Database.all().take(${database_limit + 1}).toArray().map(.name)`,
+        {
+          secret: `${client.secret}:${path.join("/")}:admin`,
+        }
+      );
+      if (databases.status !== 200) {
+        this.error(`Error: ${databases.body.error.code}`);
+      }
+
+      if (databases.body.data.length > database_limit) {
+        overflowedLimit = true;
+      }
+
+      const nested_paths = databases.body.data.map((database) => [
+        ...path,
+        database,
+      ]);
+
+      paths.push(...nested_paths);
+      allDatabases.push(...nested_paths.map((path) => path.join("/")));
+    }
+
+    allDatabases.sort();
+
+    ux.action.stop();
+
+    return allDatabases;
+  };
+}

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -252,6 +252,19 @@ export class ShellConfig {
 
     return this.endpoint!.makeScopedEndpoint(database, opts.role);
   };
+
+  /**
+   * Saves the project config, if present.
+   */
+  saveProjectConfig() {
+    this.projectConfig?.save(this.projectConfigFile()!);
+  }
+
+  projectConfigFile(): string | undefined {
+    return this.projectPath === undefined
+      ? undefined
+      : path.join(this.projectPath, ".fauna-project");
+  }
 }
 
 const readFileOpt = (fileName: string) => {

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -279,7 +279,7 @@ const readFile = (fileName: string) => {
   return fs.readFileSync(fileName, "utf8");
 };
 
-const getRootConfigPath = () => {
+export const getRootConfigPath = () => {
   return path.join(os.homedir(), ".fauna-shell");
 };
 

--- a/src/lib/config/project-config.ts
+++ b/src/lib/config/project-config.ts
@@ -1,3 +1,6 @@
+const ini = require("ini");
+
+import * as fs from "fs";
 import { RootConfig, Config, InvalidConfigError } from ".";
 
 // Represents `.fauna-project`
@@ -26,6 +29,16 @@ export class ProjectConfig {
         );
       }
     }
+  }
+
+  save(path: string) {
+    const config = {
+      default: this.defaultStack,
+      stack: this.stacks,
+    };
+
+    const encoded = ini.encode(config);
+    fs.writeFileSync(path, encoded);
   }
 }
 

--- a/src/lib/fauna-command.js
+++ b/src/lib/fauna-command.js
@@ -3,7 +3,7 @@ import { ShellConfig } from "./config";
 import { stringifyEndpoint } from "./misc";
 import { query as q, errors, Client } from "faunadb";
 import { green } from "chalk";
-import FaunaClient from "./fauna-client.js";
+import FaunaClient from "./fauna-client";
 import fetch from "node-fetch";
 
 /**
@@ -140,11 +140,11 @@ class FaunaCommand extends Command {
           scope: dbScope,
           role,
         });
-        const client = new FaunaClient(
-          connectionOptions.url,
-          connectionOptions.secret,
-          this.flags.timeout ? parseInt(this.flags.timeout, 10) : undefined
-        );
+        const client = new FaunaClient({
+          endpoint: connectionOptions.url,
+          secret: connectionOptions.secret,
+          time: this.flags.timeout ? parseInt(this.flags.timeout, 10) : undefined
+        });
 
         // validate the client settings
         await client.query("0");


### PR DESCRIPTION
Ticket(s): ENG-5533

Adds `fauna stack add`.

This takes a few arguments:
- `--name`: name of the new stack (optional)
- `--endpoint`: endpoint of the new stack (optional)
- `--database`: database of the new stack (optional)
- `--set-default`: sets the new stack as the default. (optional)
- `--non-interactive`: disables interaction, and makes `--name`, `--endpoint`, and `--database` required. (optional, defaults to false)

This commands asks you to select an endpoint, then select a database path, then choose a name for the stack. Finally, it asks you if you want to make the new stack the default. Each of these 4 questions will be skipped if a command line argument is given.

The first question, asking for an endpoint, will let you search and select an endpoint from `~/.fauna-shell`.

The second question, asking for a database path, will give you a sorted list of all database paths in that endpoint. This could be quite expensive, and you might want to set the database path to a database that doesn't exist yet. So this part needs a bit of work and thought for the expected behavior.

No questions will be asked if `--non-interactive` is given, and the `--name`, `--endpoint`, and `--database` flags will be required.
