### PR TITLE
Improved error catching and logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "yarn build && oclif manifest",
     "pretest": "yarn fixlint",
-    "local-test": "export $(cat .env | xargs); c8 -r text mocha --forbid-only \"test/**/eval.test.{js,ts}\"",
+    "local-test": "export $(cat .env | xargs); c8 -r text mocha --forbid-only \"test/**/*.test.{js,ts}\"",
     "test": "export $(cat .env.test | xargs); c8 -r html mocha --forbid-only \"test/**/*.test.{js,ts}\"",
     "lint": "eslint .",
     "fixlint": "eslint . --fix",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "yarn build && oclif manifest",
     "pretest": "yarn fixlint",
-    "local-test": "export $(cat .env | xargs); c8 -r text mocha --forbid-only \"test/**/*.test.{js,ts}\"",
+    "local-test": "export $(cat .env | xargs); c8 -r text mocha --forbid-only \"test/**/eval.test.{js,ts}\"",
     "test": "export $(cat .env.test | xargs); c8 -r html mocha --forbid-only \"test/**/*.test.{js,ts}\"",
     "lint": "eslint .",
     "fixlint": "eslint . --fix",

--- a/src/commands/eval.js
+++ b/src/commands/eval.js
@@ -202,17 +202,16 @@ class EvalCommand extends FaunaCommand {
       const response = await runQueries(res.body, client);
       return await writeFormattedOutput(outputFile, response, flags.format);
     } catch (error) {
-      this.error(
-        error.faunaError instanceof faunadb.errors.FaunaHTTPError
-          ? util.inspect(
-              JSON.parse(error.faunaError.requestResult.responseRaw),
-              {
-                depth: null,
-                compact: false,
-              }
-            )
-          : error.faunaError.message
-      );
+      if (error.faunaError === undefined) {
+        // this happens when wrapQueries fails during the runInContext step
+        // at that point, we have Errors that didn't get run as a query, so
+        // they don't have a .faunaError property
+        this.error(error.message)
+      } else if (error.faunaError instanceof faunadb.errors.FaunaHTTPError) {
+        this.error(util.inspect(JSON.parse(error.faunaError.requestResult.responseRaw), { depth: null, compact: false }))
+      } else {
+        this.error(error.faunaError.message)
+      }
     }
   }
 

--- a/src/commands/eval.js
+++ b/src/commands/eval.js
@@ -206,11 +206,16 @@ class EvalCommand extends FaunaCommand {
         // this happens when wrapQueries fails during the runInContext step
         // at that point, we have Errors that didn't get run as a query, so
         // they don't have a .faunaError property
-        this.error(error.message)
+        this.error(error.message);
       } else if (error.faunaError instanceof faunadb.errors.FaunaHTTPError) {
-        this.error(util.inspect(JSON.parse(error.faunaError.requestResult.responseRaw), { depth: null, compact: false }))
+        this.error(
+          util.inspect(JSON.parse(error.faunaError.requestResult.responseRaw), {
+            depth: null,
+            compact: false,
+          })
+        );
       } else {
-        this.error(error.faunaError.message)
+        this.error(error.faunaError.message);
       }
     }
   }

--- a/src/lib/fauna-command.js
+++ b/src/lib/fauna-command.js
@@ -87,14 +87,14 @@ class FaunaCommand extends Command {
     }
   }
 
