### PR TITLE
Fix the examples in endpoint add

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,7 +678,7 @@ ALIASES
 EXAMPLES
   $ fauna endpoint add
 
-  $ fauna endpoint add localhost --url http://localhost:8443/ --key secret
+  $ fauna endpoint add localhost --url http://localhost:8443/ --secret secret
 
   $ fauna endpoint add localhost --set-default
 ```

--- a/src/commands/endpoint/add.ts
+++ b/src/commands/endpoint/add.ts
@@ -15,7 +15,7 @@ export default class AddEndpointCommand extends Command {
 
   static examples = [
     "$ fauna endpoint add",
-    "$ fauna endpoint add localhost --url http://localhost:8443/ --key secret",
+    "$ fauna endpoint add localhost --url http://localhost:8443/ --secret secret",
     "$ fauna endpoint add localhost --set-default",
   ];
 


### PR DESCRIPTION
Ticket(s): ENG-5723

Something that was missed in https://github.com/fauna/fauna-shell/pull/263, `key` is now `secret`. h/t to @adambollen.