### PR TITLE
Error if there are no child DBs

### DIFF
--- a/src/lib/stack-factory.ts
+++ b/src/lib/stack-factory.ts
@@ -115,6 +115,8 @@ export class StackFactory {
       });
       await client.close();
       return res;
+    } else if (databasePaths.length === 0) {
+      this.cmd.error("No databases found in the given endpoint");
     } else {
       await client.close();
       return searchSelect({

--- a/src/lib/stack-factory.ts
+++ b/src/lib/stack-factory.ts
@@ -97,7 +97,7 @@ export class StackFactory {
 
     const res = await client.query("0");
     if (res.status !== 200) {
-      this.cmd.error(`Error: ${res.body.error.code}`);
+      this.cmd.error(`${res.body.error.code}`);
     }
 
     const databasePaths = await this.getDatabasePaths(client);


### PR DESCRIPTION
Ticket(s): ENG-5572

Emits an error if there are no databases, and fixes an error.

`--database` doesn't validate the database name at all, so you can get around the error by doing that if you want.
