### PR TITLE
Add warning when creating a project in a nested directory

### DIFF
--- a/src/commands/project/init.ts
+++ b/src/commands/project/init.ts
@@ -39,7 +39,6 @@ export class ProjectInitCommand extends Command {
       this.error(`Project already exists at ${projectPath}`);
     }
     this.log(`Creating project at ${projectPath}`);
-    // todo: show a warning if there is a .fauna-project in an ancestor anywhere up the line
 
     const existingProject = getProjectConfigPath(projectPath);
     if (existingProject !== undefined) {

--- a/src/commands/project/init.ts
+++ b/src/commands/project/init.ts
@@ -1,6 +1,7 @@
 import { Args, Command } from "@oclif/core";
 import {
   fileExists,
+  getProjectConfigPath,
   PROJECT_FILE_NAME,
   ProjectConfig,
   ShellConfig,
@@ -29,18 +30,23 @@ export class ProjectInitCommand extends Command {
   async run() {
     const { args } = await this.parse();
     const projectDir = this.getProjectPath(args.projectDir);
-    this.log(projectDir);
     await this.execute(projectDir);
   }
 
   async execute(projectDir: string): Promise<void> {
     const projectPath = path.join(projectDir, PROJECT_FILE_NAME);
     if (fileExists(projectPath)) {
-      this.error(
-        "Attempted to run init for a directory that already has a .fauna-project."
+      this.error(`Project already exists at ${projectPath}`);
+    }
+    this.log(`Creating project at ${projectPath}`);
+    // todo: show a warning if there is a .fauna-project in an ancestor anywhere up the line
+
+    const existingProject = getProjectConfigPath(projectPath);
+    if (existingProject !== undefined) {
+      this.log(
+        `Warning: the new project will override the existing project at ${existingProject}`
       );
     }
-    // todo: show a warning if there is a .fauna-project in an ancestor anywhere up the line
 
     const shellConfig = ShellConfig.readWithOverrides({
       projectPath: projectPath,

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -305,15 +305,17 @@ export const getRootConfigPath = () => {
   return path.join(os.homedir(), ".fauna-shell");
 };
 
-export const getProjectConfigPath = (): string | undefined => {
-  let current;
-  try {
-    current = process.cwd();
-  } catch (err) {
-    // If the cwd is not accessible, just give up. If this happens, one of our
-    // dependencies actually explodes elsewhere, but we might as well handle
-    // errors where possible.
-    return undefined;
+export const getProjectConfigPath = (start?: string): string | undefined => {
+  let current = start;
+  if (current === undefined) {
+    try {
+      current = process.cwd();
+    } catch (err) {
+      // If the cwd is not accessible, just give up. If this happens, one of our
+      // dependencies actually explodes elsewhere, but we might as well handle
+      // errors where possible.
+      return undefined;
+    }
   }
 
   // eslint-disable-next-line no-constant-condition


### PR DESCRIPTION
Ticket(s): ENG-5573

Emits a warning if there's already a project file above the given project directory.
