### PR TITLE
Update schema status msg for staged default

### DIFF
--- a/src/commands/schema/push.ts
+++ b/src/commands/schema/push.ts
@@ -22,7 +22,7 @@ export default class PushSchemaCommand extends SchemaCommand {
   static examples = [
     "$ fauna schema push",
     "$ fauna schema push --dir schemas/myschema",
-    "$ fauna schema push --staged",
+    "$ fauna schema push --skip-staged",
   ];
 
   async run() {

--- a/src/commands/schema/status.ts
+++ b/src/commands/schema/status.ts
@@ -87,7 +87,7 @@ export default class StatusSchemaCommand extends SchemaCommand {
           this.log("  " + validateJson.diff.split("\n").join("\n  "));
 
           this.log("(use `fauna schema diff` to display local changes)");
-          this.log("(use `fauna schema push --staged` to stage local changes)");
+          this.log("(use `fauna schema push` to stage local changes)");
         }
       }
     } catch (err) {


### PR DESCRIPTION
Ticket(s): [DOCS-3567](https://faunadb.atlassian.net/browse/DOCS-3567)

Updates a message and example as a follow-up to https://github.com/fauna/fauna-shell/pull/387. `fauna schema push --staged` is no more.

[DOCS-3567]: https://faunadb.atlassian.net/browse/DOCS-3567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