### PR TITLE
don't blow up for invalid config

### DIFF
--- a/src/commands/stack/add.ts
+++ b/src/commands/stack/add.ts
@@ -31,7 +31,7 @@ export default class AddStackCommand extends Command {
   ];
 
   async run() {
-    const config = ShellConfig.read({});
+    const config = ShellConfig.read({}, this);
 
     await this.execute(config);
   }

--- a/src/commands/stack/list.ts
+++ b/src/commands/stack/list.ts
@@ -10,7 +10,7 @@ export default class ListStackCommand extends Command {
   static examples = ["$ fauna stack list"];
 
   async run() {
-    const config = ShellConfig.read({});
+    const config = ShellConfig.read({}, this);
 
     await this.execute(config);
   }

--- a/src/commands/stack/select.ts
+++ b/src/commands/stack/select.ts
@@ -14,7 +14,7 @@ export default class SelectStackCommand extends Command {
   static examples = ["$ fauna stack select my-stack"];
 
   async run() {
-    const config = ShellConfig.read({});
+    const config = ShellConfig.read({}, this);
 
     await this.execute(config);
   }

--- a/src/lib/fauna-command.js
+++ b/src/lib/fauna-command.js
@@ -37,7 +37,7 @@ class FaunaCommand extends Command {
     const { flags: f, args: a } = await this.parse(this.constructor);
     this.flags = f;
     this.args = a;
-    this.shellConfig = ShellConfig.read(this.flags);
+    this.shellConfig = ShellConfig.read(this.flags, this);
   }
 
   success(msg) {

--- a/test/commands/endpoint.test.ts
+++ b/test/commands/endpoint.test.ts
@@ -69,6 +69,7 @@ describe("endpoint:add", () => {
             graphqlPort: 443,
           },
         },
+        invalidEndpoints: [],
       });
       expect(ctx.config.saveRootConfig.calledOnce).to.be.true;
     });
@@ -122,6 +123,7 @@ describe("endpoint:add", () => {
             graphqlPort: 443,
           },
         },
+        invalidEndpoints: [],
       });
       expect(ctx.config.saveRootConfig.calledOnce).to.be.true;
     });
@@ -191,6 +193,7 @@ describe("endpoint:remove", () => {
             graphqlPort: 443,
           },
         },
+        invalidEndpoints: [],
       });
       expect(ctx.config.saveRootConfig.calledOnce).to.be.true;
     });
@@ -230,6 +233,7 @@ describe("endpoint:remove", () => {
             graphqlPort: 443,
           },
         },
+        invalidEndpoints: [],
       });
       expect(ctx.config.saveRootConfig.calledOnce).to.be.true;
     });

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -4,6 +4,7 @@ import {
   ShellConfig,
   ShellOpts,
   getProjectConfigPath,
+  getRootConfigPath,
 } from "../../src/lib/config";
 import sinon from "sinon";
 
@@ -104,6 +105,23 @@ describe("root config", () => {
       secret: "fn1234",
       url: "https://db.fauna.com",
     });
+  });
+
+  it("fails to save if the root config has invalid endpoints", () => {
+    const invalidConfig = new ShellConfig({
+      rootConfig: {
+        default: "my-endpoint",
+        "my-endpoint": {
+          secret: "fn1234",
+          url: "http://localhost:8443",
+        },
+        invalidEndpoints: ["invalid-endpoint"],
+      },
+    });
+    const expectedMsg = `The following endpoint definitions in ${getRootConfigPath()} are invalid:\n ${invalidConfig.rootConfig.invalidEndpoints.join(
+      "\n"
+    )}\n Resolve them by ensuring they have a secret defined or remove them if they are not needed.`;
+    expect(() => invalidConfig.saveRootConfig()).to.throw(expectedMsg);
   });
 });
 


### PR DESCRIPTION
ENG-5603

This will make it such that commands emit warnings when invalid endpoints are detected in the fauna shell config.  Users will still be able to use the shell if this is the case, all invalid endpoints will be ignored. As it currently stands, any attempt to update the fauna shell config file will fail if there are invalid endpoints as we would remove them in that scenario.

