### PR TITLE
Add fauna schema pull --staged

### DIFF
--- a/src/commands/schema/push.ts
+++ b/src/commands/schema/push.ts
@@ -10,7 +10,7 @@ export default class PushSchemaCommand extends SchemaCommand {
       description: "Push the change without a diff or schema version check",
       default: false,
     }),
-    stage: Flags.boolean({
+    staged: Flags.boolean({
       description:
         "Stages the schema change, instead of applying it immediately",
       default: false,
@@ -22,7 +22,7 @@ export default class PushSchemaCommand extends SchemaCommand {
   static examples = [
     "$ fauna schema push",
     "$ fauna schema push --dir schemas/myschema",
-    "$ fauna schema push --stage",
+    "$ fauna schema push --staged",
   ];
 
   async run() {
@@ -33,7 +33,7 @@ export default class PushSchemaCommand extends SchemaCommand {
       if (this.flags?.force) {
         const params = new URLSearchParams({
           force: "true", // Just push.
-          staged: this.flags?.stage ? "true" : "false",
+          staged: this.flags?.staged ? "true" : "false",
         });
 
         // This is how MDN says to do it for some reason.
@@ -88,7 +88,7 @@ export default class PushSchemaCommand extends SchemaCommand {
         if (confirmed) {
           const params = new URLSearchParams({
             version: json.version,
-            staged: this.flags?.stage ? "true" : "false",
+            staged: this.flags?.staged ? "true" : "false",
           });
 
           const path = new URL(`/schema/1/update?${params}`, url);

--- a/test/commands/schema.test.ts
+++ b/test/commands/schema.test.ts
@@ -85,20 +85,20 @@ describe("fauna schema push test", () => {
     stubConfirm.restore();
   });
 
-  it("runs schema push --stage", async () => {
+  it("runs schema push --staged", async () => {
     nock(getEndpoint(), { allowUnmocked: false })
       .persist()
       .post("/", matchFqlReq(query.Now()))
       .reply(200, new Date())
       .post("/schema/1/validate?force=true")
       .reply(200, diff)
-      .post("/schema/1/update?version=0&stage=true")
+      .post("/schema/1/update?version=0&staged=true")
       .reply(200, updated);
 
     // Stubbing the confirmation to always return true
     const stubConfirm = sinon.stub(inquirer, "confirm").resolves(true);
     const { stdout } = await runCommand(
-      withOpts(["schema push", "--dir=test/testdata", "--stage"])
+      withOpts(["schema push", "--dir=test/testdata", "--staged"])
     );
     expect(stdout).to.contain(`${diff.diff}`);
     // Restore the stub after the test

--- a/test/commands/schema.test.ts
+++ b/test/commands/schema.test.ts
@@ -256,6 +256,8 @@ describe(`fauna schema pull`, () => {
         .reply(200, new Date())
         .get("/schema/1/files")
         .reply(200, pullfiles)
+        .get("/schema/1/staged/status?version=0")
+        .reply(200, { status: "none" })
         .get("/schema/1/files/functions.fsl")
         .reply(200, functions)
         .get("/schema/1/files/main.fsl")
@@ -305,4 +307,93 @@ describe(`fauna schema pull`, () => {
       stubConfirm.restore();
     });
   }
+
+  it(`requires --staged when there's a staged schema`, async () => {
+    const stubConfirm = sinon.stub(inquirer, "confirm").resolves(true);
+
+    nock(getEndpoint(), { allowUnmocked: false })
+      .persist()
+      .post("/", matchFqlReq(query.Now()))
+      .reply(200, new Date())
+      .get("/schema/1/files")
+      .reply(200, pullfiles)
+      .get("/schema/1/staged/status?version=0")
+      .reply(200, { status: "ready" });
+
+    const { error } = await runCommand(
+      withOpts(["schema pull", `--dir=${testdir}`])
+    );
+    expect(error?.message).to.equal(
+      "There is a staged schema change. Use --staged to pull it."
+    );
+
+    stubConfirm.restore();
+  });
+
+  it(`disallows --staged when there's no staged schema`, async () => {
+    const stubConfirm = sinon.stub(inquirer, "confirm").resolves(true);
+
+    nock(getEndpoint(), { allowUnmocked: false })
+      .persist()
+      .post("/", matchFqlReq(query.Now()))
+      .reply(200, new Date())
+      .get("/schema/1/files")
+      .reply(200, pullfiles)
+      .get("/schema/1/staged/status?version=0")
+      .reply(200, { status: "none" });
+
+    const { error } = await runCommand(
+      withOpts(["schema pull", `--dir=${testdir}`, `--staged`])
+    );
+    expect(error?.message).to.equal(
+      "There are no staged schema changes to pull."
+    );
+
+    stubConfirm.restore();
+  });
+
+  it(`runs schema pull --staged`, async () => {
+    const stubConfirm = sinon.stub(inquirer, "confirm").resolves(true);
+
+    nock(getEndpoint(), { allowUnmocked: false })
+      .persist()
+      .post("/", matchFqlReq(query.Now()))
+      .reply(200, new Date())
+      .get("/schema/1/files")
+      .reply(200, pullfiles)
+      .get("/schema/1/staged/status?version=0")
+      .reply(200, { status: "ready" })
+      .get("/schema/1/files/functions.fsl")
+      .reply(200, functions)
+      .get("/schema/1/files/main.fsl")
+      .reply(200, main)
+      .get("/schema/1/files/roles%2Fmyrole.fsl")
+      .reply(200, myrole);
+
+    // This should work as normal.
+    const { stdout } = await runCommand(
+      withOpts(["schema pull", `--dir=${testdir}`, `--staged`])
+    );
+    expect(stdout).to.contain("Pull makes the following changes:");
+    expect(
+      fs.readFileSync(path.join(testdir, "functions.fsl"), "utf8")
+    ).to.equal(functions.content);
+    expect(fs.readFileSync(path.join(testdir, "main.fsl"), "utf8")).to.equal(
+      main.content
+    );
+    expect(
+      fs.readFileSync(path.join(testdir, "roles", "myrole.fsl"), "utf8")
+    ).to.equal(myrole.content);
+    expect(fs.statSync(path.join(testdir, "no.fsl")).isDirectory()).to.equal(
+      true
+    );
+    expect(fs.statSync(path.join(testdir, "nofsl")).isDirectory()).to.equal(
+      true
+    );
+    expect(fs.statSync(path.join(testdir, "main.notfsl")).isFile()).to.equal(
+      true
+    );
+
+    stubConfirm.restore();
+  });
 });


### PR DESCRIPTION
Ticket(s): ENG-6786

Adds `--staged` to `fauna schema pull`, which is required when there is a staged schema, and disallowed when there is no staged schema.
