### PR TITLE
Cleanup common options when talking to fauna

### DIFF
--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -1,0 +1,148 @@
+// @ts-check
+
+import chalk from "chalk";
+import yargs from "yargs";
+
+import databaseCommand from "./commands/database/database.mjs";
+import evalCommand from "./commands/eval.mjs";
+import keyCommand from "./commands/key.mjs";
+import loginCommand from "./commands/login.mjs";
+import schemaCommand from "./commands/schema/schema.mjs";
+import shellCommand from "./commands/shell.mjs";
+import { authNZMiddleware } from "./lib/auth/authNZ.mjs";
+import { checkForUpdates, fixPaths, logArgv } from "./lib/middleware.mjs";
+
+/** @typedef {import('awilix').AwilixContainer<import('./config/setup-container.mjs').modifiedInjectables> } cliContainer */
+
+/** @type {cliContainer} */
+export let container;
+/** @type {import('yargs').Argv} */
+export let builtYargs;
+
+/**
+ * @param {string|string[]} argvInput - The command string provided by the user or test. Parsed by yargs into an argv object.
+ * @param {cliContainer} _container - A built and ready for use awilix container with registered injectables.
+ */
+export async function run(argvInput, _container) {
+  container = _container;
+  const logger = container.resolve("logger");
+  const parseYargs = container.resolve("parseYargs");
+  if (process.env.NODE_ENV === "production") {
+    process.removeAllListeners("warning");
+  }
+
+  try {
+    builtYargs = buildYargs(argvInput);
+    await parseYargs(builtYargs);
+  } catch (e) {
+    let subMessage = chalk.reset(
+      "Use 'fauna <command> --help' for more information about a command.",
+    );
+
+    if (argvInput.length > 0) {
+      subMessage = chalk.red(e.message);
+    }
+    const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${subMessage}`;
+    logger.stderr(message);
+    logger.fatal(e.stack, "error");
+    const exitCode = e.exitCode !== undefined ? e.exitCode : 1;
+    container.resolve("errorHandler")(e, exitCode);
+  }
+}
+
+/**
+ * This is split out so it can be injected & spied on. This allows ensuring that,
+ * e.g., it's only run once per command invocation.
+ * @param {import('yargs').Argv<any>} builtYargs
+ * @returns {Promise<any>} builtYargs
+ */
+export async function parseYargs(builtYargs) {
+  return builtYargs.parseAsync();
+}
+
+/**
+ * @param {string|string[]} argvInput
+ * @returns {import('yargs').Argv<any>}
+ */
+function buildYargs(argvInput) {
+  // have to build a yargsInstance _before_ chaining off it
+  // https://github.com/yargs/yargs/blob/main/docs/typescript.md?plain=1#L124
+  const yargsInstance = yargs(argvInput);
+
+  // these debug commands are used by the tests in environments where they can't mock out the command handler
+  if (
+    process.env.NODE_ENV !== "production" ||
+    process.env.DEBUG_COMMANDS === "true"
+  ) {
+    yargsInstance
+      .command("throw", false, {
+        handler: () => {
+          throw new Error("this is a test error");
+        },
+        builder: {},
+      })
+      .command("reject", false, {
+        handler: async () => {
+          throw new Error("this is a rejected promise");
+        },
+        builder: {},
+      })
+      .command("warn", false, {
+        handler: async () => {
+          process.emitWarning("this is a warning emited on the node process");
+        },
+        builder: {},
+      });
+  }
+
+  return yargsInstance
+    .scriptName("fauna")
+    .middleware([checkForUpdates, logArgv], true)
+    .middleware([fixPaths, authNZMiddleware], false)
+    .command("eval", "evaluate a query", evalCommand)
+    .command("shell", "start an interactive shell", shellCommand)
+    .command("login", "login via website", loginCommand)
+    .command(keyCommand)
+    .command(schemaCommand)
+    .command(databaseCommand)
+    .demandCommand()
+    .strict(true)
+    .options({
+      profile: {
+        alias: "p",
+        type: "string",
+        description: "a user profile",
+        default: "default",
+      },
+      color: {
+        description:
+          "whether or not to emit escape codes for multi-color terminal output.",
+        type: "boolean",
+        // https://github.com/chalk/chalk?tab=readme-ov-file#chalklevel
+        default: chalk.level > 0,
+      },
+      verbosity: {
+        description: "the lowest level diagnostic logs to emit",
+        type: "number",
+        default: 0,
+      },
+      verboseComponent: {
+        description:
+          "components to emit diagnostic logs for; this takes precedence over the 'verbosity' flag",
+        type: "array",
+        default: [],
+        choices: ["fetch", "error", "argv"],
+      },
+      // Whether authNZ middleware should run. Better way of doing this?
+      authRequired: {
+        hidden: true,
+        default: false,
+      },
+    })
+    .wrap(yargsInstance.terminalWidth())
+    .help("help", "show help")
+    .fail(false)
+    .exitProcess(false)
+    .version(false)
+    .completion();
+}

--- a/src/commands/database/create.mjs
+++ b/src/commands/database/create.mjs
@@ -1,0 +1,64 @@
+//@ts-check
+
+import { FaunaError, fql } from "fauna";
+import { container } from "../../cli.mjs";
+import { throwForV10Error } from "../../lib/fauna.mjs";
+
+async function createDatabase(argv) {
+  const logger = container.resolve("logger");
+  const runV10Query = container.resolve("runV10Query");
+
+  try {
+    await runV10Query({
+      url: argv.url,
+      secret: argv.secret,
+      query: fql`Database.create({
+        name: ${argv.name},
+        protected: ${argv.protected ?? null},
+        typechecked: ${argv.typechecked ?? null},
+        priority: ${argv.priority ?? null},
+      })`,
+    });
+    logger.stdout(`Database '${argv.name}' was successfully created.`);
+  } catch (e) {
+    if (e instanceof FaunaError) {
+      throwForV10Error(e, {
+        onConstraintFailure: () =>
+          `Constraint failure: The database '${argv.name}' may already exists or one of the provided options may be invalid.`,
+      });
+    }
+    throw e;
+  }
+}
+
+function buildCreateCommand(yargs) {
+  return yargs
+    .options({
+      name: {
+        type: "string",
+        required: true,
+        description: "the name of the database to create",
+      },
+      typechecked: {
+        type: "string",
+        description: "enable typechecking for the database",
+      },
+      protected: {
+        type: "boolean",
+        description: "allow destructive schema changes",
+      },
+      priority: {
+        type: "number",
+        description: "user-defined priority assigned to the child database",
+      },
+    })
+    .version(false)
+    .help("help", "show help");
+}
+
+export default {
+  command: "create",
+  description: "Creates a database",
+  builder: buildCreateCommand,
+  handler: createDatabase,
+};

--- a/src/commands/database/database.mjs
+++ b/src/commands/database/database.mjs
@@ -1,0 +1,46 @@
+//@ts-check
+
+import listCommand from "./list.mjs";
+import createCommand from "./create.mjs";
+import deleteCommand from "./delete.mjs";
+import { container } from "../../cli.mjs";
+import { commonQueryOptions } from "../../lib/command-helpers.mjs";
+
+function validateArgs(argv) {
+  const logger = container.resolve("logger");
+
+  if (argv.secret && argv.database) {
+    // Providing a database and secret are conflicting options. If both are provided,
+    // it is not clear which one to use.
+    throw new Error(
+      "Cannot use both the '--secret' and '--database' options together. Please specify only one.",
+    );
+  } else if (argv.role && argv.secret) {
+    // The '--role' option is not supported when using a secret. Secrets have an
+    // implicit role.
+    logger.warn(
+      "The '--role' option is not supported when using a secret. It will be ignored.",
+    );
+  }
+  return true;
+}
+
+function buildDatabase(yargs) {
+  return yargs
+    .options(commonQueryOptions)
+    .check(validateArgs)
+    .command(listCommand)
+    .command(createCommand)
+    .command(deleteCommand)
+    .version(false)
+    .help("help", "show help");
+}
+
+export default {
+  command: "database",
+  aliases: ["db"],
+  describe: "Interact with your databases",
+  builder: buildDatabase,
+  // eslint-disable-next-line no-empty-function
+  handler: () => {},
+};

--- a/src/commands/database/delete.mjs
+++ b/src/commands/database/delete.mjs
@@ -1,0 +1,47 @@
+//@ts-check
+
+import { FaunaError, fql } from "fauna";
+import { container } from "../../cli.mjs";
+import { throwForV10Error } from "../../lib/fauna.mjs";
+
+async function deleteDatabase(argv) {
+  const logger = container.resolve("logger");
+  const runV10Query = container.resolve("runV10Query");
+
+  try {
+    await runV10Query({
+      url: argv.url,
+      secret: argv.secret,
+      query: fql`Database.byName(${argv.name}).delete()`,
+    });
+    logger.stdout(`Database '${argv.name}' was successfully deleted.`);
+  } catch (e) {
+    if (e instanceof FaunaError) {
+      throwForV10Error(e, {
+        onDocumentNotFound: () =>
+          `Not found: Database '${argv.name}' not found. Please check the database name and try again.`,
+      });
+    }
+    throw e;
+  }
+}
+
+function buildDeleteCommand(yargs) {
+  return yargs
+    .options({
+      name: {
+        type: "string",
+        required: true,
+        description: "the name of the database to delete",
+      },
+    })
+    .version(false)
+    .help("help", "show help");
+}
+
+export default {
+  command: "delete",
+  description: "Deletes a database",
+  builder: buildDeleteCommand,
+  handler: deleteDatabase,
+};

--- a/src/lib/command-helpers.mjs
+++ b/src/lib/command-helpers.mjs
@@ -1,0 +1,97 @@
+//@ts-check
+
+function buildHeaders() {
+  const headers = {
+    "X-Fauna-Source": "Fauna Shell",
+  };
+  if (!["ShellCommand", "EvalCommand"].includes(constructor.name)) {
+    headers["x-fauna-shell-builtin"] = "true";
+  }
+  return headers;
+}
+
+export async function getSimpleClient(argv) {
+  let client;
+  if (argv.version === "4") {
+    const faunadb = (await import("faunadb")).default;
+    const { Client, query: q } = faunadb;
+    const { hostname, port, protocol } = new URL(argv.url);
+    const scheme = protocol?.replace(/:$/, "");
+    client = new Client({
+      domain: hostname,
+      port: Number(port),
+      scheme: /** @type {('http'|'https')} */ (scheme),
+      secret: argv.secret,
+      timeout: argv.timeout,
+
+      fetch: fetch,
+
+      headers: buildHeaders(),
+    });
+
+    // validate the client settings
+    await client.query(q.Now());
+  } else {
+    const FaunaClient = (await import("./fauna-client.mjs")).default;
+    client = new FaunaClient({
+      endpoint: argv.url,
+      secret: argv.secret,
+      timeout: argv.timeout,
+    });
+
+    // validate the client settings
+    await client.query("0");
+  }
+
+  return client;
+}
+
+// used for queries customers can't configure that are made on their behalf
+export const commonQueryOptions = {
+  url: {
+    alias: "u",
+    type: "string",
+    description: "the Fauna URL to query",
+    default: "https://db.fauna.com:443",
+  },
+  secret: {
+    alias: "s",
+    type: "string",
+    description: "the database secret to use when calling Fauna",
+  },
+  database: {
+    alias: "d",
+    type: "string",
+    description: "a database path, including region",
+  },
+  role: {
+    alias: "r",
+    type: "string",
+    description: "the role to use when calling Fauna",
+    default: "admin",
+  },
+};
+
+// used for queries customers can configure
+export const commonConfigurableQueryOptions = {
+  ...commonQueryOptions,
+  // TODO: is this unused? i think it might be
+  version: {
+    description: "which FQL version to use",
+    type: "string",
+    alias: "v",
+    default: "10",
+    choices: ["4", "10"],
+  },
+  // v10 specific options
+  typecheck: {
+    type: "boolean",
+    description: "enable typechecking",
+    default: undefined,
+  },
+  timeout: {
+    type: "number",
+    description: "connection timeout in milliseconds",
+    default: 5000,
+  },
+};

--- a/test/database/create.mjs
+++ b/test/database/create.mjs
@@ -1,0 +1,105 @@
+//@ts-check
+
+import sinon from "sinon";
+import chalk from "chalk";
+import { expect } from "chai";
+import * as awilix from "awilix";
+import { fql, ServiceError } from "fauna";
+import { builtYargs, run } from "../../src/cli.mjs";
+import { setupTestContainer as setupContainer } from "../../src/config/setup-test-container.mjs";
+
+describe("database create", () => {
+  let container, logger, runV10Query;
+
+  beforeEach(() => {
+    // reset the container before each test
+    container = setupContainer();
+    logger = container.resolve("logger");
+    runV10Query = container.resolve("runV10Query");
+  });
+
+  [{ missing: "name", command: "database create --secret 'secret'" }].forEach(
+    ({ missing, command }) => {
+      it(`requires a ${missing}`, async () => {
+        try {
+          await run(command, container);
+        } catch (e) {}
+
+        const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
+          `Missing required argument: ${missing}`,
+        )}`;
+        expect(logger.stderr).to.have.been.calledWith(message);
+        expect(container.resolve("parseYargs")).to.have.been.calledOnce;
+      });
+    },
+  );
+
+  [
+    {
+      args: "--name 'testdb' --secret 'secret'",
+      expected: { name: "testdb", secret: "secret" },
+    },
+    {
+      args: "--name 'testdb' --secret 'secret' --typechecked",
+      expected: { name: "testdb", secret: "secret", typechecked: true },
+    },
+    {
+      args: "--name 'testdb' --secret 'secret' --protected",
+      expected: { name: "testdb", secret: "secret", protected: true },
+    },
+    {
+      args: "--name 'testdb' --secret 'secret' --priority 10",
+      expected: { name: "testdb", secret: "secret", priority: 10 },
+    },
+  ].forEach(({ args, expected }) => {
+    describe("calls fauna with the user specified arguments", () => {
+      it(`${args}`, async () => {
+        await run(`database create ${args}`, container);
+        expect(runV10Query).to.have.been.calledOnceWith({
+          url: sinon.match.string,
+          secret: expected.secret,
+          query: fql`Database.create({
+            name: ${expected.name},
+            protected: ${expected.protected ?? null},
+            typechecked: ${expected.typechecked ?? null},
+            priority: ${expected.priority ?? null},
+          })`,
+        });
+      });
+    });
+  });
+
+  [
+    {
+      error: new ServiceError({
+        error: { code: "constraint_failure", message: "whatever" },
+      }),
+      expectedMessage:
+        "Constraint failure: The database 'testdb' may already exists or one of the provided options may be invalid.",
+    },
+    {
+      error: new ServiceError({
+        error: { code: "unauthorized", message: "whatever" },
+      }),
+      expectedMessage:
+        "Authentication failed: Please either log in using 'fauna login' or provide a valid database secret with '--secret'.",
+    },
+  ].forEach(({ error, expectedMessage }) => {
+    it(`handles ${error.code} errors when calling fauna`, async () => {
+      const runV10QueryStub = sinon.stub().rejects(error);
+      container.register({
+        runV10Query: awilix.asValue(runV10QueryStub),
+      });
+
+      try {
+        await run(
+          `database create --name 'testdb' --secret 'secret'`,
+          container,
+        );
+      } catch (e) {}
+
+      const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(expectedMessage)}`;
+      expect(logger.stderr).to.have.been.calledWith(message);
+    });
+  });
+});

--- a/test/database/database.mjs
+++ b/test/database/database.mjs
@@ -1,0 +1,48 @@
+//@ts-check
+
+import chalk from "chalk";
+import { expect } from "chai";
+import { builtYargs, run } from "../../src/cli.mjs";
+import { setupTestContainer as setupContainer } from "../../src/config/setup-test-container.mjs";
+
+describe("database create", () => {
+  let container, logger, runV10Query;
+
+  beforeEach(() => {
+    // reset the container before each test
+    container = setupContainer();
+    logger = container.resolve("logger");
+    runV10Query = container.resolve("runV10Query");
+  });
+
+  [
+    {
+      command:
+        "database create --name 'name' --secret 'secret' --database 'database'",
+      message:
+        "Cannot use both the '--secret' and '--database' options together. Please specify only one.",
+    },
+    {
+      command:
+        "database delete --name 'name' --secret 'secret' --database 'database'",
+      message:
+        "Cannot use both the '--secret' and '--database' options together. Please specify only one.",
+    },
+    {
+      command: "database list --secret 'secret' --database 'database'",
+      message:
+        "Cannot use both the '--secret' and '--database' options together. Please specify only one.",
+    },
+  ].forEach(({ message, command }) => {
+    it(`requires a ${message}`, async () => {
+      try {
+        await run(command, container);
+      } catch (e) {}
+
+      expect(logger.stderr).to.have.been.calledWith(
+        `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(message)}`,
+      );
+      expect(container.resolve("parseYargs")).to.have.been.calledOnce;
+    });
+  });
+});

--- a/test/database/delete.mjs
+++ b/test/database/delete.mjs
@@ -1,0 +1,88 @@
+//@ts-check
+
+import chalk from "chalk";
+import sinon from "sinon";
+import { expect } from "chai";
+import * as awilix from "awilix";
+import { fql, ServiceError } from "fauna";
+import { builtYargs, run } from "../../src/cli.mjs";
+import { setupTestContainer as setupContainer } from "../../src/config/setup-test-container.mjs";
+
+describe("database delete", () => {
+  let container, logger, runV10Query;
+
+  beforeEach(() => {
+    // reset the container before each test
+    container = setupContainer();
+    logger = container.resolve("logger");
+    runV10Query = container.resolve("runV10Query");
+  });
+
+  [{ missing: "name", command: "database delete --secret 'secret'" }].forEach(
+    ({ missing, command }) => {
+      it(`requires a ${missing}`, async () => {
+        try {
+          await run(command, container);
+        } catch (e) {}
+
+        const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
+          `Missing required argument: ${missing}`,
+        )}`;
+        expect(logger.stderr).to.have.been.calledWith(message);
+        expect(container.resolve("parseYargs")).to.have.been.calledOnce;
+      });
+    },
+  );
+
+  [
+    {
+      args: "--name 'testdb' --secret 'secret'",
+      expected: { name: "testdb", secret: "secret" },
+    },
+  ].forEach(({ args, expected }) => {
+    describe("calls fauna with the user specified arguments", () => {
+      it(`${args}`, async () => {
+        await run(`database create ${args}`, container);
+        expect(runV10Query).to.have.been.calledOnceWith({
+          url: sinon.match.string,
+          secret: expected.secret,
+          query: fql`Database.byName(${expected.name}).delete()`,
+        });
+      });
+    });
+  });
+
+  [
+    {
+      error: new ServiceError({
+        error: { code: "unauthorized", message: "whatever" },
+      }),
+      expectedMessage:
+        "Authentication failed: Please either log in using 'fauna login' or provide a valid database secret with '--secret'.",
+    },
+    {
+      error: new ServiceError({
+        error: { code: "document_not_found", message: "whatever" },
+      }),
+      expectedMessage:
+        "Not found: Database 'testdb' not found. Please check the database name and try again.",
+    },
+  ].forEach(({ error, expectedMessage }) => {
+    it(`handles ${error.code} errors when calling fauna`, async () => {
+      const runV10QueryStub = sinon.stub().rejects(error);
+      container.register({
+        runV10Query: awilix.asValue(runV10QueryStub),
+      });
+
+      try {
+        await run(
+          `database delete --name 'testdb' --secret 'secret'`,
+          container,
+        );
+      } catch (e) {}
+
+      const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(expectedMessage)}`;
+      expect(logger.stderr).to.have.been.calledWith(message);
+    });
+  });
+});

--- a/test/general-cli.mjs
+++ b/test/general-cli.mjs
@@ -1,0 +1,214 @@
+//@ts-check
+
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import * as awilix from "awilix";
+import { expect } from "chai";
+import chalk from "chalk";
+import { stub } from "sinon";
+
+import { builtYargs, run } from "../src/cli.mjs";
+import { setupTestContainer as setupContainer } from "../src/config/setup-test-container.mjs";
+import { f } from "./helpers.mjs";
+
+const __dirname = import.meta.dirname;
+
+describe("cli operations", function () {
+  let container;
+
+  beforeEach(() => {
+    container = setupContainer();
+  });
+
+  it("should exit with a helpful message if a flag is not provided", async function () {
+    const logger = container.resolve("logger");
+
+    // this is missing the --secret flag
+    try {
+      await run(`database create`, container);
+    } catch (e) {}
+
+    expect(logger.stdout).to.not.be.called;
+    const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
+      "Missing required argument: name",
+    )}`;
+    expect(logger.stderr).to.have.been.calledWith(message);
+    expect(container.resolve("parseYargs")).to.have.been.calledOnce;
+  });
+
+  it("should exit with a helpful message if a non-existent flag is provided", async function () {
+    const logger = container.resolve("logger");
+
+    // the halflight flag doesn't exist
+    try {
+      await run(`schema pull --secret "secret" --halflight`, container);
+    } catch (e) {}
+
+    expect(logger.stdout).to.not.be.called;
+    const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
+      "Unknown argument: halflight",
+    )}`;
+    expect(logger.stderr).to.have.been.calledWith(message);
+    expect(container.resolve("parseYargs")).to.have.been.calledOnce;
+  });
+
+  // TODO: this doesn't work because turning on strict mode breaks parsing sub-commands. why?
+  it("should exit with a helpful message if a non-existent command is provided", async function () {
+    const logger = container.resolve("logger");
+
+    // this command does not exist
+    try {
+      await run(`inland-empire`, container);
+    } catch (e) {}
+
+    expect(logger.stdout).to.not.be.called;
+    const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
+      "Unknown argument: inland-empire",
+    )}`;
+    expect(logger.stderr).to.have.been.calledWith(message);
+    expect(container.resolve("parseYargs")).to.have.been.calledOnce;
+  });
+
+  it("should exit with a helpful message if no command is provided", async function () {
+    const logger = container.resolve("logger");
+
+    // no input
+    try {
+      await run("", container);
+    } catch (e) {}
+
+    expect(logger.stdout).to.not.be.called;
+    const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.reset(
+      "Use 'fauna <command> --help' for more information about a command.",
+    )}`;
+    expect(logger.stderr).to.have.been.calledWith(message);
+    expect(container.resolve("parseYargs")).to.have.been.calledOnce;
+  });
+
+  it("should exit with a helpful message if the handler throws", async function () {
+    const logger = container.resolve("logger");
+
+    // this hidden command's handler always throws
+    try {
+      await run(`throw`, container);
+    } catch (e) {}
+
+    expect(logger.stdout).to.not.be.called;
+    const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
+      "this is a test error",
+    )}`;
+    expect(logger.stderr).to.have.been.calledWith(message);
+    expect(container.resolve("parseYargs")).to.have.been.calledOnce;
+  });
+
+  it("should exit with a helpful message if the handler returns a rejected promise", async function () {
+    const logger = container.resolve("logger");
+
+    // this hidden command's handler always returns a rejected promise
+    try {
+      await run(`reject`, container);
+    } catch (e) {}
+
+    expect(logger.stdout).to.not.be.called;
+    const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
+      "this is a rejected promise",
+    )}`;
+    expect(logger.stderr).to.have.been.calledWith(message);
+    expect(container.resolve("parseYargs")).to.have.been.calledOnce;
+  });
+
+  it("should check for updates when run", async function () {
+    const fetch = container.resolve("fetch");
+    fetch.onCall(0).resolves(
+      f({
+        version: 0,
+        status: "none",
+        diff: "Staged schema: none",
+        pending_summary: "",
+        text_diff: "",
+      }),
+    );
+    fetch.onCall(1).resolves(
+      f({
+        version: 0,
+        diff: "",
+      }),
+    );
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = path.dirname(__filename);
+    const packagePath = path.join(__dirname, "../package.json");
+
+    const packageJson = JSON.parse(
+      fs.readFileSync(packagePath, {
+        encoding: "utf-8",
+      }),
+    );
+    const notify = stub();
+    const updateNotifier = stub().returns({ notify });
+    container.register({ updateNotifier: awilix.asValue(updateNotifier) });
+
+    await run(`schema status --secret "secret"`, container);
+
+    expect(updateNotifier).to.have.been.calledWith({
+      pkg: packageJson,
+      updateCheckInterval: 1000 * 60 * 60 * 24 * 7, // 1 week
+    });
+    expect(notify).to.have.been.called;
+  });
+
+  it("does not expose debug commands in production", async function () {
+    const cliPath = path.resolve(__dirname, "../dist/cli.cjs");
+    const { stderr } = spawnSync(cliPath, ["throw"], {
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    expect(stderr).to.include("Unknown argument: throw");
+  });
+
+  it("enables nodeJS warnings from the dev entrypoint", async function () {
+    const cliPath = path.resolve(__dirname, "../src/user-entrypoint.mjs");
+    let cli = spawnSync(cliPath, ["warn"], {
+      encoding: "utf8",
+      timeout: 5000,
+    });
+    if (cli.error) throw cli.error;
+    let stderr = cli.stderr;
+
+    // the dev script should emit warnings
+    expect(stderr).to.include(
+      "Warning: this is a warning emited on the node process",
+    );
+  });
+
+  it("suppresses nodeJS warnings from the prod entrypoint", async function () {
+    const cliPath = path.resolve(__dirname, "../dist/cli.cjs");
+    let cli = spawnSync(cliPath, ["warn"], {
+      encoding: "utf8",
+      timeout: 5000,
+      env: {
+        ...process.env,
+        DEBUG_COMMANDS: "true",
+      },
+    });
+    if (cli.error) throw cli.error;
+
+    let stderr = cli.stderr;
+    // the prod one should not
+    expect(stderr).to.equal("");
+  });
+
+  it.skip("should detect color support if the user does not specify", async function () {
+    // i can't find a way to mock this that doesn't involve setting a flag
+    // and setting a flag defeats the purpose of testing if it's _detected_ automatically
+    // skipping for now
+  });
+
+  it.skip("should only ever parse args once", async function () {
+    // for now, this is mostly taken care of by the tests above, which set assert that
+    // parseYargs was only called once in their respective error cases
+  });
+});


### PR DESCRIPTION
Ticket(s): FE-###

## Problem
We will always want to enable a certain set of options for commands that talk to fauna. These options include `url`, `secret`, `database` and `role`. At the moment these are spread around, some defined at the top level of the cli and other kept in the `commonQueryOptions` object.

## Solution
Consolidate these options in one place and setup some validation on top of them so users are warned if they specify conflicting or redundant args.

## Result
It will be easier to wire up just in time db keys for commands that talk to fauna.

## Testing
Added new tests to make sure the arg validation works.
