### PR TITLE
enable endpoint logging for shell command

### DIFF
--- a/src/commands/shell.js
+++ b/src/commands/shell.js
@@ -9,6 +9,8 @@ const esprima = require("esprima");
 const EvalCommand = require("./eval.js");
 
 class ShellCommand extends EvalCommand {
+  outputConnectionInfo = true;
+
   commands = [
     {
       cmd: "clear",


### PR DESCRIPTION
When disabling this for the eval command, which returns valid JSON, I unintentionally disabled it for the shell command as well because the shell command inherits from the eval command.

