### PR TITLE
Add fauna schema diff --active

### DIFF
--- a/src/commands/schema/diff.ts
+++ b/src/commands/schema/diff.ts
@@ -1,9 +1,14 @@
 import SchemaCommand from "../../lib/schema-command";
-import { colorParam, hasColor } from "../../lib/color";
+import { bold, colorParam, hasColor, reset } from "../../lib/color";
+import { Flags } from "@oclif/core";
 
 export default class DiffSchemaCommand extends SchemaCommand {
   static flags = {
     ...SchemaCommand.flags,
+    active: Flags.boolean({
+      description: "Compare the local schema to the active schema.",
+      default: false,
+    }),
   };
 
   static description = "Print the diff between local and remote schema.";
@@ -15,24 +20,70 @@ export default class DiffSchemaCommand extends SchemaCommand {
   async run() {
     const fps = this.gatherRelativeFSLFilePaths();
     const files = this.read(fps);
+    const { url, secret } = await this.fetchsetup();
+
+    let version: string | undefined = undefined;
+    let status: string = "";
+
     try {
-      const { url, secret } = await this.fetchsetup();
+      const res = await fetch(new URL(`/schema/1/staged/status`, url), {
+        method: "GET",
+        headers: { AUTHORIZATION: `Bearer ${secret}` },
+        // https://github.com/nodejs/node/issues/46221
+        // https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1483
+        // @ts-expect-error-next-line
+        duplex: "half",
+      });
+
+      const json = await res.json();
+      if (json.error) {
+        this.error(json.error.message);
+      }
+
+      version = json.version;
+      status = json.status;
+
+      if (json.status === "none" && this.flags?.active) {
+        this.error(
+          "There is no staged schema, so passing `--active` does nothing"
+        );
+      }
+    } catch (err) {
+      this.error(err);
+    }
+
+    try {
       const params = new URLSearchParams({
         ...(hasColor() ? { color: colorParam() } : {}),
-        force: "true",
+        staged: this.flags?.active ? "false" : "true",
+        ...(version !== undefined ? { version } : { force: "true" }),
       });
       const res = await fetch(new URL(`/schema/1/validate?${params}`, url), {
         method: "POST",
         headers: { AUTHORIZATION: `Bearer ${secret}` },
         body: this.body(files),
-        // https://github.com/nodejs/node/issues/46221
-        // https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1483
         // @ts-expect-error-next-line
         duplex: "half",
       });
       const json = await res.json();
       if (json.error) {
         this.error(json.error.message);
+      }
+
+      if (status !== "none") {
+        if (this.flags?.active) {
+          this.log(
+            `Differences between the ${bold()}local${reset()} schema and the ${bold()}remote, active${reset()} schema:`
+          );
+        } else {
+          this.log(
+            `Differences between the ${bold()}local${reset()} schema and the ${bold()}remote, staged${reset()} schema:`
+          );
+        }
+      } else {
+        this.log(
+          `Differences between the ${bold()}local${reset()} schema and the ${bold()}remote${reset()} schema:`
+        );
       }
       this.log(json.diff ? json.diff : "No schema differences");
     } catch (err) {

--- a/src/commands/schema/diff.ts
+++ b/src/commands/schema/diff.ts
@@ -6,12 +6,14 @@ export default class DiffSchemaCommand extends SchemaCommand {
   static flags = {
     ...SchemaCommand.flags,
     active: Flags.boolean({
-      description: "Compare the local schema to the active schema.",
+      description:
+        "Compare the local schema to the active schema instead of the staged schema.",
       default: false,
     }),
   };
 
-  static description = "Print the diff between local and remote schema.";
+  static description =
+    "Print the diff between local schema and staged remote schema.";
   static examples = [
     "$ fauna schema diff",
     "$ fauna schema diff --dir schemas/myschema",

--- a/src/lib/color.ts
+++ b/src/lib/color.ts
@@ -26,3 +26,14 @@ export const colorParam = (): string => {
 export const hasColor = (): boolean => {
   return colorEnabled ?? false;
 };
+
+export const reset = (): string => esc(`\u001b[0m`);
+export const bold = (): string => esc(`\u001b[1m`);
+
+const esc = (str: string): string => {
+  if (hasColor()) {
+    return str;
+  } else {
+    return "";
+  }
+};


### PR DESCRIPTION
Ticket(s): ENG-6796

Currently, `fauna schema diff` diffs against the active schema, which isn't what I'd expect it to do. This changes the default to diff against the staged schema, adds a flag to toggle the behavior, and shows which schemas are being compared in the command output.
