### PR TITLE
Send Schema body as FormData; Format schema test file

### DIFF
--- a/fsl/test-script.mjs
+++ b/fsl/test-script.mjs
@@ -1,41 +1,52 @@
 #!/usr/bin/env zx
 
 /**
-  * This is provided in the pipeline to pass in the built version of the
-  * fauna CLI to be tested.
-  */
+ * This is provided in the pipeline to pass in the built version of the
+ * fauna CLI to be tested.
+ */
 let faunaCmd;
 if (argv._.length === 1) {
-  faunaCmd = `${argv._[0]}`
+  faunaCmd = `${argv._[0]}`;
 } else {
-  faunaCmd = "fauna"
+  faunaCmd = "fauna";
 }
 
-const expectedCollNames = ["bye", "hi"]
-const expectedFuncNames = ["sayHello"]
-const secretFlag = process.env.FAUNA_SECRET
+const expectedCollNames = ["bye", "hi"];
+const expectedFuncNames = ["sayHello"];
+const secretFlag = process.env.FAUNA_SECRET;
 if (secretFlag) {
-  $.verbose = false
-  console.log("A secret was found for FAUNA_SECRET, it will be used for all fauna CLI commands")
+  $.verbose = false;
+  console.log(
+    "A secret was found for FAUNA_SECRET, it will be used for all fauna CLI commands"
+  );
 }
 
