### PR TITLE
[FE-6127] Delete Database

### DIFF
--- a/src/commands/database/create.mjs
+++ b/src/commands/database/create.mjs
@@ -37,6 +37,7 @@ function buildCreateCommand(yargs) {
     .options({
       name: {
         type: "string",
+        required: true,
         description: "the name of the database to create",
       },
       typechecked: {
@@ -53,7 +54,6 @@ function buildCreateCommand(yargs) {
       },
       ...commonQueryOptions,
     })
-    .demandOption("name")
     .version(false)
     .help("help", "show help");
 }

--- a/src/commands/database/create.mjs
+++ b/src/commands/database/create.mjs
@@ -1,10 +1,9 @@
 //@ts-check
 
 import { FaunaError, fql } from "fauna";
-
 import { container } from "../../cli.mjs";
-import { commonQueryOptions } from "../../lib/command-helpers.mjs";
 import { throwForV10Error } from "../../lib/fauna.mjs";
+import { commonQueryOptions } from "../../lib/command-helpers.mjs";
 
 async function createDatabase(argv) {
   const logger = container.resolve("logger");
@@ -21,7 +20,7 @@ async function createDatabase(argv) {
         priority: ${argv.priority ?? null},
       })`,
     });
-    logger.stdout(`Database ${argv.name} created`);
+    logger.stdout(`Database '${argv.name}' was successfully created.`);
   } catch (e) {
     if (e instanceof FaunaError) {
       throwForV10Error(e, {

--- a/src/commands/database/database.mjs
+++ b/src/commands/database/database.mjs
@@ -1,7 +1,8 @@
 //@ts-check
 
-import createCommand from "./create.mjs";
 import listCommand from "./list.mjs";
+import createCommand from "./create.mjs";
+import deleteCommand from "./delete.mjs";
 
 function buildDatabase(yargs) {
   return yargs
@@ -12,8 +13,9 @@ function buildDatabase(yargs) {
         default: "default",
       },
     })
-    .command(createCommand)
     .command(listCommand)
+    .command(createCommand)
+    .command(deleteCommand)
     .demandCommand()
     .version(false)
     .help("help", "show help");

--- a/src/commands/database/delete.mjs
+++ b/src/commands/database/delete.mjs
@@ -1,0 +1,49 @@
+//@ts-check
+
+import { FaunaError, fql } from "fauna";
+import { container } from "../../cli.mjs";
+import { throwForV10Error } from "../../lib/fauna.mjs";
+import { commonQueryOptions } from "../../lib/command-helpers.mjs";
+
+async function deleteDatabase(argv) {
+  const logger = container.resolve("logger");
+  const runV10Query = container.resolve("runV10Query");
+
+  try {
+    await runV10Query({
+      url: argv.url,
+      secret: argv.secret,
+      query: fql`Database.byName(${argv.name}).delete()`,
+    });
+    logger.stdout(`Database '${argv.name}' was successfully deleted.`);
+  } catch (e) {
+    if (e instanceof FaunaError) {
+      throwForV10Error(e, {
+        onDocumentNotFound: () =>
+          `Not found: Database '${argv.name}' not found. Please check the database name and try again.`,
+      });
+    }
+    throw e;
+  }
+}
+
+function buildDeleteCommand(yargs) {
+  return yargs
+    .options({
+      name: {
+        type: "string",
+        description: "the name of the database to delete",
+      },
+      ...commonQueryOptions,
+    })
+    .demandOption("name")
+    .version(false)
+    .help("help", "show help");
+}
+
+export default {
+  command: "delete",
+  description: "Deletes a database",
+  builder: buildDeleteCommand,
+  handler: deleteDatabase,
+};

--- a/src/commands/database/delete.mjs
+++ b/src/commands/database/delete.mjs
@@ -32,11 +32,11 @@ function buildDeleteCommand(yargs) {
     .options({
       name: {
         type: "string",
+        required: true,
         description: "the name of the database to delete",
       },
       ...commonQueryOptions,
     })
-    .demandOption("name")
     .version(false)
     .help("help", "show help");
 }

--- a/src/lib/fauna.mjs
+++ b/src/lib/fauna.mjs
@@ -100,6 +100,7 @@ export const runV10Query = async ({
  * @param {(e: ServiceError) => string} [handlers.onLimitExceeded] - Handler for rate/resource limit errors
  * @param {(e: ServiceError) => string} [handlers.onTimeOut] - Handler for timeout errors
  * @param {(e: ServiceError) => string} [handlers.onInternalError] - Handler for internal server errors
+ * @param {(e: ServiceError) => string} [handlers.onDocumentNotFound] - Handler for document not found errors
  * @param {(e: ClientError) => string} [handlers.onClientError] - Handler for general client errors
  * @param {(e: ClientClosedError) => string} [handlers.onClientClosedError] - Handler for closed client errors
  * @param {(e: NetworkError) => string} [handlers.onNetworkError] - Handler for network-related errors
@@ -121,7 +122,7 @@ export const throwForV10Error = (e, handlers = {}) => {
       case "unauthorized":
         throw new Error(
           handlers.onUnauthorized?.(e) ??
-            "Authentication failed: Please either log in using 'fauna login' or provide a valid database secret with '--secret'",
+            "Authentication failed: Please either log in using 'fauna login' or provide a valid database secret with '--secret'.",
         );
       case "forbidden":
         throw new Error(handlers.onForbidden?.(e) ?? e.message);
@@ -133,6 +134,8 @@ export const throwForV10Error = (e, handlers = {}) => {
         throw new Error(handlers.onTimeOut?.(e) ?? e.message);
       case "internal_error":
         throw new Error(handlers.onInternalError?.(e) ?? e.message);
+      case "document_not_found":
+        throw new Error(handlers.onDocumentNotFound?.(e) ?? e.message);
       default:
         throw e;
     }

--- a/test/database/create.mjs
+++ b/test/database/create.mjs
@@ -1,11 +1,10 @@
 //@ts-check
 
-import * as awilix from "awilix";
-import { expect } from "chai";
-import chalk from "chalk";
-import { fql, ServiceError } from "fauna";
 import sinon from "sinon";
-
+import chalk from "chalk";
+import { expect } from "chai";
+import * as awilix from "awilix";
+import { fql, ServiceError } from "fauna";
 import { builtYargs, run } from "../../src/cli.mjs";
 import { setupTestContainer as setupContainer } from "../../src/config/setup-test-container.mjs";
 

--- a/test/database/delete.mjs
+++ b/test/database/delete.mjs
@@ -1,11 +1,10 @@
 //@ts-check
 
-import * as awilix from "awilix";
-import { expect } from "chai";
 import chalk from "chalk";
-import { fql, ServiceError } from "fauna";
 import sinon from "sinon";
-
+import { expect } from "chai";
+import * as awilix from "awilix";
+import { fql, ServiceError } from "fauna";
 import { builtYargs, run } from "../../src/cli.mjs";
 import { setupTestContainer as setupContainer } from "../../src/config/setup-test-container.mjs";
 

--- a/test/database/delete.mjs
+++ b/test/database/delete.mjs
@@ -9,7 +9,7 @@ import sinon from "sinon";
 import { builtYargs, run } from "../../src/cli.mjs";
 import { setupTestContainer as setupContainer } from "../../src/config/setup-test-container.mjs";
 
-describe("database create", () => {
+describe("database delete", () => {
   let container, logger, runV10Query;
 
   beforeEach(() => {
@@ -20,8 +20,8 @@ describe("database create", () => {
   });
 
   [
-    { missing: "name", command: "database create --secret 'secret'" },
-    { missing: "secret", command: "database create --name 'name'" },
+    { missing: "name", command: "database delete --secret 'secret'" },
+    { missing: "secret", command: "database delete --name 'name'" },
   ].forEach(({ missing, command }) => {
     it(`requires a ${missing}`, async () => {
       try {
@@ -41,18 +41,6 @@ describe("database create", () => {
       args: "--name 'testdb' --secret 'secret'",
       expected: { name: "testdb", secret: "secret" },
     },
-    {
-      args: "--name 'testdb' --secret 'secret' --typechecked",
-      expected: { name: "testdb", secret: "secret", typechecked: true },
-    },
-    {
-      args: "--name 'testdb' --secret 'secret' --protected",
-      expected: { name: "testdb", secret: "secret", protected: true },
-    },
-    {
-      args: "--name 'testdb' --secret 'secret' --priority 10",
-      expected: { name: "testdb", secret: "secret", priority: 10 },
-    },
   ].forEach(({ args, expected }) => {
     describe("calls fauna with the user specified arguments", () => {
       it(`${args}`, async () => {
@@ -60,12 +48,7 @@ describe("database create", () => {
         expect(runV10Query).to.have.been.calledOnceWith({
           url: sinon.match.string,
           secret: expected.secret,
-          query: fql`Database.create({
-            name: ${expected.name},
-            protected: ${expected.protected ?? null},
-            typechecked: ${expected.typechecked ?? null},
-            priority: ${expected.priority ?? null},
-          })`,
+          query: fql`Database.byName(${expected.name}).delete()`,
         });
       });
     });
@@ -74,17 +57,17 @@ describe("database create", () => {
   [
     {
       error: new ServiceError({
-        error: { code: "constraint_failure", message: "whatever" },
-      }),
-      expectedMessage:
-        "Constraint failure: The database 'testdb' may already exists or one of the provided options may be invalid.",
-    },
-    {
-      error: new ServiceError({
         error: { code: "unauthorized", message: "whatever" },
       }),
       expectedMessage:
         "Authentication failed: Please either log in using 'fauna login' or provide a valid database secret with '--secret'.",
+    },
+    {
+      error: new ServiceError({
+        error: { code: "document_not_found", message: "whatever" },
+      }),
+      expectedMessage:
+        "Not found: Database 'testdb' not found. Please check the database name and try again.",
     },
   ].forEach(({ error, expectedMessage }) => {
     it(`handles ${error.code} errors when calling fauna`, async () => {
@@ -95,7 +78,7 @@ describe("database create", () => {
 
       try {
         await run(
-          `database create --name 'testdb' --secret 'secret'`,
+          `database delete --name 'testdb' --secret 'secret'`,
           container,
         );
       } catch (e) {}


### PR DESCRIPTION
Ticket(s): FE-6127

## Problem
We do not support the `fauna database delete` command yet.

## Solution
- Wire up this command following the patterns established by `fauna database create`.
- Ensure we handle some of the common error scenarios a user might run into. For example, the database does not exist.

## Result
You can delete a database using `fauna database delete --name <db_name> --secret <parent_db_secret>`

## Out of Scope
Authenticating with the credentials vended by `fauna login`.

## Testing
Added units to ensure we handle args correctly and call fauna/handle errors correctly.

<img width="1072" alt="Screenshot 2024-11-25 at 2 20 57 PM" src="https://github.com/user-attachments/assets/8cc5c7ac-d749-4e94-a391-8ca665338cf5">
