### PR TITLE
update pipeline to point to 1.1.1

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -5,7 +5,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/fauna/fauna-shell.git
-      branch: main
+      branch: 1.1.1
 
 jobs:
   - name: test


### PR DESCRIPTION
This is a temporary update so that we can release a patched version of 1.1.0 that doesn't show an error message when adding a default endpoint

