### PR TITLE
New shell login setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "inquirer": "^8.1.1",
     "moment": "^2.29.1",
     "object-sizeof": "^1.6.1",
+    "open": "8.4.2",
     "prettier": "^2.3.0",
     "rate-limiter-flexible": "^2.3.6",
     "stream-json": "^1.7.3"

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "yarn build && oclif manifest",
     "pretest": "yarn fixlint",
+    "local": "export $(cat .env | xargs); node bin/run",
     "local-test": "export $(cat .env | xargs); c8 -r text mocha --forbid-only \"test/**/*.test.{js,ts}\"",
     "test": "export $(cat .env.test | xargs); c8 -r html mocha --forbid-only \"test/**/*.test.{js,ts}\"",
     "lint": "eslint .",

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -41,12 +41,14 @@ export default class LoginCommand extends Command {
 
     const oAuth = new OAuthServer();
     await oAuth.start();
-    const dashboardOAuthURL = (await fetch(oAuth.getRequestUrl())).url;
-    const error = new URL(dashboardOAuthURL).searchParams.get("error");
-    if (error) {
-      throw new Error(`Error during login: ${error}`);
-    }
-    this.log(`To login, open your browser to:\n ${dashboardOAuthURL}`);
+    oAuth.server.on("ready", async () => {
+      const dashboardOAuthURL = (await fetch(oAuth.getRequestUrl())).url;
+      const error = new URL(dashboardOAuthURL).searchParams.get("error");
+      if (error) {
+        throw new Error(`Error during login: ${error}`);
+      }
+      this.log(`To login, open your browser to:\n ${dashboardOAuthURL}`);
+    });
     oAuth.server.on("auth_code_received", async () => {
       try {
         const tokenResponse = await oAuth.getToken();

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -37,7 +37,6 @@ export default class LoginCommand extends Command {
   }
 
   async execute() {
-    await this.parse();
 
     const oAuth = new OAuthServer();
     await oAuth.start();

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -9,7 +9,7 @@ type AccessToken = {
 };
 
 export default class LoginCommand extends Command {
-  static description = "Log in to a Fauna account.";
+  static description = "Login to your Fauna account.";
   static examples = ["$ fauna login"];
   static flags = {};
 

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,16 +1,5 @@
-import { input, confirm, password } from "@inquirer/prompts";
-import { ShellConfig } from "../lib/config";
-import { hostname } from "os";
 import { Command } from "@oclif/core";
-import { underline, blue } from "chalk";
 import OAuthServer from "../lib/auth/oauth-client";
-
-const DEFAULT_NAME = "cloud";
-const AUTH = process.env.FAUNA_AUTH ?? "https://auth.console.fauna.com";
-
-type Regions = {
-  [key: string]: Region;
-};
 
 type AccessToken = {
   access_token: string;
@@ -18,20 +7,6 @@ type AccessToken = {
   ttl: string;
   state: string;
 };
-
-class Region {
-  name: string;
-  secret: string;
-
-  constructor(name: string, secret: string) {
-    this.name = name;
-    this.secret = secret;
-  }
-
-  endpointName(base: string) {
-    return `${base}-${this.name}`;
-  }
-}
 
 // const DASHBOARD_URL = "http://localhost:3005/login";
 
@@ -64,15 +39,10 @@ export default class LoginCommand extends Command {
   async execute() {
     await this.parse();
 
-    // const { port } = await startOAuthClient();
     const oAuth = new OAuthServer();
-    await oAuth.start();
-    // TODO: from within our local server, do a GET to frontdoor and receive
-    // the redirect url to the dashboard w/ ?request= then tell them to open that.
     const authUrl = (await fetch(oAuth.getRequestUrl())).url;
-    this.log(`To login, press Enter or open your browser to:\n ${authUrl}`);
-    const { default: open } = await import("open");
-    open(authUrl);
+    await oAuth.start();
+    this.log(`To login, open your browser to:\n ${authUrl}`);
     oAuth.server.on("auth_code_received", async () => {
       try {
         const token: AccessToken = await (await oAuth.getToken()).json();
@@ -87,136 +57,5 @@ export default class LoginCommand extends Command {
         console.error(err);
       }
     });
-
-    // const base = await this.askName(config);
-    // const regions = await this.passwordStrategy();
-    // const newDefault = await this.askDefault(config, base, regions);
-
-    // for (const region of Object.values(regions)) {
-    //   config.rootConfig.endpoints[region.endpointName(base)] = new Endpoint({
-    //     url: DB,
-    //     secret: Secret.parse(region.secret),
-    //   });
-    // }
-
-    // config.rootConfig.defaultEndpoint = newDefault;
-    // config.saveRootConfig();
-
-    // this.log("Configuration updated.");
-  }
-
-  async askName(config: ShellConfig): Promise<string> {
-    const name = await input({
-      message: "Endpoint name",
-      default: DEFAULT_NAME,
-      validate: (endpoint: string) =>
-        endpoint === "" ? "Provide an endpoint name." : true,
-    });
-
-    if (config.rootConfig.endpoints[name] !== undefined) {
-      const confirmed = await confirm({
-        message: `The endpoint ${name} already exists. Overwrite?`,
-        default: false,
-      });
-      if (!confirmed) {
-        return this.askName(config);
-      }
-    }
-
-    return name;
-  }
-
-  async passwordStrategy(): Promise<Regions> {
-    return this.loginByPassword({
-      email: await input({
-        message: `Email address (from ${underline(
-          blue("https://dashboard.fauna.com/")
-        )})`,
-        validate: (email) => {
-          return !email || !/\S+@\S+\.\S+/.test(email)
-            ? "Provide a valid email address."
-            : true;
-        },
-      }),
-      password: await password({
-        message: "Password",
-        mask: true,
-      }),
-    });
-  }
-
-  async otp({
-    email,
-    password,
-  }: {
-    email: string;
-    password: string;
-  }): Promise<Regions> {
-    const otp = await input({
-      message: "Enter your multi-factor authentication code",
-    });
-
-    return this.loginByPassword({
-      email,
-      password,
-      otp,
-    });
-  }
-
-  async handlePasswordStrategyError({
-    email,
-    password,
-    error,
-  }: {
-    email: string;
-    password: string;
-    error: any;
-  }): Promise<Regions> {
-    if (["otp_required", "otp_invalid"].includes(error.code)) {
-      if (error.code === "otp_invalid") {
-        this.log(error.message);
-      }
-      return this.otp({ email, password });
-    }
-
-    if (error.code === "invalid_credentials") {
-      this.log(error.message);
-      return this.passwordStrategy();
-    }
-
-    throw error;
-  }
-
-  async loginByPassword({
-    email,
-    password,
-    otp,
-  }: {
-    email: string;
-    password: string;
-    otp?: string;
-  }): Promise<Regions> {
-    const resp = await fetch(new URL("login", AUTH), {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        email,
-        password,
-        type: "shell",
-        session: "Fauna Shell - " + hostname(),
-        ...(otp && { otp }),
-      }),
-    });
-    const json = await resp.json();
-    if (resp.ok) {
-      return Object.fromEntries(
-        Object.entries(json.regionGroups).map(([key, v]) => [
-          key,
-          new Region(key, (v as any).secret),
-        ])
-      );
-    } else {
-      return this.handlePasswordStrategyError({ email, password, error: json });
-    }
   }
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,0 +1,222 @@
+import { input, confirm, password } from "@inquirer/prompts";
+import { ShellConfig } from "../lib/config";
+import { hostname } from "os";
+import { Command } from "@oclif/core";
+import { underline, blue } from "chalk";
+import OAuthServer from "../lib/auth/oauth-client";
+
+const DEFAULT_NAME = "cloud";
+const AUTH = process.env.FAUNA_AUTH ?? "https://auth.console.fauna.com";
+
+type Regions = {
+  [key: string]: Region;
+};
+
+type AccessToken = {
+  access_token: string;
+  token_type: string;
+  ttl: string;
+  state: string;
+};
+
+class Region {
+  name: string;
+  secret: string;
+
+  constructor(name: string, secret: string) {
+    this.name = name;
+    this.secret = secret;
+  }
+
+  endpointName(base: string) {
+    return `${base}-${this.name}`;
+  }
+}
+
+// const DASHBOARD_URL = "http://localhost:3005/login";
+
+export default class LoginCommand extends Command {
+  static description = "Log in to a Fauna account.";
+  static examples = ["$ fauna login"];
+  static flags = {};
+
+  async run() {
+    await this.execute();
+  }
+
+  async getSession(access_token: string) {
+    const myHeaders = new Headers();
+    myHeaders.append("Authorization", `Bearer ${access_token}`);
+
+    const requestOptions = {
+      method: "POST",
+      headers: myHeaders,
+    };
+
+    const response = await fetch(
+      "http://localhost:8000/api/v1/session",
+      requestOptions
+    );
+    const session = await response.json();
+    return session;
+  }
+
+  async execute() {
+    await this.parse();
+
+    // const { port } = await startOAuthClient();
+    const oAuth = new OAuthServer();
+    await oAuth.start();
+    // TODO: from within our local server, do a GET to frontdoor and receive
+    // the redirect url to the dashboard w/ ?request= then tell them to open that.
+    const authUrl = (await fetch(oAuth.getRequestUrl())).url;
+    this.log(`To login, press Enter or open your browser to:\n ${authUrl}`);
+    const { default: open } = await import("open");
+    open(authUrl);
+    oAuth.server.on("auth_code_received", async () => {
+      try {
+        const token: AccessToken = await (await oAuth.getToken()).json();
+        this.log("Authentication successful!");
+        const { state, ttl, access_token, token_type } = token;
+        if (state !== oAuth.state) {
+          throw new Error("Error during login: invalid state.");
+        }
+        const session = await this.getSession(access_token);
+        this.log("Session created:", session);
+      } catch (err) {
+        console.error(err);
+      }
+    });
+
+    // const base = await this.askName(config);
+    // const regions = await this.passwordStrategy();
+    // const newDefault = await this.askDefault(config, base, regions);
+
+    // for (const region of Object.values(regions)) {
+    //   config.rootConfig.endpoints[region.endpointName(base)] = new Endpoint({
+    //     url: DB,
+    //     secret: Secret.parse(region.secret),
+    //   });
+    // }
+
+    // config.rootConfig.defaultEndpoint = newDefault;
+    // config.saveRootConfig();
+
+    // this.log("Configuration updated.");
+  }
+
+  async askName(config: ShellConfig): Promise<string> {
+    const name = await input({
+      message: "Endpoint name",
+      default: DEFAULT_NAME,
+      validate: (endpoint: string) =>
+        endpoint === "" ? "Provide an endpoint name." : true,
+    });
+
+    if (config.rootConfig.endpoints[name] !== undefined) {
+      const confirmed = await confirm({
+        message: `The endpoint ${name} already exists. Overwrite?`,
+        default: false,
+      });
+      if (!confirmed) {
+        return this.askName(config);
+      }
+    }
+
+    return name;
+  }
+
+  async passwordStrategy(): Promise<Regions> {
+    return this.loginByPassword({
+      email: await input({
+        message: `Email address (from ${underline(
+          blue("https://dashboard.fauna.com/")
+        )})`,
+        validate: (email) => {
+          return !email || !/\S+@\S+\.\S+/.test(email)
+            ? "Provide a valid email address."
+            : true;
+        },
+      }),
+      password: await password({
+        message: "Password",
+        mask: true,
+      }),
+    });
+  }
+
+  async otp({
+    email,
+    password,
+  }: {
+    email: string;
+    password: string;
+  }): Promise<Regions> {
+    const otp = await input({
+      message: "Enter your multi-factor authentication code",
+    });
+
+    return this.loginByPassword({
+      email,
+      password,
+      otp,
+    });
+  }
+
+  async handlePasswordStrategyError({
+    email,
+    password,
+    error,
+  }: {
+    email: string;
+    password: string;
+    error: any;
+  }): Promise<Regions> {
+    if (["otp_required", "otp_invalid"].includes(error.code)) {
+      if (error.code === "otp_invalid") {
+        this.log(error.message);
+      }
+      return this.otp({ email, password });
+    }
+
+    if (error.code === "invalid_credentials") {
+      this.log(error.message);
+      return this.passwordStrategy();
+    }
+
+    throw error;
+  }
+
+  async loginByPassword({
+    email,
+    password,
+    otp,
+  }: {
+    email: string;
+    password: string;
+    otp?: string;
+  }): Promise<Regions> {
+    const resp = await fetch(new URL("login", AUTH), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email,
+        password,
+        type: "shell",
+        session: "Fauna Shell - " + hostname(),
+        ...(otp && { otp }),
+      }),
+    });
+    const json = await resp.json();
+    if (resp.ok) {
+      return Object.fromEntries(
+        Object.entries(json.regionGroups).map(([key, v]) => [
+          key,
+          new Region(key, (v as any).secret),
+        ])
+      );
+    } else {
+      return this.handlePasswordStrategyError({ email, password, error: json });
+    }
+  }
+}

--- a/src/lib/auth/oauth-client.ts
+++ b/src/lib/auth/oauth-client.ts
@@ -50,6 +50,9 @@ class OAuthClient {
   }
 
   public getToken() {
+    const now = new Date();
+    // Short expiry for access token as it's only used to create a session
+    now.setUTCMinutes(now.getUTCMinutes() + 10);
     const params = {
       grant_type: "authorization_code",
       client_id: clientId,
@@ -57,7 +60,7 @@ class OAuthClient {
       code: this.auth_code,
       redirect_uri: `${redirectUri}:${this.port}`,
       code_verifier: this.code_verifier,
-      ttl: "2024-09-17T00:00:00.00Z",
+      ttl: now.toISOString(),
     };
     return fetch(`${frontdoorURL}/token`, {
       method: "POST",

--- a/src/lib/auth/oauth-client.ts
+++ b/src/lib/auth/oauth-client.ts
@@ -38,7 +38,6 @@ class OAuthClient {
   public getRequestUrl() {
     const params = {
       client_id: clientId,
-      client_secret: clientSecret,
       redirect_uri: `${redirectUri}:${this.port}`,
       code_challenge: this.code_challenge,
       code_challenge_method: "S256",

--- a/src/lib/auth/oauth-client.ts
+++ b/src/lib/auth/oauth-client.ts
@@ -1,0 +1,161 @@
+import http, { IncomingMessage, ServerResponse } from "http";
+const { randomBytes, createHash } = require("node:crypto");
+import url from "url";
+import net from "net";
+
+// env var
+const dashboardURL = "http://localhost:3005/authorize/complete";
+// env var
+const frontdoorURL = "http://localhost:8000/api/v1/oauth";
+// env var
+const clientId = "Gj6wAqni5MS0U72qfcGjh9pS8+U=";
+const clientSecret = "5kXhq2MrHLPF4iV5aPC5PRnGrCNhnRUsV6C8gtlj8PtkIJINR5Je2A==";
+const redirectUri = `http://127.0.0.1`;
+
+class OAuthClient {
+  public server: http.Server;
+  public port: number;
+  private code_verifier: string;
+  private code_challenge: string;
+  private auth_code: string;
+  public state: string;
+
+  constructor() {
+    this.server = http.createServer(this.handleRequest.bind(this));
+    this.code_verifier = Buffer.from(randomBytes(20)).toString("base64url");
+    this.code_challenge = createHash("sha256")
+      .update(this.code_verifier)
+      .digest("base64url");
+    this.port = 0;
+    this.auth_code = "";
+    this.state = this.generateCSRFToken();
+  }
+
+  private generateCSRFToken(): string {
+    return Buffer.from(randomBytes(20)).toString("base64url");
+  }
+
+  public getRequestUrl() {
+    const params = {
+      client_id: clientId,
+      client_secret: clientSecret,
+      redirect_uri: `${redirectUri}:${this.port}`,
+      code_challenge: this.code_challenge,
+      code_challenge_method: "S256",
+      response_type: "code",
+      scope: "create_session",
+      state: this.state,
+    };
+    return `${frontdoorURL}/authorize?${new URLSearchParams(params)}`;
+  }
+
+  public getToken() {
+    const params = {
+      grant_type: "authorization_code",
+      client_id: clientId,
+      client_secret: clientSecret,
+      code: this.auth_code,
+      redirect_uri: `${redirectUri}:${this.port}`,
+      code_verifier: this.code_verifier,
+      ttl: "2024-09-17T00:00:00.00Z",
+    };
+    return fetch(`${frontdoorURL}/token`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams(params),
+    });
+  }
+
+  private handleRequest(req: IncomingMessage, res: ServerResponse) {
+    const allowedOrigins = [
+      "http://localhost:3005",
+      "http://127.0.0.1:3005",
+      "http://dashboard.fauna.com",
+      "http://dashboard.fauna-dev.com",
+      "http://dashboard.fauna-preview.com",
+    ];
+    const origin = req.headers.origin || "";
+
+    if (allowedOrigins.includes(origin)) {
+      res.setHeader("Access-Control-Allow-Origin", origin);
+      res.setHeader("Access-Control-Allow-Methods", "GET");
+      res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+    }
+
+    if (req.method === "GET") {
+      const parsedUrl = url.parse(req.url || "", true);
+      if (parsedUrl.pathname !== "/") {
+        console.error("Error while retrieving authorization code! Try again.");
+        this.closeServer();
+      }
+      const query = parsedUrl.query;
+      if (query.error) {
+        console.error("Error returned from server:", query.error);
+        this.closeServer();
+      }
+      if (query.code) {
+        const authCode = query.code;
+        if (!authCode || typeof authCode !== "string") {
+          console.error("Invalid authorization code returned from server");
+          this.server.close();
+        } else {
+          this.auth_code = authCode;
+          if (query.state !== this.state) {
+            console.error("Invalid state returned from server");
+            this.closeServer();
+          }
+          // Send them to a nice page that shows auth is complete and they can close the window.
+          res.writeHead(301, { Location: dashboardURL });
+          res.end();
+          this.server.emit("auth_code_received");
+          this.closeServer();
+        }
+      }
+    } else {
+      console.error("Error while retrieving authorization code! Try again.");
+      this.closeServer();
+    }
+  }
+
+  private isPortAvailable(port: number): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      const tester = net
+        .createServer()
+        .once("error", (err: any) =>
+          err.code === "EADDRINUSE" ? resolve(false) : reject(err)
+        )
+        .once("listening", () =>
+          tester.once("close", () => resolve(true)).close()
+        )
+        .listen(port);
+    });
+  }
+
+  public async start() {
+    let port: number;
+    let isAvailable: boolean = false;
+
+    // Loop until an available port is found
+    do {
+      port = Math.floor(Math.random() * (63000 - 62500 + 1)) + 62500;
+      isAvailable = await this.isPortAvailable(port);
+    } while (!isAvailable);
+
+    this.port = port;
+
+    this.server.listen(port, () => {
+      // console.log(`Server is listening on port ${port}`);
+    });
+
+    return { server: this.server, port };
+  }
+
+  public closeServer() {
+    this.server.closeAllConnections();
+    this.server.close();
+  }
+}
+
+export default OAuthClient;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2703,6 +2703,11 @@ define-data-property@^1.1.4:
     es-errors "^1.3.0"
     gopd "^1.0.1"
 
+define-lazy-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
+  integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
+
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
@@ -3898,7 +3903,7 @@ is-core-module@^2.13.0, is-core-module@^2.5.0, is-core-module@^2.8.1:
   dependencies:
     hasown "^2.0.2"
 
-is-docker@^2.0.0:
+is-docker@^2.0.0, is-docker@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
   integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
@@ -5472,6 +5477,15 @@ onetime@^5.1.0, onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+open@8.4.2:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-8.4.2.tgz#5b5ffe2a8f793dcd2aad73e550cb87b59cb084f9"
+  integrity sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==
+  dependencies:
+    define-lazy-prop "^2.0.0"
+    is-docker "^2.1.1"
+    is-wsl "^2.2.0"
 
 optionator@^0.8.1:
   version "0.8.3"


### PR DESCRIPTION
Ticket(s): FE-5879

* Basic interface to call frontdoor auth code, token and session endpoints. 
* Only works locally as frontdoor only knows about the local client id.
* Fails if `new_session_tokens` is not turned on

### Out of Scope

In another PR i'll break some of this out to a new frontdoor client where I can add unit tests and other methods like refresh session

https://github.com/user-attachments/assets/4826c457-50f4-4044-a671-601beff799f8

