### PR TITLE
Add yarn build to publish.sh

### DIFF
--- a/concourse/scripts/publish.sh
+++ b/concourse/scripts/publish.sh
@@ -4,8 +4,8 @@ set -eou
 
 cd ./fauna-shell-repository
 
-mkdir dist
-npm install
+yarn install
+yarn build
 
 PACKAGE_VERSION=$(node -p -e "require('./package.json').version")
 NPM_LATEST_VERSION=$(npm view fauna-shell version)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fauna-shell",
   "description": "faunadb shell",
-  "version": "1.2.0-beta1",
+  "version": "1.2.0-beta2",
   "author": "Fauna",
   "bin": {
     "fauna": "./bin/run"


### PR DESCRIPTION
Adds `yarn build` to publish. `1.2.0-beta1` doesn't have any build artifacts :/
