### PR TITLE
[DOCS-3026] Bump required Node.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,9 @@ key 200219702370238976 deleted
 
 See [Commands](#commands) for a list of commands and help on their usage.
 
-# Technical Requirements
+# Requirements
 
-In order to use Fauna Shell, you must have Node.js version >= 16 installed.
+To use Fauna Shell, you must have Node.js v20.x or later.
 
 # Shell
 


### PR DESCRIPTION
Ticket(s): [DOCS-3026](https://faunadb.atlassian.net/browse/DOCS-3026)

## Problem

As of writing, the Node.js LTS is v20.x. Earlier Node.js versions give a warning for the `punycode` dependency:

`DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.`

Related convo: https://faunadb.slack.com/archives/C05UDBXU34N/p1718994576191169

[DOCS-3026]: https://faunadb.atlassian.net/browse/DOCS-3026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