### PR TITLE
implement basic path completions

### DIFF
--- a/src/commands/query.mjs
+++ b/src/commands/query.mjs
@@ -23,6 +23,9 @@ function validate(argv) {
   const { existsSync, accessSync, constants } = container.resolve("fs");
   const dirname = container.resolve("dirname");
 
+  // don't validate completion invocations
+  if (argv.getYargsCompletions) return;
+
   if (argv.input && argv.fql) {
     throw new ValidationError("Cannot specify both --input and [fql]");
   }

--- a/src/lib/command-helpers.mjs
+++ b/src/lib/command-helpers.mjs
@@ -165,8 +165,12 @@ export const resolveFormat = (argv) => {
  * @param {string} argv.database - The database to use
  * @param {string} argv.secret - The secret to use
  * @param {boolean} argv.local - Whether to use a local Fauna container
+ * @param {boolean|undefined} argv.getYargsCompletions - Whether this CLI run is to generate completions
  */
 export const validateDatabaseOrSecret = (argv) => {
+  // don't validate completion invocations
+  if (argv.getYargsCompletions) return true;
+
   if (!argv.database && !argv.secret && !argv.local) {
     throw new ValidationError(
       "No database or secret specified. Please use either --database, --secret, or --local to connect to your desired Fauna database.",

--- a/src/lib/completions.mjs
+++ b/src/lib/completions.mjs
@@ -1,0 +1,45 @@
+// @ts-check
+
+import * as path from "node:path";
+
+import { FaunaAccountClient } from "../lib/fauna-account-client.mjs";
+import { buildCredentials } from "./auth/credentials.mjs";
+import { getConfig, locateConfig } from "./config/config.mjs";
+
+export function getProfileCompletions(currentWord, argv) {
+  const configPath = locateConfig(path.resolve(argv.config));
+  if (!configPath) return undefined;
+  return Object.keys(getConfig(configPath).toJSON());
+}
+
+export async function getDbCompletions(currentWord, argv) {
+  const regionGroups = ["us-std", "eu-std", "global"];
+
+  function getRegionGroup(currentWord) {
+    const rg = regionGroups.filter((rg) => currentWord.startsWith(rg));
+    return rg.length ? rg[0] : undefined;
+  }
+
+  if (!getRegionGroup(currentWord)) {
+    return regionGroups;
+  } else {
+    const { pageSize } = argv;
+    buildCredentials({ ...argv, user: "default" });
+    const accountClient = new FaunaAccountClient();
+    try {
+      const response = await accountClient.listDatabases({
+        pageSize,
+        path: currentWord,
+      });
+      return response.results.map(({ name }) => path.join(currentWord, name));
+    } catch (e) {
+      const response = await accountClient.listDatabases({
+        pageSize,
+        path: path.dirname(currentWord),
+      });
+      return response.results.map(({ name }) =>
+        path.join(path.dirname(currentWord), name),
+      );
+    }
+  }
+}

--- a/src/lib/config/config.mjs
+++ b/src/lib/config/config.mjs
@@ -35,6 +35,10 @@ export function getConfig(path) {
   return yaml.parseDocument(fileBody);
 }
 
+export function locateConfig(path) {
+  return path === process.cwd() ? checkForDefaultConfig(process.cwd()) : path;
+}
+
 /**
  * Checks the specified directory for default configuration files.
  *
@@ -96,7 +100,7 @@ function validateConfig(profileName, profileBody, configPath) {
  *
  * @param {string|string[]} argvInput - The raw command line arguments.
  * @param {string} path
- * @returns {object} - The yargs parser
+ * @returns {object} - The parsed argv
  */
 export function configParser(argvInput, path) {
   const userProvidedConfigPath =

--- a/src/lib/middleware.mjs
+++ b/src/lib/middleware.mjs
@@ -72,11 +72,11 @@ export function checkForUpdates(argv) {
  * If --local is provided and --secret is not, argv.secret is
  * set to 'secret'.
  * @param {import('yargs').Arguments} argv
- * @returns {import('yargs').Arguments}
+ * @returns {void}
  */
 export function applyLocalArg(argv) {
   applyLocalToUrl(argv);
-  return applyLocalToSecret(argv);
+  applyLocalToSecret(argv);
 }
 
 /**

--- a/test/completions.mjs
+++ b/test/completions.mjs
@@ -1,0 +1,220 @@
+//@ts-check
+
+import { expect } from "chai";
+import { match, stub } from "sinon";
+
+import { run } from "../src/cli.mjs";
+import { setupTestContainer as setupContainer } from "../src/config/setup-test-container.mjs";
+import { validDefaultConfigNames } from "../src/lib/config/config.mjs";
+import { eventually, mockAccessKeysFile } from "./helpers.mjs";
+
+const realLogger = console.log; // eslint-disable-line no-console
+/**
+ * @param {object} args
+ * @prop {string} [configPath]
+ * @prop {string} [matchFlag = ""] - the option/argument/flag before the substring to generate completions for. in `fauna query --profile hello`, the matchFlag is `profile`; do not include the leading `--`.
+ * @prop {string} [matchSubstring = ""] - the substring generate completions for. in `fauna query --profile hello`, the matchSubstring is `hello`.
+ * @prop {string} [command]
+ * @prop {Record<string, string>} [env]
+ * @prop {any} container
+ */
+async function complete({
+  configPath,
+  matchFlag = "",
+  matchSubstring = "",
+  container,
+  command,
+  env,
+}) {
+  // to test these manually in zsh/bash, do:
+  // `fauna --get-yargs-completions fauna query --database "us-std/stringToComplete"`
+  let commandString = `fauna --get-yargs-completions fauna`;
+  if (command) commandString += ` ${command}`;
+  if (configPath) commandString += ` --config ${configPath}`;
+  commandString += ` --${matchFlag} ${matchSubstring}`;
+  process.argv = commandString.split(" ");
+
+  if (env) {
+    for (const [key, value] of Object.entries(env)) {
+      process.env[key] = value;
+    }
+  }
+
+  await run(commandString.split(" "), container);
+}
+
+const basicConfig = {
+  default: {},
+  dev: {},
+  prod: {},
+};
+
+const advancedConfig = {
+  development: {},
+  production: {},
+};
+
+const defaultNameConfig = {
+  plain: {},
+  boring: {},
+};
+
+describe("shell completion", () => {
+  let container, fs, fakeLogger;
+
+  beforeEach(() => {
+    // reset the container before each test
+    container = setupContainer();
+
+    fakeLogger = stub();
+    console.log = fakeLogger; // eslint-disable-line no-console
+    fs = container.resolve("fs");
+  });
+
+  after(() => {
+    console.log = realLogger; // eslint-disable-line no-console
+  });
+
+  describe("for profiles", () => {
+    beforeEach(() => {
+      fs.readdirSync.withArgs(match.any).returns([
+        {
+          isFile: () => true,
+          name: validDefaultConfigNames[0],
+          path: process.cwd(),
+          parentParth: process.cwd(),
+        },
+      ]);
+      fs.readFileSync
+        .withArgs("/config/basic.yaml")
+        .returns(JSON.stringify(basicConfig));
+      fs.readFileSync
+        .withArgs("/config/advanced.yaml")
+        .returns(JSON.stringify(advancedConfig));
+      fs.readFileSync
+        .withArgs(validDefaultConfigNames[0])
+        .returns(JSON.stringify(defaultNameConfig));
+    });
+
+    it("works with config files in the same directory with default names", async () => {
+      await complete({
+        container,
+        matchFlag: "profile",
+      });
+      expect(fakeLogger).to.have.been.calledWith("plain");
+      expect(fakeLogger).to.have.been.calledWith("boring");
+    });
+
+    it("works with config files chosen by flag or env var", async () => {
+      await complete({
+        container,
+        matchFlag: "profile",
+        env: {
+          FAUNA_CONFIG: "/config/basic.yaml",
+        },
+      });
+      expect(fakeLogger).to.have.been.calledWith("default");
+      expect(fakeLogger).to.have.been.calledWith("dev");
+      expect(fakeLogger).to.have.been.calledWith("prod");
+    });
+
+    it("prioritizes config file paths provided by flag over env vars", async () => {
+      await complete({
+        container,
+        matchFlag: "profile",
+        env: {
+          FAUNA_CONFIG: "/config/basic.yaml",
+        },
+        configPath: "/config/advanced.yaml",
+      });
+      expect(fakeLogger).to.have.been.calledWith("development");
+      expect(fakeLogger).to.have.been.calledWith("production");
+    });
+
+    it.skip("is resilient against wrapping quotes", async () => {});
+  });
+
+  describe("for databases", () => {
+    beforeEach(() => {
+      // reset the container before each test
+      container = setupContainer();
+      fs = container.resolve("fs");
+      fs.readdirSync.withArgs(match.any).returns([
+        {
+          isFile: () => true,
+          name: validDefaultConfigNames[0],
+          path: process.cwd(),
+          parentParth: process.cwd(),
+        },
+      ]);
+      fs.readFileSync
+        .withArgs("/config/basic.yaml")
+        .returns(JSON.stringify(basicConfig));
+      mockAccessKeysFile({ fs });
+
+      let makeAccountRequest = container.resolve("makeAccountRequest");
+      const stubbedResponse = { results: [{ name: "americacentric" }] };
+      makeAccountRequest
+        .withArgs(match({ path: "/databases", params: { path: "us-std" } }))
+        .resolves(stubbedResponse);
+    });
+
+    it("suggests a region group if the current word doesn't start with a region group", async () => {
+      await complete({
+        container,
+        matchFlag: "database",
+        command: "query",
+      });
+      expect(fakeLogger).to.have.been.calledWith("eu-std");
+      expect(fakeLogger).to.have.been.calledWith("us-std");
+      expect(fakeLogger).to.have.been.calledWith("global");
+    });
+
+    it("suggests a top level database in the selected region group", async () => {
+      let makeAccountRequest = container.resolve("makeAccountRequest");
+      const stubbedResponse = { results: [{ name: "eurocentric" }] };
+      makeAccountRequest
+        .withArgs(match({ path: "/databases", params: { path: "eu-std" } }))
+        .resolves(stubbedResponse);
+      await complete({
+        container,
+        matchFlag: "database",
+        matchSubstring: "eu-std/",
+        command: "query",
+      });
+
+      await eventually(() => {
+        expect(fakeLogger).to.have.been.calledWith("eu-std/eurocentric");
+      });
+    });
+
+    it("suggests a nested level database in the selected region group", async () => {
+      let makeAccountRequest = container.resolve("makeAccountRequest");
+      const stubbedResponse = {
+        results: [{ name: "1" }, { name: "2" }, { name: "3" }, { name: "4" }],
+      };
+      makeAccountRequest
+        .withArgs(
+          match({ path: "/databases", params: { path: "eu-std/a/b/c/d" } }),
+        )
+        .resolves(stubbedResponse);
+
+      await complete({
+        container,
+        matchFlag: "database",
+        matchSubstring: "eu-std/a/b/c/d",
+        command: "query",
+      });
+      await eventually(() => {
+        expect(fakeLogger).to.have.been.calledWith("eu-std/a/b/c/d/1");
+        expect(fakeLogger).to.have.been.calledWith("eu-std/a/b/c/d/2");
+        expect(fakeLogger).to.have.been.calledWith("eu-std/a/b/c/d/3");
+        expect(fakeLogger).to.have.been.calledWith("eu-std/a/b/c/d/4");
+      });
+    });
+
+    it.skip("is resilient against trailing slashes", async () => {});
+
+    it.skip("is resilient against wrapping quotes", async () => {});
+  });
+});

--- a/test/helpers.mjs
+++ b/test/helpers.mjs
@@ -208,3 +208,18 @@ export const mockSecretKeysFile = ({
       `{${accountKey}: { "${path}:${role}": {"secret": "${secret}", "expiresAt": ${expiresAt}}}}`,
     );
 };
+
+/**
+ * retry an assertion repeatedly until it succeeds
+ * @param {function} evaluator - any function that throws if a condition isn't met.
+ * @param {number} [ms=50] - the number of milliseconds to wait for the condition. set it lower than mocha's timeout to re-throw the underlying error and have usable test failure logs.
+ */
+export async function eventually(evaluator, ms = 50) {
+  try {
+    return evaluator();
+  } catch (e) {
+    if (ms <= 0) throw e;
+    await new Promise((resolve) => setTimeout(resolve, 1)); // eslint-disable-line no-promise-executor-return
+    return eventually(evaluator, ms - 1);
+  }
+}


### PR DESCRIPTION
this change adds:
- the default yargs completions for commands, options, etc.
- custom completions for profiles (given that you have a config specified)
- custom completions for database path (given that you have specified enough information to make a request to fauna)