### PR TITLE
Stop writing an empty config file

### DIFF
--- a/src/commands/project/init.ts
+++ b/src/commands/project/init.ts
@@ -4,7 +4,6 @@ import fs from "fs";
 import * as path from "path";
 import {
   PROJECT_FILE_NAME,
-  ProjectConfig,
   ShellConfig,
   fileExists,
   getProjectConfigPath,

--- a/src/commands/project/init.ts
+++ b/src/commands/project/init.ts
@@ -74,8 +74,6 @@ export class ProjectInitCommand extends Command {
       );
     }
 
-    ProjectConfig.initialConfig(schemaDir).save(projectPath);
-
     const shellConfig = ShellConfig.readWithOverrides({
       projectPath: projectPath,
     });

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -179,9 +179,7 @@ export class ShellConfig {
     const rootConfig =
       opts?.rootConfig ?? ini.parse(readFileOpt(getRootConfigPath()));
     const projectConfigPath = opts?.projectPath ?? getProjectConfigPath();
-    const projectConfig =
-      opts?.projectConfig ??
-      (projectConfigPath ? ini.parse(readFile(projectConfigPath)) : undefined);
+    const projectConfig = opts?.projectConfig ?? {};
 
     return new ShellConfig({
       rootConfig,


### PR DESCRIPTION
Ticket(s): ENG-6776

Right now, we do the following in `fauna project init`:
- Write an empty config file
- Read it back
- Ask the user some questions
- Write the real config file

This means if you press ctrl+c during those questions, you'll be left in a broken state, and you'll need to delete and re-create the `.fauna-project` file.
