### PR TITLE
Release v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fauna-shell",
   "description": "faunadb shell",
-  "version": "1.3.1",
+  "version": "2.0.0",
   "author": "Fauna",
   "bin": {
     "fauna": "./bin/run"


### PR DESCRIPTION
Ticket(s): FE-5644, FE-5645

## Summary

* Release new major version of `fauna-shell`

## Changes

* **Breaking**: Environments running `node<18` are no longer guaranteed to be supported [diff](https://github.com/fauna/fauna-shell/commit/a1453ee4ed2424f836c59c0534ba349b1ad45e3e)
* New _temporary_ header to unblock built-in commands written in v4 until we can rewrite them to v10. V4 `shell` and `eval` queries will be blocked according to users' access policies, once the v4 deprecation flag goes live [diff](https://github.com/fauna/fauna-shell/commit/2f41e9da9cc302163b472cace988dc1455cbca9a)
