### PR TITLE
don't validate endpoint config with --secret

### DIFF
--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -201,8 +201,6 @@ export class ShellConfig {
       ? ProjectConfig.fromConfig(new Config("config key", opts.projectConfig))
       : undefined;
 
-    this.projectConfig?.validate(this.rootConfig);
-
     const urlFlag = Endpoint.getURLFromFlags(this.flags);
     if (urlFlag !== undefined) {
       try {
@@ -250,7 +248,7 @@ export class ShellConfig {
       );
     }
 
-    if (endpointName === undefined) {
+    if (endpointName === undefined || secretFlag !== undefined) {
       // This is a dummy secret. `--secret` must be set in this case, which
       // `validate` enforces.
       this.endpoint = new Endpoint({
@@ -260,6 +258,7 @@ export class ShellConfig {
         graphqlPort: this.flags.numberOpt("graphqlPort"),
       });
     } else {
+      this.projectConfig?.validate(this.rootConfig);
       this.endpoint = this.rootConfig.endpoints[endpointName];
       if (this.endpoint === undefined) {
         throw new Error(`No such endpoint '${endpointName}'`);

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -248,7 +248,15 @@ export class ShellConfig {
       );
     }
 
-    if (endpointName === undefined || secretFlag !== undefined) {
+    // There are 2 scenarios where we want to execute the first if block:
+    // 1. no endpoint name is set
+    // 2. In a CI/CD environment where a secret is set but there is no
+    // root config.  In this scenario endpoints may be set by the project
+    // configuration but won't exist in their pipeline workspace.
+    if (
+      endpointName === undefined ||
+      (secretFlag !== undefined && this.rootConfig.isEmpty())
+    ) {
       // This is a dummy secret. `--secret` must be set in this case, which
       // `validate` enforces.
       this.endpoint = new Endpoint({

--- a/src/lib/config/root-config.ts
+++ b/src/lib/config/root-config.ts
@@ -59,6 +59,10 @@ export class RootConfig {
     }
   }
 
+  isEmpty(): boolean {
+    return Object.keys(this.endpoints).length === 0;
+  }
+
   /**
    * If there is an endpoint object in the config, and it has a
    * object underneath it, we are saying that it uses the


### PR DESCRIPTION
ENG-5661
This came up while I was testing updating schema in a pipeline.  In this scenario the endpoints present in the project configuration won't exist, which is ok as long as a secret is getting passed.

