### PR TITLE
update release pipeline to use node 18

### DIFF
--- a/concourse/tasks/publish.yml
+++ b/concourse/tasks/publish.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: node
-    tag: 16.14.2-alpine3.14
+    tag: 18-alpine
 
 params:
   NPM_TOKEN:


### PR DESCRIPTION
Ticket(s): FE-5644

NPM Update pipeline step was still depending on node 16 image. This upgrades it to node 18