### PR TITLE
Don't run code coverage in local dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "yarn build && oclif manifest",
     "pretest": "yarn fixlint",
-    "local-test": "export $(cat .env | xargs); c8 -r text mocha --forbid-only \"test/**/*.test.{js,ts}\"",
+    "local-test": "export $(cat .env | xargs); mocha \"test/**/*.test.{js,ts}\"",
     "test": "export $(cat .env.test | xargs); c8 -r html mocha --forbid-only \"test/**/*.test.{js,ts}\"",
     "lint": "eslint .",
     "fixlint": "eslint . --fix",


### PR DESCRIPTION
Ticket(s): FE-###

I'd like to use `it.only` in local development, and I don't have `c8` installed, so I'd just like to call mocha directly.
