### PR TITLE
Fauna Query Options

### DIFF
--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -132,17 +132,6 @@ function buildYargs(argvInput) {
         description: "a user profile",
         default: "default",
       },
-      database: {
-        alias: "d",
-        type: "string",
-        description: "a database path, including region",
-      },
-      role: {
-        alias: "r",
-        type: "string",
-        description: "a role",
-        default: "admin",
-      },
       color: {
         description:
           "whether or not to emit escape codes for multi-color terminal output.",

--- a/src/commands/database/create.mjs
+++ b/src/commands/database/create.mjs
@@ -3,7 +3,6 @@
 import { FaunaError, fql } from "fauna";
 import { container } from "../../cli.mjs";
 import { throwForV10Error } from "../../lib/fauna.mjs";
-import { commonQueryOptions } from "../../lib/command-helpers.mjs";
 
 async function createDatabase(argv) {
   const logger = container.resolve("logger");
@@ -52,7 +51,6 @@ function buildCreateCommand(yargs) {
         type: "number",
         description: "user-defined priority assigned to the child database",
       },
-      ...commonQueryOptions,
     })
     .version(false)
     .help("help", "show help");

--- a/src/commands/database/database.mjs
+++ b/src/commands/database/database.mjs
@@ -3,16 +3,32 @@
 import listCommand from "./list.mjs";
 import createCommand from "./create.mjs";
 import deleteCommand from "./delete.mjs";
+import { container } from "../../cli.mjs";
+import { commonQueryOptions } from "../../lib/command-helpers.mjs";
+
+function validateArgs(argv) {
+  const logger = container.resolve("logger");
+
+  if (argv.secret && argv.database) {
+    // Providing a database and secret are conflicting options. If both are provided,
+    // it is not clear which one to use.
+    throw new Error(
+      "Cannot use both the '--secret' and '--database' options together. Please specify only one.",
+    );
+  } else if (argv.role && argv.secret) {
+    // The '--role' option is not supported when using a secret. Secrets have an
+    // implicit role.
+    logger.warn(
+      "The '--role' option is not supported when using a secret. It will be ignored.",
+    );
+  }
+  return true;
+}
 
 function buildDatabase(yargs) {
   return yargs
-    .options({
-      profile: {
-        type: "string",
-        description: "a user profile",
-        default: "default",
-      },
-    })
+    .options(commonQueryOptions)
+    .check(validateArgs)
     .command(listCommand)
     .command(createCommand)
     .command(deleteCommand)

--- a/src/commands/database/delete.mjs
+++ b/src/commands/database/delete.mjs
@@ -3,7 +3,6 @@
 import { FaunaError, fql } from "fauna";
 import { container } from "../../cli.mjs";
 import { throwForV10Error } from "../../lib/fauna.mjs";
-import { commonQueryOptions } from "../../lib/command-helpers.mjs";
 
 async function deleteDatabase(argv) {
   const logger = container.resolve("logger");
@@ -35,7 +34,6 @@ function buildDeleteCommand(yargs) {
         required: true,
         description: "the name of the database to delete",
       },
-      ...commonQueryOptions,
     })
     .version(false)
     .help("help", "show help");

--- a/src/lib/command-helpers.mjs
+++ b/src/lib/command-helpers.mjs
@@ -46,50 +46,6 @@ export async function getSimpleClient(argv) {
   return client;
 }
 
