### PR TITLE
Rename --force and --non-interactive to --no-input

### DIFF
--- a/src/commands/endpoint/add.ts
+++ b/src/commands/endpoint/add.ts
@@ -28,8 +28,10 @@ export default class AddEndpointCommand extends Command {
       description: "Database secret",
       required: false,
     }),
-    "non-interactive": Flags.boolean({
-      description: "Disables interaction",
+    "no-input": Flags.boolean({
+      char: "y",
+      description: "Do not read from user input.",
+      default: false,
       dependsOn: ["url", "secret"],
     }),
     "set-default": Flags.boolean({
@@ -49,8 +51,8 @@ export default class AddEndpointCommand extends Command {
   async execute(config: ShellConfig) {
     const { args, flags } = await this.parse();
 
-    if (args.name === undefined && flags["non-interactive"]) {
-      this.error("A name must be given if --non-interactive is set");
+    if (args.name === undefined && flags["no-input"]) {
+      this.error("A name must be given if --no-input is set");
     }
 
     const endpointName =
@@ -123,7 +125,7 @@ export default class AddEndpointCommand extends Command {
 
     const setDefault =
       flags?.["set-default"] ??
-      (flags?.["non-interactive"]
+      (flags?.["no-input"]
         ? false
         : await confirm({
             message: "Make this endpoint default",

--- a/src/commands/environment/add.ts
+++ b/src/commands/environment/add.ts
@@ -13,8 +13,10 @@ export default class AddEnvironmentCommand extends Command {
     database: Flags.string({
       description: "Database path to use in this environment",
     }),
-    "non-interactive": Flags.boolean({
-      description: "Disable interaction",
+    "no-input": Flags.boolean({
+      char: "y",
+      description: "Do not read from user input.",
+      default: false,
       dependsOn: ["name", "endpoint", "database"],
     }),
     "set-default": Flags.boolean({
@@ -51,7 +53,7 @@ export default class AddEnvironmentCommand extends Command {
       database: flags.database,
       name: flags.name,
       default: flags["set-default"],
-      nonInteractive: flags["non-interactive"],
+      nonInteractive: flags["no-input"],
     });
   }
 }

--- a/src/commands/schema/abandon.ts
+++ b/src/commands/schema/abandon.ts
@@ -1,15 +1,10 @@
 import { confirm } from "@inquirer/prompts";
 import SchemaCommand from "../../lib/schema-command";
-import { Flags } from "@oclif/core";
 import { colorParam, hasColor } from "../../lib/color";
 
 export default class CommitSchemaCommand extends SchemaCommand {
   static flags = {
     ...SchemaCommand.flags,
-    force: Flags.boolean({
-      description: "Push the change without a diff or schema version check",
-      default: false,
-    }),
   };
 
   static description = "Abandons the currently staged schema.";
@@ -19,7 +14,7 @@ export default class CommitSchemaCommand extends SchemaCommand {
   async run() {
     try {
       const { url, secret } = await this.fetchsetup();
-      if (this.flags?.force) {
+      if (this.flags?.["no-input"]) {
         const params = new URLSearchParams({
           force: "true", // Just abandon, don't pass a schema version through.
         });

--- a/src/commands/schema/commit.ts
+++ b/src/commands/schema/commit.ts
@@ -1,15 +1,10 @@
 import { confirm } from "@inquirer/prompts";
 import SchemaCommand from "../../lib/schema-command";
-import { Flags } from "@oclif/core";
 import { colorParam, hasColor } from "../../lib/color";
 
 export default class CommitSchemaCommand extends SchemaCommand {
   static flags = {
     ...SchemaCommand.flags,
-    force: Flags.boolean({
-      description: "Push the change without a diff or schema version check",
-      default: false,
-    }),
   };
 
   static description = "Commits the currently staged schema.";
@@ -19,7 +14,7 @@ export default class CommitSchemaCommand extends SchemaCommand {
   async run() {
     try {
       const { url, secret } = await this.fetchsetup();
-      if (this.flags?.force) {
+      if (this.flags?.["no-input"]) {
         const params = new URLSearchParams({
           force: "true", // Just commit, don't pass a schema version through.
         });

--- a/src/commands/schema/push.ts
+++ b/src/commands/schema/push.ts
@@ -6,10 +6,6 @@ import { colorParam, hasColor } from "../../lib/color";
 export default class PushSchemaCommand extends SchemaCommand {
   static flags = {
     ...SchemaCommand.flags,
-    force: Flags.boolean({
-      description: "Push the change without a diff or schema version check",
-      default: false,
-    }),
     active: Flags.boolean({
       description:
         "Skip staging the schema and make the schema active immediately. This will cause indexes to be temporarily unavailable.",
@@ -54,7 +50,7 @@ export default class PushSchemaCommand extends SchemaCommand {
       // Double negatives are confusing.
       const isStagedPush = !this.flags?.active;
 
-      if (this.flags?.force) {
+      if (this.flags?.["no-input"]) {
         const params = new URLSearchParams({
           force: "true", // Just push.
           staged: isStagedPush ? "true" : "false",

--- a/src/commands/schema/status.ts
+++ b/src/commands/schema/status.ts
@@ -78,17 +78,15 @@ export default class StatusSchemaCommand extends SchemaCommand {
       if (validateJson.error) {
         this.log(`Local changes:`);
         this.error(validateJson.error.message);
+      } else if (validateJson.diff === "") {
+        this.log(`Local changes: ${bold()}none${reset()}`);
       } else {
-        if (validateJson.diff === "") {
-          this.log(`Local changes: ${bold()}none${reset()}`);
-        } else {
-          this.log(`Local changes:`);
-          this.log();
-          this.log("  " + validateJson.diff.split("\n").join("\n  "));
+        this.log(`Local changes:`);
+        this.log();
+        this.log("  " + validateJson.diff.split("\n").join("\n  "));
 
-          this.log("(use `fauna schema diff` to display local changes)");
-          this.log("(use `fauna schema push` to stage local changes)");
-        }
+        this.log("(use `fauna schema diff` to display local changes)");
+        this.log("(use `fauna schema push` to stage local changes)");
       }
     } catch (err) {
       this.error(err);

--- a/src/lib/fauna-command.js
+++ b/src/lib/fauna-command.js
@@ -306,6 +306,11 @@ FaunaCommand.flags = {
     description: "Force color output",
     allowNo: true,
   }),
+  "no-input": Flags.boolean({
+    char: "y",
+    description: "Do not read from user input.",
+    default: false,
+  }),
 };
 
 export default FaunaCommand;

--- a/test/commands/endpoint.test.ts
+++ b/test/commands/endpoint.test.ts
@@ -37,7 +37,7 @@ describe("endpoint:add", () => {
     sinon.stub(ShellConfig, "read").returns(this.config);
     const { stdout } = await captureOutput(async () =>
       AddEndpointCommand.run([
-        "--non-interactive",
+        "--no-input",
         "foobar",
         "--url",
         "http://foo.baz",
@@ -84,7 +84,7 @@ describe("endpoint:add", () => {
     sinon.stub(ShellConfig, "read").returns(this.config);
     const { stdout } = await captureOutput(async () =>
       AddEndpointCommand.run([
-        "--non-interactive",
+        "--no-input",
         "foobar",
         "--url",
         "http://foo.baz",

--- a/test/commands/environment.test.ts
+++ b/test/commands/environment.test.ts
@@ -45,7 +45,7 @@ describe("environment:add", () => {
     sinon.stub(ShellConfig, "read").returns(this.config);
     const { stdout } = await captureOutput(async () =>
       AddEnvironmentComand.run([
-        "--non-interactive",
+        "--no-input",
         "--name",
         "foobar",
         "--endpoint",
@@ -87,7 +87,7 @@ describe("environment:add", () => {
     sinon.stub(ShellConfig, "read").returns(this.config);
     const { stdout } = await captureOutput(async () =>
       AddEnvironmentComand.run([
-        "--non-interactive",
+        "--no-input",
         "--name",
         "foobar",
         "--endpoint",
@@ -130,7 +130,7 @@ describe("environment:add", () => {
     sinon.stub(ShellConfig, "read").returns(this.config);
     const { error } = await captureOutput(async () =>
       AddEnvironmentComand.run([
-        "--non-interactive",
+        "--no-input",
         "--name",
         "my-app",
         "--endpoint",
@@ -167,7 +167,7 @@ describe("environment:add", () => {
     sinon.stub(ShellConfig, "read").returns(this.config);
     const { error } = await captureOutput(async () =>
       AddEnvironmentComand.run([
-        "--non-interactive",
+        "--no-input",
         "--name",
         "foobar",
         "--endpoint",

--- a/test/integ/schema.test.ts
+++ b/test/integ/schema.test.ts
@@ -16,11 +16,11 @@ describe.skip("fauna schema staged commands", () => {
     await cleanupDBs();
   });
 
-  it("fauna schema push --stage --force works", async () => {
+  it("fauna schema push --stage --no-input works", async () => {
     const secret = await newDB();
 
     await shellOk(
-      "fauna schema push --dir test/integ/schema/start --force",
+      "fauna schema push --dir test/integ/schema/start --no-input",
       secret
     );
 
@@ -29,7 +29,7 @@ describe.skip("fauna schema staged commands", () => {
     ).to.deep.equal(["User"]);
 
     await shellOk(
-      "fauna schema push --dir test/integ/schema/staged_index --force --stage",
+      "fauna schema push --dir test/integ/schema/staged_index --no-input --stage",
       secret
     );
 
@@ -70,7 +70,7 @@ describe.skip("fauna schema staged commands", () => {
     const secret = await newDB();
 
     await shellOk(
-      "fauna schema push --dir test/integ/schema/start --force",
+      "fauna schema push --dir test/integ/schema/start --no-input",
       secret
     );
 
@@ -82,7 +82,7 @@ describe.skip("fauna schema staged commands", () => {
     );
 
     await shellOk(
-      "fauna schema push --dir test/integ/schema/staged_index --force --stage",
+      "fauna schema push --dir test/integ/schema/staged_index --no-input --stage",
       secret
     );
 
@@ -112,11 +112,11 @@ describe.skip("fauna schema staged commands", () => {
     );
   });
 
-  it("fauna schema commit --force works", async () => {
+  it("fauna schema commit --no-input works", async () => {
     const secret = await newDB();
 
     await shellOk(
-      "fauna schema push --dir test/integ/schema/start --force",
+      "fauna schema push --dir test/integ/schema/start --no-input",
       secret
     );
 
@@ -130,7 +130,7 @@ describe.skip("fauna schema staged commands", () => {
     ).to.deep.equal(["User"]);
 
     await shellOk(
-      "fauna schema push --dir test/integ/schema/staged_index --force --stage",
+      "fauna schema push --dir test/integ/schema/staged_index --no-input --stage",
       secret
     );
 
@@ -146,7 +146,7 @@ describe.skip("fauna schema staged commands", () => {
     ).to.deep.equal(null);
 
     // Commit the schema
-    await shellOk("fauna schema commit --dir . --force", secret);
+    await shellOk("fauna schema commit --dir . --no-input", secret);
 
     // Index should now be available on the companion object.
     expect(
@@ -166,15 +166,15 @@ describe.skip("fauna schema staged commands", () => {
 
     // Comitting when there is nothing staged should return an error.
     expect(
-      await shellErr("fauna schema commit --dir . --force", secret)
+      await shellErr("fauna schema commit --dir . --no-input", secret)
     ).to.equal("There is no staged schema to commit");
   });
 
-  it("fauna schema abandon --force works", async () => {
+  it("fauna schema abandon --no-input works", async () => {
     const secret = await newDB();
 
     await shellOk(
-      "fauna schema push --dir test/integ/schema/start --force",
+      "fauna schema push --dir test/integ/schema/start --no-input",
       secret
     );
 
@@ -188,7 +188,7 @@ describe.skip("fauna schema staged commands", () => {
     ).to.deep.equal(["User"]);
 
     await shellOk(
-      "fauna schema push --dir test/integ/schema/staged_index --force --stage",
+      "fauna schema push --dir test/integ/schema/staged_index --no-input --stage",
       secret
     );
 
@@ -218,7 +218,7 @@ describe.skip("fauna schema staged commands", () => {
     ).to.deep.equal(null);
 
     // Abandon the schema
-    await shellOk("fauna schema abandon --dir . --force", secret);
+    await shellOk("fauna schema abandon --dir . --no-input", secret);
 
     // Index should no longer be in the definition object.
     expect(
@@ -244,7 +244,7 @@ describe.skip("fauna schema staged commands", () => {
 
     // Abandoning when there is no staged schema should return an error.
     expect(
-      await shellErr("fauna schema abandon --dir . --force", secret)
+      await shellErr("fauna schema abandon --dir . --no-input", secret)
     ).to.equal("There is no staged schema to abandon");
   });
 });


### PR DESCRIPTION
Ticket(s): FE-###

Renames `--force` and `--non-interact` to `--no-input`.
