### PR TITLE
Add fauna schema status

### DIFF
--- a/src/commands/schema/status.ts
+++ b/src/commands/schema/status.ts
@@ -1,0 +1,37 @@
+import SchemaCommand from "../../lib/schema-command";
+
+export default class StatusSchemaCommand extends SchemaCommand {
+  static flags = {
+    ...SchemaCommand.flags,
+  };
+
+  static description = "Print the staged schema status.";
+  static examples = ["$ fauna schema status"];
+
+  async run() {
+    try {
+      const { url, secret } = await this.fetchsetup();
+      const res = await fetch(
+        new URL("/schema/1/staged/status?diff=true", url),
+        {
+          method: "GET",
+          headers: { AUTHORIZATION: `Bearer ${secret}` },
+          // https://github.com/nodejs/node/issues/46221
+          // https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1483
+          // @ts-expect-error-next-line
+          duplex: "half",
+        }
+      );
+
+      const json = await res.json();
+      if (json.error) {
+        this.error(json.error.message);
+      }
+
+      this.log(json.diff);
+    } catch (err) {
+      console.log(err);
+      this.error(err);
+    }
+  }
+}

--- a/test/commands/schema.test.js
+++ b/test/commands/schema.test.js
@@ -99,6 +99,25 @@ describe("fauna schema push test", () => {
     // Restore the stub after the test
     stubConfirm.restore();
   });
+
+  it("runs schema status", async () => {
+    nock(getEndpoint(), { allowUnmocked: false })
+      .persist()
+      .post("/", matchFqlReq(q.Now()))
+      .reply(200, new Date())
+      .get("/schema/1/staged/status?diff=true")
+      .reply(200, {
+        version: 0,
+        status: "ready",
+        diff: diff.diff,
+      });
+
+    // Stubbing the confirmation to always return true
+    const { stdout } = await runCommand(
+      withOpts(["schema status", "--dir=test/testdata"])
+    );
+    expect(stdout).to.contain(`${diff.diff}`);
+  });
 });
 
 const testdir = "test/testdata";

--- a/test/integ/schema.test.ts
+++ b/test/integ/schema.test.ts
@@ -51,4 +51,57 @@ describe.skip("fauna schema staged commands", () => {
       )
     ).to.deep.equal(null);
   });
+
+  const status = async (secret: string) => {
+    const output = await shellOk("fauna schema status --dir .", secret);
+
+    // Remove the "Connected to endpoint" line.
+    return output.split("\n").slice(1).join("\n");
+  };
+
+  it("fauna schema status works", async () => {
+    const secret = await newDB();
+
+    await shellOk(
+      "fauna schema push --dir test/integ/schema/start --force",
+      secret
+    );
+
+    expect(await status(secret)).to.equal(
+      stripMargin(
+        `|Status: none
+         |`
+      )
+    );
+
+    await shellOk(
+      "fauna schema push --dir test/integ/schema/staged_index --force --stage",
+      secret
+    );
+
+    expect(await status(secret)).to.equal(
+      stripMargin(
+        `|Status: ready
+         |The schema is ready to be committed.
+         |
+         |Staged changes:
+         |* Modifying collection \`User\` at 0:90/main.fsl:
+         |  * Summary:
+         |    + added: index \`byName\` (see diff)
+         |
+         |  * Diff:
+         |      collection User {
+         |        name: String
+         |        email: String
+         |    +
+         |    +   index byName {
+         |    +     terms [.name]
+         |    +   }
+         |      }
+         |
+         |
+         |`
+      )
+    );
+  });
 });


### PR DESCRIPTION
Ticket(s): ENG-6711

Adds `fauna schema status`, which shows the current staged status for a database.

This accepts a `--dir` option, so that it'll integrate with the other project management stuff.
