### PR TITLE
Add --endpointURL flag

### DIFF
--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -159,7 +159,7 @@ export class ShellConfig {
 
     this.projectConfig?.validate(this.rootConfig);
 
-    const urlFlag = Endpoint.getURLFromConfig(this.flags);
+    const urlFlag = Endpoint.getURLFromFlags(this.flags);
     if (urlFlag !== undefined) {
       try {
         new URL(urlFlag);

--- a/src/lib/config/root-config.ts
+++ b/src/lib/config/root-config.ts
@@ -88,21 +88,41 @@ export class Endpoint {
   }
 
   static getURLFromConfig = (config: Config): string | undefined => {
-    const url = config.strOpt("url");
-    const scheme = config.strOpt("scheme");
-    const domain = config.strOpt("domain");
-    const port = config.numberOpt("port");
+    return this.getURLInner({
+      url: config.strOpt("url"),
+      scheme: config.strOpt("scheme"),
+      domain: config.strOpt("domain"),
+      port: config.numberOpt("port"),
+    });
+  };
 
+  static getURLFromFlags = (flags: Config): string | undefined => {
+    return this.getURLInner({
+      url: flags.strOpt("endpointURL"),
+      scheme: flags.strOpt("scheme"),
+      domain: flags.strOpt("domain"),
+      port: flags.numberOpt("port"),
+    });
+  };
+
+  static getURLInner = (opts: {
+    url?: string;
+    scheme?: string;
+    domain?: string;
+    port?: number;
+  }): string | undefined => {
     if (
-      url === undefined &&
-      (domain !== undefined || port !== undefined || scheme !== undefined)
+      opts.url === undefined &&
+      (opts.domain !== undefined ||
+        opts.port !== undefined ||
+        opts.scheme !== undefined)
     ) {
-      const scheme0 = scheme ?? "https";
-      const domain0 = domain ?? "db.fauna.com";
-      const port0 = port ? `:${port}` : "";
-      return `${scheme0}://${domain0}${port0}`;
+      const scheme = opts.scheme ?? "https";
+      const domain = opts.domain ?? "db.fauna.com";
+      const port = opts.port ? `:${opts.port}` : "";
+      return `${scheme}://${domain}${port}`;
     } else {
-      return url;
+      return opts.url;
     }
   };
 }

--- a/src/lib/config/root-config.ts
+++ b/src/lib/config/root-config.ts
@@ -87,8 +87,11 @@ export class Endpoint {
     };
   }
 
+  /**
+   * Gets a database URL from config.
+   */
   static getURLFromConfig = (config: Config): string | undefined => {
-    return this.getURLInner({
+    return this.getURL({
       url: config.strOpt("url"),
       scheme: config.strOpt("scheme"),
       domain: config.strOpt("domain"),
@@ -96,8 +99,14 @@ export class Endpoint {
     });
   };
 
+  /**
+   * Gets a database URL from command line flags.
+   *
+   * Note: this is similar to `getURLFromConfig`, but looks up `endpointURL`
+   * instead of `url` for the url value.
+   */
   static getURLFromFlags = (flags: Config): string | undefined => {
-    return this.getURLInner({
+    return this.getURL({
       url: flags.strOpt("endpointURL"),
       scheme: flags.strOpt("scheme"),
       domain: flags.strOpt("domain"),
@@ -105,7 +114,7 @@ export class Endpoint {
     });
   };
 
-  static getURLInner = (opts: {
+  static getURL = (opts: {
     url?: string;
     scheme?: string;
     domain?: string;

--- a/src/lib/fauna-command.js
+++ b/src/lib/fauna-command.js
@@ -206,22 +206,33 @@ FaunaCommand.flags = {
   ...Command.flags,
   domain: Flags.string({
     description: "Fauna server domain",
+    // Emits a warning if this flag is used.
+    deprecated: { to: "endpointURL" },
+    // Hides the flag in `--help`
+    hidden: true,
   }),
   scheme: Flags.string({
     description: "Connection scheme",
     options: ["https", "http"],
+    deprecated: { to: "endpointURL" },
+    hidden: true,
   }),
   port: Flags.string({
     description: "Connection port",
+    deprecated: { to: "endpointURL" },
+    hidden: true,
+  }),
+  endpointURL: Flags.string({
+    description: "Database URL. Overrides the `url` in ~/.fauna-shell",
   }),
   timeout: Flags.string({
     description: "Connection timeout in milliseconds",
   }),
   secret: Flags.string({
-    description: "Fauna secret key",
+    description: "Secret key. Overrides the `secret` in ~/.fauna-shell",
   }),
   endpoint: Flags.string({
-    description: "Fauna server endpoint",
+    description: "Connection endpoint, from ~/.fauna-shell",
   }),
   graphqlHost: Flags.string({
     description: "The Fauna GraphQL API host",

--- a/test/commands/eval.test.js
+++ b/test/commands/eval.test.js
@@ -1,5 +1,5 @@
 const { expect, test } = require("@oclif/test");
-const { withOpts, getEndpoint, matchFqlReq } = require("../helpers/utils.js");
+const { withOpts, getEndpoint, matchFqlReq, withLegacyOpts } = require("../helpers/utils.js");
 const { query: q } = require("faunadb");
 
 describe("eval", () => {
@@ -17,6 +17,23 @@ describe("eval", () => {
       ])
     )
     .it("runs eval on root db", (ctx) => {
+      expect(JSON.parse(ctx.stdout).data[0].targetDb).to.equal("root");
+    });
+
+  test
+    .nock(getEndpoint(), { allowUnmocked: true }, mockQuery)
+    .stdout()
+    .command(
+      withLegacyOpts([
+        "eval",
+        "--version",
+        "4",
+        "--format",
+        "json",
+        "Paginate(Collections())",
+      ])
+    )
+    .it("works with legacy --domain, --schema, and --port opts", (ctx) => {
       expect(JSON.parse(ctx.stdout).data[0].targetDb).to.equal("root");
     });
 

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -2,7 +2,10 @@ const url = require("url");
 const { query: q } = require("faunadb");
 const env = process.env;
 
-module.exports.withOpts = (cmd) => {
+/**
+ * Sets --domain, --secret, --scheme, and --port.
+ */
+module.exports.withLegacyOpts = (cmd) => {
   const opts = [
     "--secret",
     env.FAUNA_SECRET,
@@ -12,6 +15,19 @@ module.exports.withOpts = (cmd) => {
     env.FAUNA_SCHEME,
     "--port",
     env.FAUNA_PORT,
+  ];
+  return cmd.concat(opts);
+};
+
+/**
+ * Sets --secret and --endpointURL
+ */
+module.exports.withOpts = (cmd) => {
+  const opts = [
+    "--secret",
+    env.FAUNA_SECRET,
+    "--endpointURL",
+    `${env.FAUNA_SCHEME}://${env.FAUNA_DOMAIN}:${env.FAUNA_PORT}`,
   ];
   return cmd.concat(opts);
 };


### PR DESCRIPTION
ENG-5530

Adds `--endpointURL`, and deprecates the old flags. I also chose to hide the old flags, as we really don't want new users to use them. So the old flags don't show up in `--help`, but they still exist and work as expected. Using the old flags will emit a warning though.
