### PR TITLE
Clarify quick start text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,21 @@
 ### Quick Start
 
+Sanity check your local setup:
+
 ```
+# Install dependencies
 npm install
-npm run build
+# Run the local code
 ./src/user-entrypoint.mjs
+# Make sure you can build
+npm run build
 ```
 
+If you change code and want to see how it behaves from a customer-perspective:
+
+```
+./src/user-entrypoint.mjs <command> <subcommand> --options
+```
 
 
 ### Application versions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,8 @@ npm run build
 If you change code and want to see how it behaves from a customer-perspective:
 
 ```
-./src/user-entrypoint.mjs <command> <subcommand> --options
+./src/user-entrypoint.mjs <command> <subcommand> [--option ...]
 ```
-
 
 ### Application versions
 


### PR DESCRIPTION

## Problem

Dev quick start brain freezes people who notice a build is not needed to run the code.
## Solution

Rearrange the quick start text and add comments for clarity.
## Result

People don't have to stop and think.
## Testing

Read it and let me know if it still makes you pause.
