### PR TITLE
Write 0600 permissions when editing root config

### DIFF
--- a/src/lib/config/root-config.ts
+++ b/src/lib/config/root-config.ts
@@ -85,7 +85,9 @@ export class RootConfig {
     const config = this.toIni();
 
     const encoded = ini.encode(config);
-    fs.writeFileSync(path, encoded);
+    fs.writeFileSync(path, encoded, {
+      mode: 0o600,
+    });
   }
 
   toIni() {


### PR DESCRIPTION
Ticket(s): FE-###

## Problem

~/.fauna-shell contains secrets, so it should not be readable by everyone by default.

## Solution

Write it with mode 0600.

## Result

It is not readable by others by default.

## Testing

I did `fauna cloud-login`, and the new file is only readable and writable by me:

```
$ ls -la ~/.fauna-shell*
-rw------- 1 macmv macmv  232 Dec  7 13:27 .fauna-shell
-rw-r--r-- 1 macmv macmv 1.5K Oct  9 10:49 .fauna-shell.bak
-rw-r--r-- 1 macmv macmv 1.5K Oct 12 15:40 .fauna-shell.old
```
