### PR TITLE
Simplify flags to push and diff

### DIFF
--- a/src/commands/schema/diff.ts
+++ b/src/commands/schema/diff.ts
@@ -1,6 +1,6 @@
 import SchemaCommand from "../../lib/schema-command";
 import { bold, colorParam, hasColor, reset } from "../../lib/color";
-import { Args, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
 
 type Target = "local" | "staged" | "active";
 
@@ -11,13 +11,15 @@ export default class DiffSchemaCommand extends SchemaCommand {
       description: "Display the text diff instead of the semantic diff.",
       default: false,
     }),
-  };
-
-  static args = {
-    ...SchemaCommand.args,
-    target: Args.string({
-      description: "The target schema to compare against (active | staged).",
-      required: false,
+    active: Flags.boolean({
+      description:
+        "Show the diff against the active schema instead of the staged schema.",
+      default: false,
+    }),
+    staged: Flags.boolean({
+      description:
+        "Show the diff between the active and staged schema, instead of the local schema.",
+      default: false,
     }),
   };
 
@@ -116,15 +118,17 @@ export default class DiffSchemaCommand extends SchemaCommand {
   }
 
   parseTarget(): [Target, Target] {
-    const target: string = this.args?.target;
-
-    if (!target) {
+    if (!this.flags?.active && !this.flags?.staged) {
       return ["staged", "local"];
     }
 
-    if (target === "active") {
+    if (this.flags?.active && this.flags?.staged) {
+      this.error("Cannot specify both --active and --staged");
+    }
+
+    if (this.flags?.active) {
       return ["active", "local"];
-    } else if (target === "staged") {
+    } else if (this.flags?.staged) {
       return ["active", "staged"];
     } else {
       // NB: `this.error` quits the program, so return `any` to make typescript happy.

--- a/src/commands/schema/push.ts
+++ b/src/commands/schema/push.ts
@@ -10,7 +10,7 @@ export default class PushSchemaCommand extends SchemaCommand {
       description: "Push the change without a diff or schema version check",
       default: false,
     }),
-    "skip-staged": Flags.boolean({
+    active: Flags.boolean({
       description:
         "Skip staging the schema and make the schema active immediately. This will cause indexes to be temporarily unavailable.",
       default: false,
@@ -22,7 +22,7 @@ export default class PushSchemaCommand extends SchemaCommand {
   static examples = [
     "$ fauna schema push",
     "$ fauna schema push --dir schemas/myschema",
-    "$ fauna schema push --skip-staged",
+    "$ fauna schema push --active",
   ];
 
   async run() {
@@ -44,7 +44,7 @@ export default class PushSchemaCommand extends SchemaCommand {
         this.error(statusjson.error.message);
       }
 
-      if (statusjson.status !== "none" && this.flags?.["skip-staged"]) {
+      if (statusjson.status !== "none" && this.flags?.active) {
         this.error(
           "Cannot skip a staged push while there is a staged schema.\n" +
             "Use `fauna schema status` to check the staged schema."
@@ -52,7 +52,7 @@ export default class PushSchemaCommand extends SchemaCommand {
       }
 
       // Double negatives are confusing.
-      const isStagedPush = !this.flags?.["skip-staged"];
+      const isStagedPush = !this.flags?.active;
 
       if (this.flags?.force) {
         const params = new URLSearchParams({

--- a/test/commands/schema.test.ts
+++ b/test/commands/schema.test.ts
@@ -85,7 +85,7 @@ describe("fauna schema diff test", () => {
     expect(stdout).to.contain(`${diff.diff}`);
   });
 
-  it("runs schema diff active", async () => {
+  it("runs schema diff --active", async () => {
     nock(getEndpoint(), { allowUnmocked: false })
       .persist()
       .post("/", matchFqlReq(query.Now()))
@@ -96,7 +96,7 @@ describe("fauna schema diff test", () => {
       .reply(200, diff);
 
     const { stdout } = await runCommand(
-      withOpts(["schema diff", "--dir=test/testdata", "active"])
+      withOpts(["schema diff", "--dir=test/testdata", "--active"])
     );
 
     expect(stdout).to.contain(
@@ -105,7 +105,7 @@ describe("fauna schema diff test", () => {
     expect(stdout).to.contain(`${diff.diff}`);
   });
 
-  it("runs schema diff staged", async () => {
+  it("runs schema diff --staged", async () => {
     nock(getEndpoint(), { allowUnmocked: false })
       .persist()
       .post("/", matchFqlReq(query.Now()))
@@ -114,7 +114,7 @@ describe("fauna schema diff test", () => {
       .reply(200, { status: "ready", diff: diff.diff, version: 0 });
 
     const { stdout } = await runCommand(
-      withOpts(["schema diff", "--dir=test/testdata", "staged"])
+      withOpts(["schema diff", "--dir=test/testdata", "--staged"])
     );
 
     expect(stdout).to.contain(

--- a/test/commands/schema.test.ts
+++ b/test/commands/schema.test.ts
@@ -155,7 +155,7 @@ describe("fauna schema push test", () => {
     stubConfirm.restore();
   });
 
-  it("runs schema push --skip-staged", async () => {
+  it("runs schema push --active", async () => {
     nock(getEndpoint(), { allowUnmocked: false })
       .persist()
       .post("/", matchFqlReq(query.Now()))
@@ -169,7 +169,7 @@ describe("fauna schema push test", () => {
     // Stubbing the confirmation to always return true
     const stubConfirm = sinon.stub(inquirer, "confirm").resolves(true);
     const { stdout } = await runCommand(
-      withOpts(["schema push", "--dir=test/testdata", "--skip-staged"])
+      withOpts(["schema push", "--dir=test/testdata", "--active"])
     );
     expect(stdout).to.contain(`${diff.diff}`);
     // Restore the stub after the test


### PR DESCRIPTION
Ticket(s): ENG-6842

Renames `push --skip-staged` to `push --active`, and switches `diff` to take flags instead of an argument.
