### PR TITLE
login/account keys reference 'user' instead of 'profile'

### DIFF
--- a/src/lib/auth/accountKeys.mjs
+++ b/src/lib/auth/accountKeys.mjs
@@ -5,8 +5,8 @@ import { InvalidCredsError } from "../misc.mjs";
 
 /**
  * Class representing the account key(s) available to the user.
- * This class is scoped to a specific profile, as each command invocation will correlate
- * 1:1 with a profile. The profile determines how we access the local credentials file.
+ * This class is scoped to a specific user, as each command invocation will correlate
+ * 1:1 with a user. The user determines how we access the local credentials file.
  *
  * Keeps track of local keys in this.keyStore, used for getting and saving to/from the filesystem.
  * this.key is the currently active account key, it stays updated after refreshes
@@ -14,8 +14,8 @@ import { InvalidCredsError } from "../misc.mjs";
 export class AccountKeys {
   constructor(argv) {
     this.logger = container.resolve("logger");
-    this.profile = argv.profile;
-    this.keyStore = new AccountKeyStorage(this.profile);
+    this.user = argv.user;
+    this.keyStore = new AccountKeyStorage(this.user);
     const storedKey = this.keyStore.get()?.accountKey;
     const { key, keySource } = AccountKeys.resolveKeySources(argv, storedKey);
     this.key = key;
@@ -56,7 +56,7 @@ export class AccountKeys {
    */
   promptLogin() {
     throw new Error(
-      `The requested profile ${this.profile || ""} is not signed in or has expired.\nPlease re-authenticate\n\n
+      `The requested user ${this.user || ""} is not signed in or has expired.\nPlease re-authenticate\n\n
       To sign in, run:\n\nfauna login\n
       `,
     );

--- a/src/lib/auth/databaseKeys.mjs
+++ b/src/lib/auth/databaseKeys.mjs
@@ -15,8 +15,9 @@ const DEFAULT_ROLE = "admin";
  */
 export class DatabaseKeys {
   constructor(argv, accountKey) {
-    const { database, role } = argv;
-    this.keyName = DatabaseKeys.getKeyName(database, role);
+    const { database } = argv;
+    this.role = argv.role || DEFAULT_ROLE;
+    this.keyName = DatabaseKeys.getKeyName(database, this.role);
     this.keyStore = new SecretKeyStorage(accountKey);
     this.ttlMs = TTL_DEFAULT_MS;
 
@@ -28,8 +29,6 @@ export class DatabaseKeys {
     if (this.keySource !== "credentials-file") {
       // Provided secret carries a role assignment already
       this.role = undefined;
-    } else {
-      this.role = role || DEFAULT_ROLE;
     }
 
     if (!key && keySource !== "credentials-file") {

--- a/src/lib/fauna-account-client.mjs
+++ b/src/lib/fauna-account-client.mjs
@@ -187,12 +187,12 @@ export class FaunaAccountClient {
    *
    * @param {Object} params - The parameters for creating the key.
    * @param {string} params.path - The path of the database, including region group
-   * @param {string} [params.role] - The builtin role for the key. Default admin.
+   * @param {string} params.role - The builtin role for the key.
    * @param {string} params.ttl - ISO String for the key's expiration time
    * @returns {Promise<Object>} - A promise that resolves when the key is created.
    * @throws {Error} - Throws an error if there is an issue during key creation.
    */
-  async createKey({ path, role = "admin", ttl }) {
+  async createKey({ path, role, ttl }) {
     const TTL_DEFAULT_MS = 1000 * 60 * 60 * 24;
     return await this.retryableAccountRequest({
       method: "POST",

--- a/src/lib/file-util.mjs
+++ b/src/lib/file-util.mjs
@@ -287,11 +287,11 @@ export class SecretKeyStorage extends CredentialsStorage {
 export class AccountKeyStorage extends CredentialsStorage {
   /**
    * Creates an instance of AccountKey.
-   * @param {string} profile - The profile used to index the account keys.
+   * @param {string} user - The user used to index the account keys.
    */
-  constructor(profile) {
+  constructor(user) {
     super("access_keys");
-    this.profile = profile;
+    this.user = user;
   }
 
   /**
@@ -299,11 +299,11 @@ export class AccountKeyStorage extends CredentialsStorage {
    * @returns { Object<"refreshToken" | "accountKey", string> } The account key and refresh token.
    */
   get() {
-    return super.get(this.profile);
+    return super.get(this.user);
   }
 
   save(value) {
-    super.save(this.profile, value);
+    super.save(this.user, value);
   }
 
   /**
@@ -311,7 +311,7 @@ export class AccountKeyStorage extends CredentialsStorage {
    * @returns {boolean} - Returns true if the operation was successful, otherwise false.
    */
   delete() {
-    return super.delete(this.profile);
+    return super.delete(this.user);
   }
 }
 


### PR DESCRIPTION

Ticket(s): FE-###

## Problem
* Creds use `profile` instead of `user` arg

## Solution
* `accountKeys.mjs` uses `user` arg now to index the creds file
* Fix the default `role` arg being `undefined`. Should be `admin`

## Result

```bash
➜  fauna-shell git:(creds-user) ✗ node ./src/user-entrypoint.mjs login -u devuser
To login, open your browser to:
 https://dashboard.fauna-dev.com/authorize?request_id=T6WMH7qX3h4X2gzm521rcersX-eLxvKcyG2om-BlBxS0PlfnyEp4Aw
Login Success!

➜  fauna-shell git:(creds-user) ✗ node ./src/user-entrypoint.mjs eval "1" -d us-std -u devuser
1
```
