### PR TITLE
improve pipeline reliability

### DIFF
--- a/concourse/scripts/wait-for-it.sh
+++ b/concourse/scripts/wait-for-it.sh
@@ -1,0 +1,16 @@
+attempt_counter=0
+max_attempts=100
+
+echo "waiting for $1"
+until $(curl -m 1 --output /dev/null --silent --head --fail $1); do
+  if [ ${attempt_counter} -eq ${max_attempts} ];then
+    echo ""
+    echo "Max attempts reached to $1"
+    exit 1
+  fi
+
+  echo "."
+  attempt_counter=$(($attempt_counter+1))
+  sleep 5
+done
+echo "$1 is up and running!"

--- a/concourse/tasks/integration.yml
+++ b/concourse/tasks/integration.yml
@@ -23,4 +23,10 @@ services:
     volumes:
       - "../../:/tmp/app"
     working_dir: "/tmp/app"
-    command: [sh, -c, "yarn install && yarn run test"]
+    command: 
+      - sh 
+      - -cx 
+      - |
+        apk add curl
+        concourse/scripts/wait-for-it.sh http://core:8443/ping
+        yarn install && yarn run test

--- a/test/commands/databases.test.js
+++ b/test/commands/databases.test.js
@@ -15,6 +15,7 @@ const databases = [
 
 describe("database test", () => {
   test
+    .timeout(7000)
     .nock(getEndpoint(), { allowUnmocked: true }, (api) =>
       api
         .persist()


### PR DESCRIPTION
Our list-databases test runs long and is bumping up against our timeout and failing sometimes.


