### PR TITLE
Add type: shell to cloud-login

### DIFF
--- a/src/commands/cloud-login.ts
+++ b/src/commands/cloud-login.ts
@@ -179,6 +179,7 @@ export default class CloudLoginCommand extends Command {
       body: JSON.stringify({
         email,
         password,
+        type: "shell",
         session: "Fauna Shell - " + hostname(),
         ...(otp && { otp }),
       }),


### PR DESCRIPTION
Ticket(s): ENG-5538

Once this feature is merged in the auth service, we can ship this, and it'll make sessions not get destroyed when you log into the dashboard.