-// export async function ensureDbScopeClient({ scope, version, argv }) {
-//   const path = scope.split("/");
-
-//   const { connectionOptions } = await getClient({ version: "4", argv });
-//   const { hostname, port, protocol } = new URL(connectionOptions.url);
-
-//   if (!connectionOptions.secret.allowDatabase) {
-//     throw new Error(
-//       "Cannot specify database with a secret that contains a database"
-//     );
-//   }
-
-//   for (let i = 0; i < path.length; i++) {
-//     const client = new Client({
-//       domain: hostname,
-//       port,
-//       scheme: protocol?.replace(/:$/, ""),
-//       secret: connectionOptions.secret.buildSecret(),
-
-//       // See getClient.
-//       fetch: fetch,
-
-//       headers: _getHeaders(),
-//     });
-//     const exists = await client.query(q.Exists(q.Database(path[i])));
-//     await client.close();
-
-//     if (!exists) {
-//       const fullPath = [
-//         ...connectionOptions.secret.databaseScope,
-//         ...path.slice(0, i + 1),
-//       ];
-//       throw new Error(`Database '${fullPath.join("/")}' doesn't exist`);
-//     }
-
-//     connectionOptions.secret.appendScope(path[i]);
-//   }
-
-//   return getClient({
-//     dbScope: scope,
-//     version,
-//   });
-// }
-
 // used for queries customers can't configure that are made on their behalf
 export const commonQueryOptions = {
   url: {
@@ -100,7 +56,15 @@ export const commonQueryOptions = {
   secret: {
     type: "string",
     description: "the secret to use when calling Fauna",
-    required: true,
+  },
+  database: {
+    type: "string",
+    description: "a database path, including region",
+  },
+  role: {
+    type: "string",
+    description: "a role",
+    default: "admin",
   },
 };
 

--- a/test/database/create.mjs
+++ b/test/database/create.mjs
@@ -18,22 +18,21 @@ describe("database create", () => {
     runV10Query = container.resolve("runV10Query");
   });
 
-  [
-    { missing: "name", command: "database create --secret 'secret'" },
-    { missing: "secret", command: "database create --name 'name'" },
-  ].forEach(({ missing, command }) => {
-    it(`requires a ${missing}`, async () => {
-      try {
-        await run(command, container);
-      } catch (e) {}
+  [{ missing: "name", command: "database create --secret 'secret'" }].forEach(
+    ({ missing, command }) => {
+      it(`requires a ${missing}`, async () => {
+        try {
+          await run(command, container);
+        } catch (e) {}
 
-      const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
-        `Missing required argument: ${missing}`,
-      )}`;
-      expect(logger.stderr).to.have.been.calledWith(message);
-      expect(container.resolve("parseYargs")).to.have.been.calledOnce;
-    });
-  });
+        const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
+          `Missing required argument: ${missing}`,
+        )}`;
+        expect(logger.stderr).to.have.been.calledWith(message);
+        expect(container.resolve("parseYargs")).to.have.been.calledOnce;
+      });
+    },
+  );
 
   [
     {

--- a/test/database/database.mjs
+++ b/test/database/database.mjs
@@ -1,0 +1,48 @@
+// @ts-check
+
+import { expect } from "chai";
+import chalk from "chalk";
+
+import { builtYargs, run } from "../../src/cli.mjs";
+import { setupTestContainer as setupContainer } from "../../src/config/setup-test-container.mjs";
+
+describe("database create", () => {
+  let container, logger;
+
+  beforeEach(() => {
+    // reset the container before each test
+    container = setupContainer();
+    logger = container.resolve("logger");
+  });
+
+  [
+    {
+      command:
+        "database create --name 'name' --secret 'secret' --database 'database'",
+      message:
+        "Cannot use both the '--secret' and '--database' options together. Please specify only one.",
+    },
+    {
+      command:
+        "database delete --name 'name' --secret 'secret' --database 'database'",
+      message:
+        "Cannot use both the '--secret' and '--database' options together. Please specify only one.",
+    },
+    {
+      command: "database list --secret 'secret' --database 'database'",
+      message:
+        "Cannot use both the '--secret' and '--database' options together. Please specify only one.",
+    },
+  ].forEach(({ message, command }) => {
+    it(`requires a ${message}`, async () => {
+      try {
+        await run(command, container);
+      } catch (e) {}
+
+      expect(logger.stderr).to.have.been.calledWith(
+        `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(message)}`,
+      );
+      expect(container.resolve("parseYargs")).to.have.been.calledOnce;
+    });
+  });
+});

--- a/test/database/delete.mjs
+++ b/test/database/delete.mjs
@@ -18,22 +18,21 @@ describe("database delete", () => {
     runV10Query = container.resolve("runV10Query");
   });
 
-  [
-    { missing: "name", command: "database delete --secret 'secret'" },
-    { missing: "secret", command: "database delete --name 'name'" },
-  ].forEach(({ missing, command }) => {
-    it(`requires a ${missing}`, async () => {
-      try {
-        await run(command, container);
-      } catch (e) {}
+  [{ missing: "name", command: "database delete --secret 'secret'" }].forEach(
+    ({ missing, command }) => {
+      it(`requires a ${missing}`, async () => {
+        try {
+          await run(command, container);
+        } catch (e) {}
 
-      const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
-        `Missing required argument: ${missing}`,
-      )}`;
-      expect(logger.stderr).to.have.been.calledWith(message);
-      expect(container.resolve("parseYargs")).to.have.been.calledOnce;
-    });
-  });
+        const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
+          `Missing required argument: ${missing}`,
+        )}`;
+        expect(logger.stderr).to.have.been.calledWith(message);
+        expect(container.resolve("parseYargs")).to.have.been.calledOnce;
+      });
+    },
+  );
 
   [
     {

--- a/test/general-cli.mjs
+++ b/test/general-cli.mjs
@@ -26,7 +26,7 @@ describe("cli operations", function () {
   it("should exit with a helpful message if a flag is not provided", async function () {
     const logger = container.resolve("logger");
 
-    // this is missing the --secret flag
+    // this is missing the --name flag
     try {
       await run(`database create`, container);
     } catch (e) {}

--- a/test/general-cli.mjs
+++ b/test/general-cli.mjs
@@ -28,12 +28,12 @@ describe("cli operations", function () {
 
     // this is missing the --secret flag
     try {
-      await run(`schema pull`, container);
+      await run(`database create`, container);
     } catch (e) {}
 
     expect(logger.stdout).to.not.be.called;
     const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
-      "Missing required argument: secret",
+      "Missing required argument: name",
     )}`;
     expect(logger.stderr).to.have.been.calledWith(message);
     expect(container.resolve("parseYargs")).to.have.been.calledOnce;


### PR DESCRIPTION
## Problem
We will always want to enable a certain set of options for commands that talk to fauna. These options include `url`, `secret`, `database` and `role`. At the moment these are spread around, some defined at the top level of the cli and other kept in the `commonQueryOptions` object.

## Solution
Consolidate these options in one place and setup some validation on top of them so users are warned if they specify conflicting or redundant args.

## Result
It will be easier to wire up just in time db keys for commands that talk to fauna.

## Out of Scope
Doing the same things with the `key` commands.

## Testing
Added new tests to make sure the arg validation works.
