### PR TITLE
Remove graphql flags from all the commands that don't need it

### DIFF
--- a/src/commands/upload-graphql-schema.js
+++ b/src/commands/upload-graphql-schema.js
@@ -7,6 +7,35 @@ const path = require("path");
 class UploadGraphQLSchemaCommand extends FaunaCommand {
   allowedExt = [".graphql", ".gql"];
 
+  static description = "Upload GraphQL schema";
+
+  static examples = [
+    "$ fauna upload-graphql-schema ./schema.gql",
+    "$ fauna upload-graphql-schema ./schema.gql --mode override",
+  ];
+
+  static args = {
+    graphqlFilePath: Args.string({
+      required: true,
+      description: "Path to GraphQL schema",
+    }),
+  };
+
+  static flags = {
+    ...FaunaCommand.flags,
+    graphqlHost: Flags.string({
+      description: "The Fauna GraphQL API host",
+    }),
+    graphqlPort: Flags.string({
+      description: "GraphQL port",
+    }),
+    mode: Flags.string({
+      description: "Upload mode",
+      default: "merge",
+      options: ["merge", "override", "replace"],
+    }),
+  };
+
   async run() {
     try {
       const { graphqlFilePath } = this.args;
@@ -40,26 +69,4 @@ class UploadGraphQLSchemaCommand extends FaunaCommand {
   }
 }
 
-UploadGraphQLSchemaCommand.description = "Upload GraphQL schema";
-
-UploadGraphQLSchemaCommand.examples = [
-  "$ fauna upload-graphql-schema ./schema.gql",
-  "$ fauna upload-graphql-schema ./schema.gql --mode override",
-];
-
-UploadGraphQLSchemaCommand.args = {
-  graphqlFilePath: Args.string({
-    required: true,
-    description: "Path to GraphQL schema",
-  }),
-};
-
-UploadGraphQLSchemaCommand.flags = {
-  ...FaunaCommand.flags,
-  mode: Flags.string({
-    description: "Upload mode",
-    default: "merge",
-    options: ["merge", "override", "replace"],
-  }),
-};
 module.exports = UploadGraphQLSchemaCommand;

--- a/src/lib/fauna-command.js
+++ b/src/lib/fauna-command.js
@@ -223,12 +223,6 @@ FaunaCommand.flags = {
   endpoint: Flags.string({
     description: "Fauna server endpoint",
   }),
-  graphqlHost: Flags.string({
-    description: "The Fauna GraphQL API host",
-  }),
-  graphqlPort: Flags.string({
-    description: "GraphQL port",
-  }),
 };
 
 export default FaunaCommand;


### PR DESCRIPTION
Ticket(s): ENG-5528

Removes `--graphqlHost` and `--graphqlPort` from all the commands that don't use it.
