### PR TITLE
Improve schema command output

### DIFF
--- a/src/commands/schema/push.ts
+++ b/src/commands/schema/push.ts
@@ -58,6 +58,7 @@ export default class PushSchemaCommand extends SchemaCommand {
         const params = new URLSearchParams({
           ...(hasColor() ? { color: colorParam() } : {}),
           force: "true",
+          diff: "summary",
         });
         const path = new URL(`/schema/1/validate?${params}`, url);
         const res = await fetch(path, {
@@ -74,12 +75,13 @@ export default class PushSchemaCommand extends SchemaCommand {
 
         let message = "Accept and push changes?";
         if (json.diff) {
-          this.log(`Proposed diff:\n`);
+          this.log("Proposed diff:\n");
           this.log(json.diff);
         } else {
           this.log("No logical changes.");
           message = "Push file contents anyway?";
         }
+        this.log("(use `fauna schema diff` to show the complete diff)");
         const confirmed = await confirm({
           message,
           default: false,

--- a/test/commands/schema.test.ts
+++ b/test/commands/schema.test.ts
@@ -125,6 +125,10 @@ describe("fauna schema diff test", () => {
 });
 
 describe("fauna schema push test", () => {
+  before(() => {
+    disableColor();
+  });
+
   afterEach(() => {
     nock.cleanAll();
   });
@@ -173,10 +177,15 @@ describe("fauna schema push test", () => {
       .persist()
       .post("/", matchFqlReq(query.Now()))
       .reply(200, new Date())
-      .get("/schema/1/staged/status?diff=true")
+      .get("/schema/1/staged/status?diff=summary")
       .reply(200, {
         version: 0,
         status: "ready",
+        diff: diff.diff,
+      })
+      .post("/schema/1/validate?diff=summary&staged=true&version=0")
+      .reply(200, {
+        version: 0,
         diff: diff.diff,
       });
 

--- a/test/commands/schema.test.ts
+++ b/test/commands/schema.test.ts
@@ -138,9 +138,9 @@ describe("fauna schema push test", () => {
       .persist()
       .post("/", matchFqlReq(query.Now()))
       .reply(200, new Date())
-      .post("/schema/1/validate?force=true")
+      .post("/schema/1/validate?force=true&diff=summary")
       .reply(200, diff)
-      .post("/schema/1/update?version=0")
+      .post("/schema/1/update?version=0&staged=false")
       .reply(200, updated);
     // Stubbing the confirmation to always return true
     const stubConfirm = sinon.stub(inquirer, "confirm").resolves(true);
@@ -157,7 +157,7 @@ describe("fauna schema push test", () => {
       .persist()
       .post("/", matchFqlReq(query.Now()))
       .reply(200, new Date())
-      .post("/schema/1/validate?force=true")
+      .post("/schema/1/validate?force=true&diff=summary")
       .reply(200, diff)
       .post("/schema/1/update?version=0&staged=true")
       .reply(200, updated);


### PR DESCRIPTION
Ticket(s): ENG-6820

This, combined with a bunch of changes in core, will now produce a more consistent output for the staged schema commands.
