### PR TITLE
fix error pulling a file path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fauna-shell",
   "description": "faunadb shell",
-  "version": "1.2.0-beta7",
+  "version": "1.2.0-beta8",
   "author": "Fauna",
   "bin": {
     "fauna": "./bin/run"

--- a/src/commands/schema/pull.ts
+++ b/src/commands/schema/pull.ts
@@ -87,7 +87,7 @@ export default class PullSchemaCommand extends SchemaCommand {
       if (confirmed) {
         for (const filename of filenames) {
           const fileres = await fetch(
-            new URL(`/schema/1/files/${filename}`, url),
+            new URL(`/schema/1/files/${encodeURIComponent(filename)}`, url),
             {
               method: "GET",
               headers: { AUTHORIZATION: `Bearer ${secret}` },

--- a/test/commands/schema.test.js
+++ b/test/commands/schema.test.js
@@ -111,7 +111,7 @@ for (const ddelete of [false, true]) {
           .reply(200, functions)
           .get("/schema/1/files/main.fsl")
           .reply(200, main)
-          .get("/schema/1/files/roles/myrole.fsl")
+          .get("/schema/1/files/roles%2Fmyrole.fsl")
           .reply(200, myrole)
       )
       .stdout()


### PR DESCRIPTION
ENG-5658
If the file being pulled was underneath a directory it would end up sending the file path to the server as part of the request path which ended up in a not found error.

