### PR TITLE
Add fauna stack list

### DIFF
--- a/src/commands/stack/list.ts
+++ b/src/commands/stack/list.ts
@@ -1,0 +1,34 @@
+import { Command } from "@oclif/core";
+import { ShellConfig } from "../../lib/config";
+import chalk from "chalk";
+
+export default class ListStackCommand extends Command {
+  static flags = {};
+
+  static description = "Lists stacks availible in `.fauna-project`.";
+
+  static examples = ["$ fauna stack list"];
+
+  async run() {
+    const config = ShellConfig.read({});
+
+    await this.execute(config);
+  }
+
+  async execute(config: ShellConfig) {
+    await this.parse();
+
+    if (config.projectConfig === undefined) {
+      this.error("No project config found");
+    }
+
+    this.log("Available stacks:");
+    for (const key of Object.keys(config.projectConfig.stacks)) {
+      if (config.projectConfig.defaultStack === key) {
+        this.log(chalk.green("* ") + key);
+      } else {
+        this.log("  " + key);
+      }
+    }
+  }
+}

--- a/test/commands/stack.test.ts
+++ b/test/commands/stack.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@oclif/test";
 import { ShellConfig } from "../../src/lib/config";
 import sinon, { SinonStub } from "sinon";
 import AddStackCommand from "../../src/commands/stack/add";
+import ListStackCommand from "../../src/commands/stack/list";
 import { Config } from "@oclif/core";
 
 const rootConfig = {
@@ -204,6 +205,39 @@ describe("stack:add", () => {
           },
         },
       });
+      expect(ctx.config.saveProjectConfig.called).to.be.false;
+    });
+});
+
+describe("stack:list", () => {
+  test
+    .add("config", () =>
+      stubbedProjectConfig({
+        default: "my-app",
+        stack: {
+          foobar: {
+            endpoint: "my-endpoint",
+            database: "my-db",
+          },
+          "my-app": {
+            endpoint: "my-endpoint",
+            database: "my-db",
+          },
+          baz: {
+            endpoint: "my-endpoint",
+            database: "my-db",
+          },
+        },
+      })
+    )
+    .stdout()
+    .do((ctx) =>
+      new ListStackCommand([], new Config({} as any)).execute(ctx.config)
+    )
+    .it("lists stack", (ctx) => {
+      expect(ctx.stdout).to.equal(
+        "Available stacks:\n  foobar\n* my-app\n  baz\n"
+      );
       expect(ctx.config.saveProjectConfig.called).to.be.false;
     });
 });


### PR DESCRIPTION
Ticket(s): ENG-5566

Adds `fauna stack list`. It takes no arguments, and just lists the stacks in `.fauna-project`. It fails if there is no `.fauna-project`.
