### PR TITLE
use secret key for ini conversion

### DIFF
--- a/src/lib/config/root-config.ts
+++ b/src/lib/config/root-config.ts
@@ -216,7 +216,7 @@ export class Endpoint {
 
   toIni() {
     return {
-      secret: this.secret,
+      secret: this.secret.key,
       ...(this.url !== "https://db.fauna.com" ? { url: this.url } : {}),
 
       ...(this.graphqlHost !== "graphql.fauna.com"

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -121,6 +121,26 @@ describe("root config", () => {
     )}\n Resolve them by ensuring they have a secret defined or remove them if they are not needed.`;
     expect(() => invalidConfig.saveRootConfig()).to.throw(expectedMsg);
   });
+  it("writes correct ini config", () => {
+    const config = new ShellConfig({
+      rootConfig: {
+        default: "my-endpoint",
+        "my-endpoint": {
+          secret: "fn1234",
+          url: "http://localhost:8443",
+        },
+      },
+    });
+    expect(config.rootConfig.toIni()).to.deep.equal({
+      default: "my-endpoint",
+      endpoint: {
+        "my-endpoint": {
+          secret: "fn1234",
+          url: "http://localhost:8443",
+        },
+      },
+    });
+  });
 });
 
 describe("root config with flags", () => {


### PR DESCRIPTION
ENG-5662
Without this it was writing secret objects to the endpoints file and causing issues.  I think we just want the key vs using buildSecret() because we currently don't allow scoped secrets in the endpoints file, just the secret itself.

