### PR TITLE
Add improved secret management

### DIFF
--- a/src/commands/cloud-login.ts
+++ b/src/commands/cloud-login.ts
@@ -4,6 +4,7 @@ import { hostname } from "os";
 import { Command } from "@oclif/core";
 import { underline, blue } from "chalk";
 import fetch from "node-fetch";
+import { Secret } from "../lib/secret";
 
 const DEFAULT_NAME = "cloud";
 const DB = process.env.FAUNA_URL ?? "https://db.fauna.com";
@@ -48,7 +49,7 @@ export default class CloudLoginCommand extends Command {
     for (const region of Object.values(regions)) {
       config.rootConfig.endpoints[region.endpointName(base)] = new Endpoint({
         url: DB,
-        secret: region.secret,
+        secret: Secret.parse(region.secret),
       });
     }
 

--- a/src/lib/secret.ts
+++ b/src/lib/secret.ts
@@ -1,0 +1,51 @@
+export class Secret {
+  // A fauna key, like `fn1234`.
+  key: string;
+  // A database scope, like `["foo", "bar"]`
+  databaseScope: string[];
+
+  constructor(opts: { key: string; databaseScope?: string[] }) {
+    this.key = opts.key;
+    this.databaseScope = opts.databaseScope ?? [];
+  }
+
+  static parse(key: string) {
+    if (key.length === 0) {
+      throw new Error("Secret cannot be empty");
+    }
+    if (key.includes(":")) {
+      throw new Error("Secret cannot be scoped");
+    }
+    return new Secret({ key });
+  }
+
+  buildSecret(opts?: { role?: string }): string {
+    let secret = this.key;
+    if (this.databaseScope.length > 0) {
+      secret += `:${this.databaseScope.join("/")}`;
+    }
+    if (opts?.role !== undefined || this.databaseScope.length > 0) {
+      const role = opts?.role ?? "admin";
+      secret += ["admin", "client", "server", "server-readonly"].includes(role)
+        ? `:${role}`
+        : `:@role/${role}`;
+    }
+    return secret;
+  }
+
+  /**
+   * Parses the given scope, appends it to the `Secret`, and returns the new
+   * secret. This mutates `this`.
+   */
+  appendScope(scope: string) {
+    this.databaseScope.push(...scope.split("/"));
+    return this;
+  }
+
+  clone(): Secret {
+    return new Secret({
+      key: this.key,
+      databaseScope: [...this.databaseScope],
+    });
+  }
+}

--- a/src/lib/stack-factory.ts
+++ b/src/lib/stack-factory.ts
@@ -115,7 +115,10 @@ export class StackFactory {
 
   promptDatabasePath = async (endpoint: Endpoint): Promise<string> => {
     const { url, secret } = endpoint;
-    const client = new FaunaClient({ endpoint: url, secret });
+    const client = new FaunaClient({
+      endpoint: url,
+      secret: secret.buildSecret(),
+    });
 
     const res = await client.query("0");
     if (res.status !== 200) {

--- a/test/commands/endpoint.test.ts
+++ b/test/commands/endpoint.test.ts
@@ -5,6 +5,7 @@ import AddEndpointCommand from "../../src/commands/endpoint/add";
 import ListEndpointCommand from "../../src/commands/endpoint/list";
 import RemoveEndpointCommand from "../../src/commands/endpoint/remove";
 import { Config } from "@oclif/core";
+import { Secret } from "../../src/lib/secret";
 
 const rootConfigPath = getRootConfigPath();
 
@@ -54,7 +55,7 @@ describe("endpoint:add", () => {
         endpoints: {
           "my-endpoint": {
             url: "http://bar.baz",
-            secret: "fn3333",
+            secret: Secret.parse("fn3333"),
             name: "my-endpoint",
             // These graphql bits are only saved if they differ from the
             // default.
@@ -64,7 +65,7 @@ describe("endpoint:add", () => {
           foobar: {
             url: "http://foo.baz",
             name: undefined,
-            secret: "fn1234",
+            secret: Secret.parse("fn1234"),
             graphqlHost: "graphql.fauna.com",
             graphqlPort: 443,
           },
@@ -108,7 +109,7 @@ describe("endpoint:add", () => {
         endpoints: {
           "my-endpoint": {
             url: "http://bar.baz",
-            secret: "fn3333",
+            secret: Secret.parse("fn3333"),
             name: "my-endpoint",
             // These graphql bits are only saved if they differ from the
             // default.
@@ -117,7 +118,7 @@ describe("endpoint:add", () => {
           },
           foobar: {
             url: "http://foo.baz",
-            secret: "fn1234",
+            secret: Secret.parse("fn1234"),
             name: undefined,
             graphqlHost: "graphql.fauna.com",
             graphqlPort: 443,
@@ -185,7 +186,7 @@ describe("endpoint:remove", () => {
         endpoints: {
           "my-endpoint": {
             url: "http://bar.baz",
-            secret: "fn3333",
+            secret: Secret.parse("fn3333"),
             name: "my-endpoint",
             // These graphql bits are only saved if they differ from the
             // default.
@@ -225,7 +226,7 @@ describe("endpoint:remove", () => {
         endpoints: {
           "other-endpoint": {
             url: "http://bar.baz",
-            secret: "fn3333",
+            secret: Secret.parse("fn3333"),
             name: "other-endpoint",
             // These graphql bits are only saved if they differ from the
             // default.

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -1,3 +1,4 @@
+import fetch from "node-fetch";
 const url = require("url");
 const { query: q } = require("faunadb");
 const env = process.env;
@@ -32,12 +33,28 @@ module.exports.withOpts = (cmd) => {
   return cmd.concat(opts);
 };
 
-module.exports.getEndpoint = () =>
+const getEndpoint = () =>
   url.format({
     protocol: env.FAUNA_SCHEME,
     hostname: env.FAUNA_DOMAIN,
     port: env.FAUNA_PORT,
   });
+
+module.exports.getEndpoint = getEndpoint;
+
+module.exports.evalV10 = (query) => {
+  const endpoint = getEndpoint();
+  const secret = env.FAUNA_SECRET;
+  return fetch(new URL("/query/1", endpoint), {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${secret}`,
+    },
+    body: JSON.stringify({
+      query,
+    }),
+  });
+}
 
 const fqlToJsonString = (fql) => JSON.stringify(q.wrap(fql));
 module.exports.fqlToJsonString = fqlToJsonString;

--- a/test/lib/secret.test.ts
+++ b/test/lib/secret.test.ts
@@ -1,0 +1,68 @@
+import { expect } from "chai";
+import { Secret } from "../../src/lib/secret";
+
+describe("secret", () => {
+  it("appends paths scoped secrets", () => {
+    const secret = Secret.parse("fn1234");
+    expect(secret.databaseScope).to.eql([]);
+
+    secret.appendScope("foo");
+    expect(secret.databaseScope).to.eql(["foo"]);
+
+    secret.appendScope("bar");
+    expect(secret.databaseScope).to.eql(["foo", "bar"]);
+  });
+
+  it("parses database paths from appendScope", () => {
+    const secret = Secret.parse("fn1234");
+    expect(secret.databaseScope).to.eql([]);
+
+    secret.appendScope("foo/bar");
+    expect(secret.databaseScope).to.eql(["foo", "bar"]);
+  });
+
+  it("disallows empty secrets", () => {
+    expect(() => Secret.parse("")).to.throw("Secret cannot be empty");
+  });
+
+  it("disallows scoped secrets", () => {
+    expect(() => Secret.parse("fn1234:foo")).to.throw(
+      "Secret cannot be scoped"
+    );
+  });
+
+  it("builds a secret with a role", () => {
+    const secret = Secret.parse("fn1234");
+    expect(secret.buildSecret()).to.equal("fn1234");
+    expect(secret.buildSecret({ role: "admin" })).to.equal("fn1234:admin");
+    expect(secret.buildSecret({ role: "server" })).to.equal("fn1234:server");
+    expect(secret.buildSecret({ role: "server-readonly" })).to.equal(
+      "fn1234:server-readonly"
+    );
+    expect(secret.buildSecret({ role: "client" })).to.equal("fn1234:client");
+    expect(secret.buildSecret({ role: "foo" })).to.equal("fn1234:@role/foo");
+  });
+
+  it("builds a secret with a scope", () => {
+    const secret = Secret.parse("fn1234");
+    secret.appendScope("foo");
+    expect(secret.buildSecret()).to.equal("fn1234:foo:admin");
+    secret.appendScope("bar");
+    expect(secret.buildSecret()).to.equal("fn1234:foo/bar:admin");
+  });
+
+  it("builds a secret with a scope and role", () => {
+    const secret = Secret.parse("fn1234");
+    secret.appendScope("foo/bar");
+    expect(secret.buildSecret()).to.equal("fn1234:foo/bar:admin");
+    expect(secret.buildSecret({ role: "admin" })).to.equal(
+      "fn1234:foo/bar:admin"
+    );
+    expect(secret.buildSecret({ role: "server" })).to.equal(
+      "fn1234:foo/bar:server"
+    );
+    expect(secret.buildSecret({ role: "foo" })).to.equal(
+      "fn1234:foo/bar:@role/foo"
+    );
+  });
+});


### PR DESCRIPTION
Ticket(s): ENG-5635

Adds a `Secret` helper class, which manages a scoped secret.

This makes it so that `fauna shell <scope>` will append the given scope to the scope in your project file. The behavior is a little weird:
```
% fauna shell bar
Connected to endpoint: neil-2-us database: foo/bar
Starting shell for database bar
Type Ctrl+D or .exit to exit the shell
bar>
```

Note that it says "connected to database foo/bar", and then says "Starting shell for database bar."

Not sure if we want to fix this or not, but I think its fine as-is.
