### PR TITLE
Improve diff args

### DIFF
--- a/src/commands/schema/diff.ts
+++ b/src/commands/schema/diff.ts
@@ -1,14 +1,23 @@
 import SchemaCommand from "../../lib/schema-command";
 import { bold, colorParam, hasColor, reset } from "../../lib/color";
-import { Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+
+type Target = "local" | "staged" | "active";
 
 export default class DiffSchemaCommand extends SchemaCommand {
   static flags = {
     ...SchemaCommand.flags,
-    active: Flags.boolean({
-      description:
-        "Compare the local schema to the active schema instead of the staged schema.",
+    text: Flags.boolean({
+      description: "Display the text diff instead of the semantic diff.",
       default: false,
+    }),
+  };
+
+  static args = {
+    ...SchemaCommand.args,
+    target: Args.string({
+      description: "The target schema to compare against (active | staged).",
+      required: false,
     }),
   };
 
@@ -20,6 +29,8 @@ export default class DiffSchemaCommand extends SchemaCommand {
   ];
 
   async run() {
+    const [source, target] = this.parseTarget();
+
     const fps = this.gatherRelativeFSLFilePaths();
     const files = this.read(fps);
     const { url, secret } = await this.fetchsetup();
@@ -27,69 +38,98 @@ export default class DiffSchemaCommand extends SchemaCommand {
     let version: string | undefined = undefined;
     let status: string = "";
 
-    try {
-      const res = await fetch(new URL(`/schema/1/staged/status`, url), {
-        method: "GET",
-        headers: { AUTHORIZATION: `Bearer ${secret}` },
-        // https://github.com/nodejs/node/issues/46221
-        // https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1483
-        // @ts-expect-error-next-line
-        duplex: "half",
-      });
-
-      const json = await res.json();
-      if (json.error) {
-        this.error(json.error.message);
-      }
-
-      version = json.version;
-      status = json.status;
-
-      if (json.status === "none" && this.flags?.active) {
-        this.error(
-          "There is no staged schema, so passing `--active` does nothing"
-        );
-      }
-    } catch (err) {
-      this.error(err);
-    }
+    const diffKind = this.flags?.text ? "textual" : "semantic";
 
     try {
       const params = new URLSearchParams({
         ...(hasColor() ? { color: colorParam() } : {}),
-        staged: this.flags?.active ? "false" : "true",
-        ...(version !== undefined ? { version } : { force: "true" }),
+        ...(target === "staged" ? { diff: diffKind } : {}),
       });
-      const res = await fetch(new URL(`/schema/1/validate?${params}`, url), {
-        method: "POST",
-        headers: { AUTHORIZATION: `Bearer ${secret}` },
-        body: this.body(files),
-        // @ts-expect-error-next-line
-        duplex: "half",
-      });
-      const json = await res.json();
-      if (json.error) {
-        this.error(json.error.message);
+      const res = await fetch(
+        new URL(`/schema/1/staged/status?${params}`, url),
+        {
+          method: "GET",
+          headers: { AUTHORIZATION: `Bearer ${secret}` },
+          // https://github.com/nodejs/node/issues/46221
+          // https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1483
+          // @ts-expect-error-next-line
+          duplex: "half",
+        }
+      );
+
+      const statusJson = await res.json();
+      if (statusJson.error) {
+        this.error(statusJson.error.message);
       }
 
-      if (status !== "none") {
-        if (this.flags?.active) {
-          this.log(
-            `Differences between the ${bold()}local${reset()} schema and the ${bold()}remote, active${reset()} schema:`
-          );
+      version = statusJson.version;
+      status = statusJson.status;
+
+      if (target === "staged") {
+        this.log(
+          `Differences from the ${bold()}remote, active${reset()} schema to the ${bold()}remote, staged${reset()} schema:`
+        );
+        if (status === "none") {
+          this.log("There is no staged schema present.");
         } else {
-          this.log(
-            `Differences between the ${bold()}local${reset()} schema and the ${bold()}remote, staged${reset()} schema:`
-          );
+          this.log(statusJson.diff ? statusJson.diff : "No schema differences");
         }
       } else {
-        this.log(
-          `Differences between the ${bold()}local${reset()} schema and the ${bold()}remote${reset()} schema:`
-        );
+        const params = new URLSearchParams({
+          ...(hasColor() ? { color: colorParam() } : {}),
+          staged: source === "staged" ? "true" : "false",
+          ...(version !== undefined ? { version } : { force: "true" }),
+          diff: diffKind,
+        });
+        const res = await fetch(new URL(`/schema/1/validate?${params}`, url), {
+          method: "POST",
+          headers: { AUTHORIZATION: `Bearer ${secret}` },
+          body: this.body(files),
+          // @ts-expect-error-next-line
+          duplex: "half",
+        });
+        const json = await res.json();
+        if (json.error) {
+          this.error(json.error.message);
+        }
+
+        if (status === "none") {
+          this.log(
+            `Differences from the ${bold()}remote${reset()} schema to the ${bold()}local${reset()} schema:`
+          );
+        } else {
+          if (source === "active") {
+            this.log(
+              `Differences from the ${bold()}remote, active${reset()} schema to the ${bold()}local${reset()} schema:`
+            );
+          } else {
+            this.log(
+              `Differences from the ${bold()}remote, staged${reset()} schema to the ${bold()}local${reset()} schema:`
+            );
+          }
+        }
+        this.log(json.diff ? json.diff : "No schema differences");
       }
-      this.log(json.diff ? json.diff : "No schema differences");
     } catch (err) {
       this.error(err);
+    }
+  }
+
+  parseTarget(): [Target, Target] {
+    const target: string = this.args?.target;
+
+    if (!target) {
+      return ["staged", "local"];
+    }
+
+    if (target === "active") {
+      return ["active", "local"];
+    } else if (target === "staged") {
+      return ["active", "staged"];
+    } else {
+      // NB: `this.error` quits the program, so return `any` to make typescript happy.
+      this.error("Invalid target. Expected: active or staged");
+      return [] as any;
     }
   }
 }


### PR DESCRIPTION
Ticket(s): ENG-6821

The following arguments to `fauna schema diff`:
- <no args>: returns the diff from staged to local schema.
- `staged`: returns the diff from active to staged schema.
- `active`: returns the diff from active to local schema.