### PR TITLE
clean up integ test documentation, error-handling

### DIFF
--- a/fsl/README.md
+++ b/fsl/README.md
@@ -5,15 +5,9 @@ In the below steps, using the default endpoint path will test out the local dev 
 Using the provided secret path will test out how schema updates will work in a pipeline, with a direct secret provided.
 
 To run them against your local changes you need to do the following:
-1. create a database called FaunaCLITest
-2. Do one of the following:
-    1. Setup a default endpoint called cli_test-us via fauna cloud-login
-    2. Obtain a secret for the FaunaCLITest database
-3. build your version of the shell with `yarn build` in the root repo directory
-4. Run the test script with one of the following:
-    1. If you have the default endpoint setup, 
-        1. `./test-script.mjs ~/fauna/fauna-shell/bin/run`
-    2. If using the database secret, 
-        1. `FAUNA_SECRET=[INSERT SECRET] ./test-script.mjs ~/fauna/fauna-shell/bin/run`
+1. Obtain the secret the pipeline uses.
+2. Run `fauna endpoint add cli_test-us --secret $SECRET --no-input`.
+3. Build your version of the shell with `yarn build` in the root repo directory
+4. Run the test script: `./test-script.mjs ~/fauna/fauna-shell/bin/run`
 
-
+To run ad-hoc commands against the test database, you will need to provide the `--secret` flag (since a db key does not work with the `./fauna-project` file in this directory). For example: `fauna schema status --endpoint cli_test-us --secret $SECRET`.

--- a/fsl/test-script.mjs
+++ b/fsl/test-script.mjs
@@ -114,5 +114,12 @@ async function execFQL(fql) {
     ? await $`${faunaCmd} eval ${fql} --format=json --secret ${secretFlag}`
     : await $`${faunaCmd} eval ${fql} --format=json`;
   const respParsed = JSON.parse(resp._stdout);
+  throwIfError(respParsed);
   return respParsed;
+}
+
+function throwIfError(networkResult) {
+  if (networkResult && networkResult.error)
+    throw new Error(`${networkResult.error.code || 'unknown'}: ${networkResult.error.message || 'unknown'}`);
+  return networkResult
 }


### PR DESCRIPTION
this change:
- eagerly throws if a fauna query has an error
- updates the documentation for running the pipeline test script locally