-
-await ensureClean()
+await ensureClean();
 
 /**
-  * Test Push
-  */
-await execFaunaCmd(["schema", "push", "--force"])
-const collNames = await execPaginated("Collection.all().map(.name).order()")
-if (collNames.length != expectedCollNames.length || !collNames.every((elem, idx) => elem === expectedCollNames[idx])) {
-  throw new Error(`Schema collections do not match actual: ${collNames} expected: ${expectedCollNames}`)
+ * Test Push
+ */
+await execFaunaCmd(["schema", "push", "--force"]);
+const collNames = await execPaginated("Collection.all().map(.name).order()");
+if (
+  collNames.length != expectedCollNames.length ||
+  !collNames.every((elem, idx) => elem === expectedCollNames[idx])
+) {
+  throw new Error(
+    `Schema collections do not match actual: ${collNames} expected: ${expectedCollNames}`
+  );
 }
-const funcNames = await execPaginated("Function.all().map(.name)")
-if (funcNames.length != expectedFuncNames.length || !funcNames.every((elem, idx) => elem === expectedFuncNames[idx])) {
-  throw new Error(`Schema functions do not match actual: ${collNames} expected: ${expectedCollNames}`)
+const funcNames = await execPaginated("Function.all().map(.name)");
+if (
+  funcNames.length != expectedFuncNames.length ||
+  !funcNames.every((elem, idx) => elem === expectedFuncNames[idx])
+) {
+  throw new Error(
+    `Schema functions do not match actual: ${collNames} expected: ${expectedCollNames}`
+  );
 }
 
-await $`rm schema/*`
+await $`rm schema/*`;
 
 /**
  * Test Pull
@@ -44,56 +55,64 @@ await $`rm schema/*`
  */
 let pullProcess;
 if (secretFlag) {
-  pullProcess = $`${faunaCmd} schema pull --secret ${secretFlag}`
+  pullProcess = $`${faunaCmd} schema pull --secret ${secretFlag}`;
 } else {
-  pullProcess = $`${faunaCmd} schema pull`
+  pullProcess = $`${faunaCmd} schema pull`;
 }
-pullProcess.stdin.write('yes\n')
-pullProcess.stdin.end()
-await sleep(10000)
-const schemaFiles = (await $`ls schema`).stdout.trim().split('\n')
-if (schemaFiles.length !== 2 || schemaFiles[0] !== "collections.fsl" || schemaFiles[1] !== "sayHelloFunction.fsl") {
-  throw new Error(`Schema files after pull did not equal expected.  Expected: ['collections.fsl, 'sayHelloFunction.fsl'] Actual: ${schemaFiles}`)
+pullProcess.stdin.write("yes\n");
+pullProcess.stdin.end();
+await sleep(10000);
+const schemaFiles = (await $`ls schema`).stdout.trim().split("\n");
+if (
+  schemaFiles.length !== 2 ||
+  schemaFiles[0] !== "collections.fsl" ||
+  schemaFiles[1] !== "sayHelloFunction.fsl"
+) {
+  throw new Error(
+    `Schema files after pull did not equal expected.  Expected: ['collections.fsl, 'sayHelloFunction.fsl'] Actual: ${schemaFiles}`
+  );
 }
-console.log("Schema tests run successfully!")
+console.log("Schema tests run successfully!");
 
 async function ensureClean() {
   await execFQL(`
     Collection.all().forEach(.delete())
     Role.all().forEach(.delete())
     Function.all().forEach(.delete())
-  `)
+  `);
   // await execFQL("Collection.create({ name: 'hi' })")
-  const respColls = await execPaginated("Collection.all() { name }")
+  const respColls = await execPaginated("Collection.all() { name }");
   if (!Array.isArray(respColls) || respColls.length != 0) {
-    throw new Error(`Expected empty collection set. ${respColls}`)
+    throw new Error(`Expected empty collection set. ${respColls}`);
   }
-  const respFunctions = await execPaginated("Function.all() { name }")
+  const respFunctions = await execPaginated("Function.all() { name }");
   if (!Array.isArray(respFunctions) || respFunctions.length != 0) {
-    throw new Error(`Expected empty function set. ${resp}`)
+    throw new Error(`Expected empty function set. ${resp}`);
   }
 }
 
 /**
-  * The provided cmd must be an array where each string you want to show up
-  * in the shell is an element.
-  * ex: execFaunaCmd(["schema", "diff"])
-  */
+ * The provided cmd must be an array where each string you want to show up
+ * in the shell is an element.
+ * ex: execFaunaCmd(["schema", "diff"])
+ */
 async function execFaunaCmd(cmd) {
   if (secretFlag) {
-    return $`${faunaCmd} ${cmd} --secret ${secretFlag}`
+    return $`${faunaCmd} ${cmd} --secret ${secretFlag}`;
   } else {
-    return $`${faunaCmd} ${cmd}`
+    return $`${faunaCmd} ${cmd}`;
   }
 }
 
 async function execPaginated(fql) {
-  const resp = await execFQL(fql)
-  return resp?.data
+  const resp = await execFQL(fql);
+  return resp?.data;
 }
 
 async function execFQL(fql) {
-  const resp = secretFlag ? await $`${faunaCmd} eval ${fql} --format=json --secret ${secretFlag}` : await $`${faunaCmd} eval ${fql} --format=json`
-  const respParsed = JSON.parse(resp._stdout)
-  return respParsed
+  const resp = secretFlag
+    ? await $`${faunaCmd} eval ${fql} --format=json --secret ${secretFlag}`
+    : await $`${faunaCmd} eval ${fql} --format=json`;
+  const respParsed = JSON.parse(resp._stdout);
+  return respParsed;
 }

--- a/src/commands/schema/push.ts
+++ b/src/commands/schema/push.ts
@@ -44,8 +44,6 @@ export default class PushSchemaCommand extends SchemaCommand {
           method: "POST",
           headers: { AUTHORIZATION: `Bearer ${secret}` },
           body: this.body(files),
-          // @ts-expect-error-next-line
-          duplex: "half",
         });
         const json = await res.json();
         if (json.error) {

--- a/src/lib/schema-command.ts
+++ b/src/lib/schema-command.ts
@@ -59,15 +59,11 @@ export default abstract class SchemaCommand extends FaunaCommand {
   // Helper to construct form data for a collection of files, as
   // returned by `gather`.
   body(files: File[]) {
-    const fd: Record<string, string> = {};
+    const fd = new FormData();
     for (const file of files) {
-      fd[file.name] = file.content.toString();
+      fd.set(file.name, new Blob([file.content]));
     }
-    const Readable = require("stream").Readable;
-    const s = new Readable();
-    s.push(JSON.stringify(fd));
-    s.push(null);
-    return s;
+    return fd;
   }
 
   // Reads the files using their relative-to-`basedir` paths and returns their


### PR DESCRIPTION
Ticket(s): FE-5644

## Problem

Schema tests run in the pipeline (but not in CircleCI). They failed: https://concourse.faunadb.net/teams/devex/pipelines/fauna-shell-release/jobs/test/builds/22

## Solution

Schema endpoint expects `Content-Type: multipart/form-data`. We had that in place before, but swept through and updated all `fetch` calls to use ReadableStream. Just needed to revert back to FormData for the Schema portion.

Also applied some `prettier` to the schema test file


## Result


```bash
➜  fsl git:(schema-test-fix) ✗ ./test-script.mjs ~/workplace/fauna-shell/bin/run
Schema tests run successfully!
```
