### PR TITLE
Create Database Command

### DIFF
--- a/src/commands/database/create.mjs
+++ b/src/commands/database/create.mjs
@@ -36,7 +36,6 @@ async function createDatabase(argv) {
 function buildCreateCommand(yargs) {
   return yargs
     .options({
-      ...commonQueryOptions,
       name: {
         type: "string",
         description: "the name of the database to create",
@@ -53,6 +52,7 @@ function buildCreateCommand(yargs) {
         type: "number",
         description: "user-defined priority assigned to the child database",
       },
+      ...commonQueryOptions,
     })
     .demandOption("name")
     .version(false)

--- a/src/commands/database/create.mjs
+++ b/src/commands/database/create.mjs
@@ -2,19 +2,20 @@
 
 import { fql } from "fauna";
 import { container } from "../../cli.mjs";
-import { runV10Query } from "../../lib/fauna.mjs";
 import { commonQueryOptions } from "../../lib/command-helpers.mjs";
 
 async function createDatabase(argv) {
   const logger = container.resolve("logger");
+  const runV10Query = container.resolve("runV10Query");
 
   await runV10Query({
     url: argv.url,
     secret: argv.secret,
     query: fql`Database.create({
       name: ${argv.name},
-      protected: ${argv.protected ?? false},
-      typechecked: ${argv.typechecked ?? false}
+      protected: ${argv.protected ?? null},
+      typechecked: ${argv.typechecked ?? null},
+      priority: ${argv.priority ?? null},
     })`,
   });
 

--- a/src/commands/database/create.mjs
+++ b/src/commands/database/create.mjs
@@ -1,18 +1,45 @@
 //@ts-check
 
+import { fql } from "fauna";
 import { container } from "../../cli.mjs";
+import { runV10Query } from "../../lib/fauna.mjs";
+import { commonQueryOptions } from "../../lib/command-helpers.mjs";
 
-async function createDatabase() {
+async function createDatabase(argv) {
   const logger = container.resolve("logger");
-  logger.stdout(`TBD`);
+
+  await runV10Query({
+    url: argv.url,
+    secret: argv.secret,
+    query: fql`Database.create({
+      name: ${argv.name},
+      protected: ${argv.protected ?? false},
+      typechecked: ${argv.typechecked ?? false}
+    })`,
+  });
+
+  logger.stdout(`Database ${argv.name} created`);
 }
 
 function buildCreateCommand(yargs) {
   return yargs
     .options({
+      ...commonQueryOptions,
       name: {
         type: "string",
         description: "the name of the database to create",
+      },
+      typechecked: {
+        type: "boolean",
+        description: "enable typechecking for the database",
+      },
+      protected: {
+        type: "boolean",
+        description: "allow destructive schema changes",
+      },
+      priority: {
+        type: "number",
+        description: "user-defined priority assigned to the child database",
       },
     })
     .demandOption("name")

--- a/src/commands/database/create.mjs
+++ b/src/commands/database/create.mjs
@@ -1,9 +1,10 @@
 //@ts-check
 
+import { FaunaError, fql } from "fauna";
+
 import { container } from "../../cli.mjs";
-import { fql, FaunaError } from "fauna";
-import { throwForV10Error } from "../../lib/fauna.mjs";
 import { commonQueryOptions } from "../../lib/command-helpers.mjs";
+import { throwForV10Error } from "../../lib/fauna.mjs";
 
 async function createDatabase(argv) {
   const logger = container.resolve("logger");

--- a/src/config/setup-container.mjs
+++ b/src/config/setup-container.mjs
@@ -16,6 +16,7 @@ import { makeAccountRequest } from "../lib/account.mjs";
 import OAuthClient from "../lib/auth/oauth-client.mjs";
 import { getSimpleClient } from "../lib/command-helpers.mjs";
 import { makeFaunaRequest } from "../lib/db.mjs";
+import { getV10Client,runV10Query } from "../lib/fauna.mjs";
 import { FaunaAccountClient } from "../lib/fauna-account-client.mjs";
 import fetchWrapper from "../lib/fetch-wrapper.mjs";
 import { AccountKey, SecretKey } from "../lib/file-util.mjs";
@@ -75,6 +76,10 @@ export const injectables = {
   accountCreds: awilix.asClass(AccountKey, { lifetime: Lifetime.SCOPED }),
   secretCreds: awilix.asClass(SecretKey, { lifetime: Lifetime.SCOPED }),
   errorHandler: awilix.asValue((error, exitCode) => exit(exitCode)),
+
+  // utilities for interacting with Fauna
+  runV10Query: awilix.asValue(runV10Query),
+  getV10Client: awilix.asValue(getV10Client),
 
   // feature-specific lib (homemade utilities)
   gatherFSL: awilix.asValue(gatherFSL),

--- a/src/lib/fauna.mjs
+++ b/src/lib/fauna.mjs
@@ -1,31 +1,71 @@
-export const getV10Client = async ({ url, secret }) => {
-  const { Client } = (await import("fauna")).default;
-  return new Client({
-    secret,
-    endpoint: url,
-  });
+//@ts-check
+
+import { Client } from "fauna";
+
+/**
+ * @type {import("fauna").QueryOptions}
+ */
+export const defaultV10QueryOptions = {
+  format: "simple",
+  typecheck: false,
 };
 
+/**
+ * Creates a V10 Fauna client.
+ *
+ * @param {object} opts
+ * @param {string} opts.url
+ * @param {string} opts.secret
+ * @returns {Promise<Client>}
+ */
+export const getV10Client = async ({ url, secret }) => {
+  // Check for required arguments.
+  if (!url || !secret) {
+    throw new Error("A url and secret are required.");
+  }
+  // Create the client.
+  return new Client({ secret, endpoint: new URL(url) });
+};
+
+/**
+ * Runs a V10 Fauna query. A client may be provided, or a url
+ * and secret may be used to create one.
+ *
+ * @param {object} opts
+ * @param {import("fauna").Query<any>} opts.query
+ * @param {string} [opts.url]
+ * @param {string} [opts.secret]
+ * @param {Client} [opts.client]
+ * @param {object} [opts.options]
+ * @returns {Promise<import("fauna").QuerySuccess<any>>}
+ */
 export const runV10Query = async ({
   query,
-  url = undefined,
-  secret = undefined,
-  client = undefined,
-  options = {
-    format: "simple",
-    typecheck: false,
-  },
+  url,
+  secret,
+  client,
+  options = {},
 }) => {
-  let _client = client;
-
-  if (!_client && url && secret) {
-    _client = await getV10Client({ url, secret });
-  } else if (!_client) {
-    throw new Error("No client provided and no url and secret provided");
+  // Check for required arguments.
+  if (!query) {
+    throw new Error("A query is required.");
+  } else if (!client && (!url || !secret)) {
+    throw new Error("A client or url and secret are required.");
   }
 
-  return _client.query(query, options).finally(() => {
-    // Clean up the client if one was created internally.
-    if (!client) _client.close();
-  });
+  // Create the client if one wasn't provided.
+  let _client =
+    client ??
+    (await getV10Client({
+      url: /** @type {string} */ (url), // We know this is a string because we check for !url above.
+      secret: /** @type {string} */ (secret), // We know this is a string because we check for !secret above.
+    }));
+
+  // Run the query.
+  return _client
+    .query(query, { ...defaultV10QueryOptions, ...options })
+    .finally(() => {
+      // Clean up the client if one was created internally.
+      if (!client && _client) _client.close();
+    });
 };

--- a/src/lib/fauna.mjs
+++ b/src/lib/fauna.mjs
@@ -6,12 +6,11 @@
 
 import {
   Client,
-  FaunaError,
-  ServiceError,
-  ClientError,
   ClientClosedError,
+  ClientError,
   NetworkError,
   ProtocolError,
+  ServiceError,
 } from "fauna";
 
 /**
@@ -89,7 +88,7 @@ export const runV10Query = async ({
  * can be provided for different types of errors, and a default error
  * message is thrown if no handler is provided.
  *
- * @param {FaunaError} e - The Fauna error to handle
+ * @param {import("fauna").FaunaError} e - The Fauna error to handle
  * @param {object} [handlers] - Optional error handlers
  * @param {(e: ServiceError) => string} [handlers.onInvalidQuery] - Handler for invalid query errors
  * @param {(e: ServiceError) => string} [handlers.onInvalidRequest] - Handler for invalid request errors

--- a/src/lib/fauna.mjs
+++ b/src/lib/fauna.mjs
@@ -1,5 +1,9 @@
 //@ts-check
 
+/**
+ * @fileoverview Fauna V10 client utilities for query execution and error handling.
+ */
+
 import {
   Client,
   FaunaError,
@@ -11,6 +15,8 @@ import {
 } from "fauna";
 
 /**
+ * Default options for V10 Fauna queries.
+ *
  * @type {import("fauna").QueryOptions}
  */
 export const defaultV10QueryOptions = {
@@ -19,14 +25,14 @@ export const defaultV10QueryOptions = {
 };
 
 /**
- * Creates a V10 Fauna client.
+ * Creates a V10 Client instance.
  *
  * @param {object} opts
  * @param {string} opts.url
  * @param {string} opts.secret
- * @returns {Promise<Client>}
+ * @returns {Client}
  */
-export const getV10Client = async ({ url, secret }) => {
+export const getV10Client = ({ url, secret }) => {
   // Check for required arguments.
   if (!url || !secret) {
     throw new Error("A url and secret are required.");
@@ -44,7 +50,7 @@ export const getV10Client = async ({ url, secret }) => {
  * @param {string} [opts.url]
  * @param {string} [opts.secret]
  * @param {Client} [opts.client]
- * @param {object} [opts.options]
+ * @param {import("fauna").QueryOptions} [opts.options]
  * @returns {Promise<import("fauna").QuerySuccess<any>>}
  */
 export const runV10Query = async ({
@@ -64,10 +70,10 @@ export const runV10Query = async ({
   // Create the client if one wasn't provided.
   let _client =
     client ??
-    (await getV10Client({
+    getV10Client({
       url: /** @type {string} */ (url), // We know this is a string because we check for !url above.
       secret: /** @type {string} */ (secret), // We know this is a string because we check for !secret above.
-    }));
+    });
 
   // Run the query.
   return _client
@@ -81,7 +87,7 @@ export const runV10Query = async ({
 /**
  * Error handler for errors thrown by the V10 driver. Custom handlers
  * can be provided for different types of errors, and a default error
- * message is thrown if no handlers are provided.
+ * message is thrown if no handler is provided.
  *
  * @param {FaunaError} e - The Fauna error to handle
  * @param {object} [handlers] - Optional error handlers

--- a/src/lib/fauna.mjs
+++ b/src/lib/fauna.mjs
@@ -1,0 +1,31 @@
+export const getV10Client = async ({ url, secret }) => {
+  const { Client } = (await import("fauna")).default;
+  return new Client({
+    secret,
+    endpoint: url,
+  });
+};
+
+export const runV10Query = async ({
+  query,
+  url = undefined,
+  secret = undefined,
+  client = undefined,
+  options = {
+    format: "simple",
+    typecheck: false,
+  },
+}) => {
+  let _client = client;
+
+  if (!_client && url && secret) {
+    _client = await getV10Client({ url, secret });
+  } else if (!_client) {
+    throw new Error("No client provided and no url and secret provided");
+  }
+
+  return _client.query(query, options).finally(() => {
+    // Clean up the client if one was created internally.
+    if (!client) _client.close();
+  });
+};

--- a/src/lib/fauna.mjs
+++ b/src/lib/fauna.mjs
@@ -1,6 +1,14 @@
 //@ts-check
 
-import { Client } from "fauna";
+import {
+  Client,
+  FaunaError,
+  ServiceError,
+  ClientError,
+  ClientClosedError,
+  NetworkError,
+  ProtocolError,
+} from "fauna";
 
 /**
  * @type {import("fauna").QueryOptions}
@@ -68,4 +76,70 @@ export const runV10Query = async ({
       // Clean up the client if one was created internally.
       if (!client && _client) _client.close();
     });
+};
+
+/**
+ * Error handler for errors thrown by the V10 driver. Custom handlers
+ * can be provided for different types of errors, and a default error
+ * message is thrown if no handlers are provided.
+ *
+ * @param {FaunaError} e - The Fauna error to handle
+ * @param {object} [handlers] - Optional error handlers
+ * @param {(e: ServiceError) => string} [handlers.onInvalidQuery] - Handler for invalid query errors
+ * @param {(e: ServiceError) => string} [handlers.onInvalidRequest] - Handler for invalid request errors
+ * @param {(e: ServiceError) => string} [handlers.onAbort] - Handler for aborted operation errors
+ * @param {(e: ServiceError) => string} [handlers.onConstraintFailure] - Handler for constraint violation errors
+ * @param {(e: ServiceError) => string} [handlers.onUnauthorized] - Handler for unauthorized access errors
+ * @param {(e: ServiceError) => string} [handlers.onForbidden] - Handler for forbidden access errors
+ * @param {(e: ServiceError) => string} [handlers.onContendedTransaction] - Handler for transaction contention errors
+ * @param {(e: ServiceError) => string} [handlers.onLimitExceeded] - Handler for rate/resource limit errors
+ * @param {(e: ServiceError) => string} [handlers.onTimeOut] - Handler for timeout errors
+ * @param {(e: ServiceError) => string} [handlers.onInternalError] - Handler for internal server errors
+ * @param {(e: ClientError) => string} [handlers.onClientError] - Handler for general client errors
+ * @param {(e: ClientClosedError) => string} [handlers.onClientClosedError] - Handler for closed client errors
+ * @param {(e: NetworkError) => string} [handlers.onNetworkError] - Handler for network-related errors
+ * @param {(e: ProtocolError) => string} [handlers.onProtocolError] - Handler for protocol-related errors
+ * @throws {Error} Always throws an error with a message based on the error code or handler response
+ * @returns {never} This function always throws an error
+ */
+export const throwForV10Error = (e, handlers = {}) => {
+  if (e instanceof ServiceError) {
+    switch (e.code) {
+      case "invalid_query":
+        throw new Error(handlers.onInvalidQuery?.(e) ?? e.message);
+      case "invalid_request ":
+        throw new Error(handlers.onInvalidRequest?.(e) ?? e.message);
+      case "abort":
+        throw new Error(handlers.onAbort?.(e) ?? e.message);
+      case "constraint_failure":
+        throw new Error(handlers.onConstraintFailure?.(e) ?? e.message);
+      case "unauthorized":
+        throw new Error(
+          handlers.onUnauthorized?.(e) ??
+            "Authentication failed: Please either log in using 'fauna login' or provide a valid database secret with '--secret'",
+        );
+      case "forbidden":
+        throw new Error(handlers.onForbidden?.(e) ?? e.message);
+      case "contended_transaction":
+        throw new Error(handlers.onContendedTransaction?.(e) ?? e.message);
+      case "limit_exceeded":
+        throw new Error(handlers.onLimitExceeded?.(e) ?? e.message);
+      case "time_out":
+        throw new Error(handlers.onTimeOut?.(e) ?? e.message);
+      case "internal_error":
+        throw new Error(handlers.onInternalError?.(e) ?? e.message);
+      default:
+        throw e;
+    }
+  } else if (e instanceof ClientError) {
+    throw new Error(handlers.onClientError?.(e) ?? e.message);
+  } else if (e instanceof ClientClosedError) {
+    throw new Error(handlers.onClientClosedError?.(e) ?? e.message);
+  } else if (e instanceof NetworkError) {
+    throw new Error(handlers.onNetworkError?.(e) ?? e.message);
+  } else if (e instanceof ProtocolError) {
+    throw new Error(handlers.onProtocolError?.(e) ?? e.message);
+  } else {
+    throw e;
+  }
 };

--- a/test/database/create.mjs
+++ b/test/database/create.mjs
@@ -1,0 +1,69 @@
+//@ts-check
+
+import { expect } from "chai";
+import chalk from "chalk";
+import { fql } from "fauna";
+import sinon from "sinon";
+
+import { builtYargs, run } from "../../src/cli.mjs";
+import { setupTestContainer as setupContainer } from "../../src/config/setup-test-container.mjs";
+
+describe("database create", () => {
+  let container, logger, runV10Query;
+
+  beforeEach(() => {
+    container = setupContainer();
+    logger = container.resolve("logger");
+    runV10Query = container.resolve("runV10Query");
+  });
+
+  [
+    { missing: "name", command: "database create --secret 'secret'" },
+    { missing: "secret", command: "database create --name 'name'" },
+  ].forEach(({ missing, command }) => {
+    it(`requires a ${missing}`, async () => {
+      try {
+        await run(command, container);
+      } catch (e) {}
+
+      const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
+        `Missing required argument: ${missing}`,
+      )}`;
+      expect(logger.stderr).to.have.been.calledWith(message);
+      expect(container.resolve("parseYargs")).to.have.been.calledOnce;
+    });
+  });
+
+  [
+    {
+      args: "--name 'testdb' --secret 'secret'",
+      expected: { name: "testdb", secret: "secret" },
+    },
+    {
+      args: "--name 'testdb' --secret 'secret' --typechecked",
+      expected: { name: "testdb", secret: "secret", typechecked: true },
+    },
+    {
+      args: "--name 'testdb' --secret 'secret' --protected",
+      expected: { name: "testdb", secret: "secret", protected: true },
+    },
+    {
+      args: "--name 'testdb' --secret 'secret' --priority 10",
+      expected: { name: "testdb", secret: "secret", priority: 10 },
+    },
+  ].forEach(({ args, expected }) => {
+    it(`calls runV10Query with correct arguments: ${args}`, async () => {
+      await run(`database create ${args}`, container);
+      expect(runV10Query).to.have.been.calledOnceWith({
+        url: sinon.match.string,
+        secret: expected.secret,
+        query: fql`Database.create({
+          name: ${expected.name},
+          protected: ${expected.protected ?? null},
+          typechecked: ${expected.typechecked ?? null},
+          priority: ${expected.priority ?? null},
+        })`,
+      });
+    });
+  });
+});

--- a/test/database/create.mjs
+++ b/test/database/create.mjs
@@ -1,8 +1,8 @@
 //@ts-check
 
+import * as awilix from "awilix";
 import { expect } from "chai";
 import chalk from "chalk";
-import * as awilix from "awilix";
 import { fql, ServiceError } from "fauna";
 import sinon from "sinon";
 

--- a/test/database/create.mjs
+++ b/test/database/create.mjs
@@ -54,17 +54,19 @@ describe("database create", () => {
       expected: { name: "testdb", secret: "secret", priority: 10 },
     },
   ].forEach(({ args, expected }) => {
-    it(`calls runV10Query with correct arguments: ${args}`, async () => {
-      await run(`database create ${args}`, container);
-      expect(runV10Query).to.have.been.calledOnceWith({
-        url: sinon.match.string,
-        secret: expected.secret,
-        query: fql`Database.create({
-          name: ${expected.name},
-          protected: ${expected.protected ?? null},
-          typechecked: ${expected.typechecked ?? null},
-          priority: ${expected.priority ?? null},
-        })`,
+    describe("calls fauna with the user specified arguments", () => {
+      it(`${args}`, async () => {
+        await run(`database create ${args}`, container);
+        expect(runV10Query).to.have.been.calledOnceWith({
+          url: sinon.match.string,
+          secret: expected.secret,
+          query: fql`Database.create({
+            name: ${expected.name},
+            protected: ${expected.protected ?? null},
+            typechecked: ${expected.typechecked ?? null},
+            priority: ${expected.priority ?? null},
+          })`,
+        });
       });
     });
   });
@@ -85,7 +87,7 @@ describe("database create", () => {
         "Authentication failed: Please either log in using 'fauna login' or provide a valid database secret with '--secret'",
     },
   ].forEach(({ error, expectedMessage }) => {
-    it(`handles fauna errors: ${error.code}`, async () => {
+    it(`handles ${error.code} errors when calling fauna`, async () => {
       const runV10QueryStub = sinon.stub().rejects(error);
       container.register({
         runV10Query: awilix.asValue(runV10QueryStub),


### PR DESCRIPTION
Ticket(s): FE-6125

## Problem
The create database command is stubbed out and does not actually do anything.

## Solution
- Wire it up with the Fauna v10 driver and run `Database.create`.
- Accept `typechecked`, `protected` and `priority` options.
- Set up some common functions to interact with the v10 driver.

## Result
The `database create` command works using a secret. Providing a database name instead of a secret is not yet supported.

## Testing
Added tests to ensure the command executes the correct query.
