### PR TITLE
Bump to 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fauna-shell",
   "description": "faunadb shell",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "Fauna",
   "bin": {
     "fauna": "./bin/run"


### PR DESCRIPTION
Ticket(s): FE-###

This release includes the switch over to `fetch`, and some improved error handling.

Seems like a patch to me, although I could be convinced it needs a minor version bump (just because the shell behavior changed slightly).
