### PR TITLE
v4 temporary header

### DIFF
--- a/src/lib/fauna-command.js
+++ b/src/lib/fauna-command.js
@@ -48,6 +48,16 @@ class FaunaCommand extends Command {
     super.error(message, { exit: 1 });
   }
 
+  _getHeaders() {
+    const headers = {
+      "X-Fauna-Source": "Fauna Shell",
+    };
+    if (!["ShellCommand", "EvalCommand"].includes(this.constructor.name)) {
+      headers["x-fauna-shell-builtin"] = "true";
+    }
+    return headers;
+  }
+
   /**
    * !!! use getClient instead
    * Runs the function in the context of a database connection.
@@ -74,9 +84,7 @@ class FaunaCommand extends Command {
         // Force http1. See getClient.
         fetch: fetch,
 
-        headers: {
-          "X-Fauna-Source": "Fauna Shell",
-        },
+        headers: this._getHeaders(),
       });
       await client.query(q.Now());
       //TODO this should return a Promise
@@ -142,9 +150,7 @@ class FaunaCommand extends Command {
           // TODO: Remove and just connect to a docker container.
           fetch: fetch,
 
-          headers: {
-            "X-Fauna-Source": "Fauna Shell",
-          },
+          headers: this._getHeaders(),
         });
 
         // validate the client settings

--- a/test/commands/databases.test.js
+++ b/test/commands/databases.test.js
@@ -22,7 +22,10 @@ describe("database test", () => {
     nock(getEndpoint(), { allowUnmocked: true })
       .persist()
       .post("/", matchFqlReq(q.Now()))
-      .reply(200, new Date())
+      .reply(200, function () {
+        expect(this.req.headers["x-fauna-shell-builtin"]).to.equal("true");
+        return new Date();
+      })
       .post("/", matchFqlReq(q.Paginate(q.Databases(), { size: 1000 })))
       .reply(200, { resource: { data: databases } });
     const { stdout } = await runCommand(withOpts(["list-databases"]));

--- a/test/commands/eval.test.js
+++ b/test/commands/eval.test.js
@@ -10,6 +10,10 @@ const {
 } = require("../helpers/utils.js");
 const { query: q } = require("faunadb");
 
+afterEach(() => {
+  nock.cleanAll();
+});
+
 describe("eval", () => {
   it("runs eval on root db", async () => {
     const scope = nock(getEndpoint(), { allowUnmocked: true });
@@ -180,6 +184,7 @@ function mockQuery(api) {
     .post("/", matchFqlReq(q.Paginate(q.Collections())))
     .reply(200, function () {
       const auth = this.req.headers.authorization.split(" ")[1].split(":");
+      expect(this.req.headers["x-fauna-shell-builtin"]).to.not.exist;
       return {
         resource: {
           data: [

--- a/test/commands/keys.test.js
+++ b/test/commands/keys.test.js
@@ -25,7 +25,10 @@ describe("keys test", () => {
     nock(getEndpoint(), { allowUnmocked: true })
       .persist()
       .post("/", matchFqlReq(q.Now()))
-      .reply(200, new Date())
+      .reply(200, function () {
+        expect(this.req.headers["x-fauna-shell-builtin"]).to.equal("true");
+        return new Date();
+      })
       .post("/", matchFqlReq(q.Paginate(q.Keys(), { size: 100 })))
       .reply(200, { resource: currentKeys })
       .post("/", matchFqlReq(q.Paginate(q.Databases(), { size: 100 })))


### PR DESCRIPTION
Ticket(s): FE-5644

## Problem

New users will eventually be unable to use the basic shell commands as they will not have v4 access

## Solution

Until all shell functions can be rewritten to use the v10 Fauna api, employ a temporary header that Core can use to continue to allow these v4 calls from the shell.

`shell` repl sessions and `eval` v4 commands will, however, not receive the temporary header and will work based on the user's access policy.

## Result

Unblock launch of v4 access restriction until we have bandwidth to rewrite shell functions to v10. 

Risk being that the header is publicly available and could be leveraged by any user regardless of their v4 access policy.

## Testing

Updated some tests to expect the header on commands other than `eval`. 

TODO: `shell` tests have been turned off for a while
