### PR TITLE
use builtin header for scoped v4 clients

### DIFF
--- a/src/lib/fauna-command.js
+++ b/src/lib/fauna-command.js
@@ -214,9 +214,7 @@ class FaunaCommand extends Command {
         // See getClient.
         fetch: fetch,
 
-        headers: {
-          "X-Fauna-Source": "Fauna Shell",
-        },
+        headers: this._getHeaders(),
       });
       const exists = await client.query(q.Exists(q.Database(path[i])));
       await client.close();

--- a/test/commands/keys.test.js
+++ b/test/commands/keys.test.js
@@ -140,6 +140,7 @@ function mockCreateKey(api, { role }) {
       const authParsed = this.req.headers.authorization
         .split(" ")[1]
         .split(":");
+      expect(this.req.headers["x-fauna-shell-builtin"]).to.equal("true");
       const allowedRoles = ["admin", "server", "server-readonly", "client"];
       if (allowedRoles.includes(role)) {
         return [


### PR DESCRIPTION
Ticket(s): FE-5698

## Problem
* scoped v4 clients weren't getting the "builtin" header

## Solution
* use the `getHeaders()` function from the other places we build a v4 client

## Result
* all methods of building a v4 client employ the "x-fauna-shell-builtin" header check
```bash
➜  fauna-shell git:(createkey-fix) ✗ node bin/run create-key made_in_v4
Connected to endpoint: devlocal-us
Connected to endpoint: devlocal-us database: made_in_v4
creating key for database 'made_in_v4' with role 'admin'

  created key for database 'made_in_v4' with role 'admin'.
  secret: <redacted>

  To access 'made_in_v4' with this key, create a client using
  the driver library for your language of choice using
  the above secret.
```

## Testing
* `create-key` is one command that uses scoped clients. Updated the `mockCreateKey` method there to expect the `builtin` header.

![Screenshot 2024-08-05 at 1 24 18 PM](https://github.com/user-attachments/assets/4d9b0f1c-8c90-4c52-a193-f67350f854c3)