-  mapConnectionError({ err, connectionOptions, version }) {
+  mapConnectionError({ err, connectionOptions }) {
     if (err instanceof errors.Unauthorized) {
       this.error(
         `Could not Connect to ${connectionOptions.url} Unauthorized Secret`
       );
     } else {
-      const code = err?.message ? `${err.message}: ` : '';
-      const details = err?.description ?? '';
+      const code = err?.message ? `${err.message}: ` : "";
+      const details = err?.description ?? "";
       this.error(`${code}${details}`);
     }
   }

--- a/src/lib/fauna-command.js
+++ b/src/lib/fauna-command.js
@@ -92,13 +92,13 @@ class FaunaCommand extends Command {
       this.error(
         `Could not Connect to ${connectionOptions.url} Unauthorized Secret`
       );
-    }
-    if (err instanceof errors.PermissionDenied && version === "v4") {
+    } else if (err instanceof errors.PermissionDenied && version === "4") {
       this.error(
         `This account is not allowed to query Fauna v4. Please use the v10 endpoint.`
       );
+    } else {
+      this.error(err);
     }
-    this.error(err);
   }
 
   async getClient({ dbScope, role, version } = {}) {

--- a/src/lib/fauna-command.js
+++ b/src/lib/fauna-command.js
@@ -88,12 +88,15 @@ class FaunaCommand extends Command {
   }
 
   mapConnectionError({ err, connectionOptions, version }) {
-    console.log("mapping conn error", err);
     if (err instanceof errors.Unauthorized) {
       this.error(
         `Could not Connect to ${connectionOptions.url} Unauthorized Secret`
       );
-    } else if (err instanceof errors.PermissionDenied && version === "4") {
+    } else if (
+      err.description === "UnknownError" &&
+      err?.requestResult?.statusCode === 410 &&
+      version === "4"
+    ) {
       this.error(
         `This account is not allowed to query Fauna v4. Please use the v10 endpoint.`
       );

--- a/src/lib/fauna-command.js
+++ b/src/lib/fauna-command.js
@@ -87,10 +87,15 @@ class FaunaCommand extends Command {
     }
   }
 
-  mapConnectionError({ err, connectionOptions }) {
+  mapConnectionError({ err, connectionOptions, version }) {
     if (err instanceof errors.Unauthorized) {
       this.error(
         `Could not Connect to ${connectionOptions.url} Unauthorized Secret`
+      );
+    }
+    if (err instanceof errors.PermissionDenied && version === "v4") {
+      this.error(
+        `This account is not allowed to query Fauna v4. Please use the v10 endpoint.`
       );
     }
     this.error(err);
@@ -153,7 +158,7 @@ class FaunaCommand extends Command {
         logConnectionMessage(connectionOptions);
         return this.clients[hashKey];
       } catch (err) {
-        this.mapConnectionError({ err, connectionOptions });
+        this.mapConnectionError({ err, connectionOptions, version });
       }
     } else {
       // construct v10 client

--- a/src/lib/fauna-command.js
+++ b/src/lib/fauna-command.js
@@ -88,6 +88,7 @@ class FaunaCommand extends Command {
   }
 
   mapConnectionError({ err, connectionOptions, version }) {
+    console.log("mapping conn error", err);
     if (err instanceof errors.Unauthorized) {
       this.error(
         `Could not Connect to ${connectionOptions.url} Unauthorized Secret`

--- a/src/lib/fauna-command.js
+++ b/src/lib/fauna-command.js
@@ -92,16 +92,10 @@ class FaunaCommand extends Command {
       this.error(
         `Could not Connect to ${connectionOptions.url} Unauthorized Secret`
       );
-    } else if (
-      err.description === "UnknownError" &&
-      err?.requestResult?.statusCode === 410 &&
-      version === "4"
-    ) {
-      this.error(
-        `This account is not allowed to query Fauna v4. Please use the v10 endpoint.`
-      );
     } else {
-      this.error(err);
+      const code = err?.message ? `${err.message}: ` : '';
+      const details = err?.description ?? '';
+      this.error(`${code}${details}`);
     }
   }
 

--- a/src/lib/fauna-command.js
+++ b/src/lib/fauna-command.js
@@ -156,7 +156,7 @@ class FaunaCommand extends Command {
         logConnectionMessage(connectionOptions);
         return this.clients[hashKey];
       } catch (err) {
-        this.mapConnectionError({ err, connectionOptions, version });
+        this.mapConnectionError({ err, connectionOptions });
       }
     } else {
       // construct v10 client

--- a/src/lib/misc.js
+++ b/src/lib/misc.js
@@ -57,20 +57,18 @@ class QueryError extends Error {
 function wrapQueries(expressions, client) {
   const q = query;
   createContext(q);
-  return expressions.map(
-    (exp, queryNumber) => () => {
-      let query
-      try {
-        query = runInContext(generate(exp), q)
-      } catch (e) {
-        return Promise.reject(e)
-      }
-
-      return client.query(query).catch((err) => {
-        throw new QueryError(generate(exp), err, queryNumber + 1);
-      })
+  return expressions.map((exp, queryNumber) => () => {
+    let query;
+    try {
+      query = runInContext(generate(exp), q);
+    } catch (e) {
+      return Promise.reject(e);
     }
-  );
+
+    return client.query(query).catch((err) => {
+      throw new QueryError(generate(exp), err, queryNumber + 1);
+    });
+  });
 }
 
 export async function runQueries(expressions, client) {

--- a/src/lib/misc.js
+++ b/src/lib/misc.js
@@ -58,14 +58,22 @@ function wrapQueries(expressions, client) {
   const q = query;
   createContext(q);
   return expressions.map(
-    (exp, queryNumber) => () =>
-      client.query(runInContext(generate(exp), q)).catch((err) => {
+    (exp, queryNumber) => () => {
+      let query
+      try {
+        query = runInContext(generate(exp), q)
+      } catch (e) {
+        return Promise.reject(e)
+      }
+
+      return client.query(query).catch((err) => {
         throw new QueryError(generate(exp), err, queryNumber + 1);
       })
+    }
   );
 }
 
-export function runQueries(expressions, client) {
+export async function runQueries(expressions, client) {
   if (expressions.length === 1) {
     var f = wrapQueries(expressions, client)[0];
     return f();

--- a/test/commands/eval.test.js
+++ b/test/commands/eval.test.js
@@ -82,8 +82,8 @@ describe("eval", () => {
 
   test
     .nock(getEndpoint(), { allowUnmocked: true }, (api) => {
-      api.post("/", matchFqlReq(q.Now())).reply(403, {
-        errors: [{ description: "Permission denied." }],
+      api.post("/", matchFqlReq(q.Now())).reply(410, {
+        errors: [{ description: "UnknownError" }],
       });
     })
     .stderr()
@@ -91,7 +91,7 @@ describe("eval", () => {
     .catch((e) => {
       expect(e.message).to.contain("not allowed to query Fauna v4");
     })
-    .it("displays proper message on v4 403");
+    .it("displays proper message on v4 410");
 });
 
 describe("eval in v10", () => {

--- a/test/commands/eval.test.js
+++ b/test/commands/eval.test.js
@@ -83,15 +83,15 @@ describe("eval", () => {
   test
     .nock(getEndpoint(), { allowUnmocked: true }, (api) => {
       api.post("/", matchFqlReq(q.Now())).reply(410, {
-        errors: [{ description: "UnknownError" }],
+        errors: [{ description: "v4 error message from core" }],
       });
     })
     .stderr()
     .command(withOpts(["eval", "--version", "4", "1"]))
     .catch((e) => {
-      expect(e.message).to.contain("not allowed to query Fauna v4");
+      expect(e.message).to.contain("v4 error message from core");
     })
-    .it("displays proper message on v4 410");
+    .it("410 from core displays core error message");
 });
 
 describe("eval in v10", () => {

--- a/test/commands/eval.test.js
+++ b/test/commands/eval.test.js
@@ -79,6 +79,19 @@ describe("eval", () => {
       expect(e.message).to.contain("transaction aborted");
     })
     .it("It pretty-prints an error message the command fails");
+
+  test
+    .nock(getEndpoint(), { allowUnmocked: true }, (api) => {
+      api.post("/", matchFqlReq(q.Now())).reply(403, {
+        errors: [{ description: "Permission denied." }],
+      });
+    })
+    .stderr()
+    .command(withOpts(["eval", "--version", "4", "1"]))
+    .catch((e) => {
+      expect(e.message).to.contain("not allowed to query Fauna v4");
+    })
+    .it("displays proper message on v4 403");
 });
 
 describe("eval in v10", () => {


### PR DESCRIPTION
Ticket(s): FE-5448

## Problem
* once core enforces v4 access (https://github.com/fauna/core/pull/11546), shell attempts to query v4 will result in 410's directly from fauna api
* Executing a v10 query within v4 client results in an unhandled error, a symptom of bad error catching

## Solution
* check for and display `err.message` and `err.description` from fauna. This will display the nice message from core regarding v4 access
* `eval` will properly catch errors from the async `wrapQueries` block

## Result
* Users see helpful error messages

## Testing
* added a test that mocks 410 response when setting up v4 client