### PR TITLE
BT-4220: Update DIND Image

### DIFF
--- a/concourse/tasks/integration-tests.yml
+++ b/concourse/tasks/integration-tests.yml
@@ -3,7 +3,10 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: karlkfi/concourse-dcind
+    repository: shared-concourse-dind
+    aws_access_key_id: ((prod-images-aws-access-key-id))
+    aws_secret_access_key: ((prod-images-aws-secret-key))
+    aws_region: us-east-2
 
 params:
   FAUNA_SECRET:


### PR DESCRIPTION
Ticket(s): BT-4217

## Problem

Pipelines are failing when we use the latest version of the fauna docker image, but the issue doesn't appear to be with the image itself but rathe the version of Docker Engine that's used in `karlkfi/concourse-dcind`

## Solution

We forked `karlkfi/concourse-dcind` and created our own updated version of that image

## Result

Pipelines should be green 🤞 

## Out of scope


## Testing

Details in Jira card -- TL;DR -- a bunch of Concourse ad-hoc runs that concluded this was a solution
