### PR TITLE
improve type inference on things pulled from awilix

### DIFF
--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -3,17 +3,16 @@
 import chalk from "chalk";
 import yargs from "yargs";
 
-import keyCommand from "./commands/key.mjs";
+import databaseCommand from "./commands/database/database.mjs";
 import evalCommand from "./commands/eval.mjs";
-import shellCommand from "./commands/shell.mjs";
+import keyCommand from "./commands/key.mjs";
 import loginCommand from "./commands/login.mjs";
 import schemaCommand from "./commands/schema/schema.mjs";
-import databaseCommand from "./commands/database/database.mjs";
-
+import shellCommand from "./commands/shell.mjs";
 import { authNZMiddleware } from "./lib/auth/authNZ.mjs";
 import { checkForUpdates, fixPaths, logArgv } from "./lib/middleware.mjs";
 
-/** @typedef {import('awilix').AwilixContainer<import('./config/setup-container.mjs').modifiedInjectables>} cliContainer */
+/** @typedef {import('awilix').AwilixContainer<import('./config/setup-container.mjs').modifiedInjectables> } cliContainer */
 
 /** @type {cliContainer} */
 export let container;
@@ -36,8 +35,10 @@ export async function run(argvInput, _container) {
     builtYargs = buildYargs(argvInput);
     await parseYargs(builtYargs);
   } catch (e) {
-    let subMessage = chalk.reset("Use 'fauna <command> --help' for more information about a command.");
-    
+    let subMessage = chalk.reset(
+      "Use 'fauna <command> --help' for more information about a command.",
+    );
+
     if (argvInput.length > 0) {
       subMessage = chalk.red(e.message);
     }

--- a/src/config/setup-container.mjs
+++ b/src/config/setup-container.mjs
@@ -28,12 +28,6 @@ import {
   writeSchemaFiles,
 } from "../lib/schema.mjs";
 
-// import { findUpSync } from 'find-up'
-// import fs from 'node:fs'
-// const __dirname = import.meta.dirname;
-// export const configPath = findUpSync(['dice.json'], { cwd: __dirname })
-// export const config = configPath ? JSON.parse(fs.readFileSync(configPath)) : {}
-
 export function setupCommonContainer() {
   const container = awilix.createContainer({
     injectionMode: awilix.InjectionMode.PROXY,
@@ -44,11 +38,8 @@ export function setupCommonContainer() {
 }
 
 /**
- * @template T
- * @typedef {{ [P in keyof T[P]]: ReturnType<T[P]['resolve']> }} Resolvers<T>
+ * @typedef {{ [Property in keyof injectables]: ReturnType<injectables[Property]["resolve"]> }} modifiedInjectables
  */
-
-/** @typedef {Resolvers<injectables>} modifiedInjectables */
 
 export const injectables = {
   // process specifics


### PR DESCRIPTION
the types for the container were broken; this commit fixes them. as a result, typescript server can properly infer the type of things resolved off the awilix container. unfortunately, it's likely not going to work in all situations - for instance, i've noticed that JSDoc comments are dropped.

before, looking at something registered with asValue:
![image](https://github.com/user-attachments/assets/0d5f301f-2ebf-491a-82a4-fb4c99b7f0e0)

before, looking at something registered with asClass:
![image](https://github.com/user-attachments/assets/253b8afb-5ab4-46f8-8e78-e269e9ae4df5)

after, looking at something registered with asValue:
![image](https://github.com/user-attachments/assets/2ed0739f-08dc-4f32-9190-9102c315c920)

after, looking at something registered with asClass:
![image](https://github.com/user-attachments/assets/df487fb1-7220-4ec6-811c-2cbfc7fd87f4)

