### PR TITLE
Finish the `database list` command

### DIFF
--- a/src/commands/database/list.mjs
+++ b/src/commands/database/list.mjs
@@ -1,6 +1,7 @@
 //@ts-check
 
 import { FaunaError } from "fauna";
+
 import { container } from "../../cli.mjs";
 import { throwForError } from "../../lib/fauna.mjs";
 import { yargsWithCommonQueryOptions } from "../../lib/command-helpers.mjs";
@@ -56,9 +57,9 @@ async function listDatabasesWithSecret(argv) {
 
 async function listDatabases(argv) {
   if (argv.secret) {
-    return listDatabasesWithSecret(argv);
+    listDatabasesWithSecret(argv);
   } else {
-    await listDatabasesWithAccountAPI(argv);
+    listDatabasesWithAccountAPI(argv);
   }
 }
 

--- a/src/commands/database/list.mjs
+++ b/src/commands/database/list.mjs
@@ -57,9 +57,9 @@ async function listDatabasesWithSecret(argv) {
 
 async function listDatabases(argv) {
   if (argv.secret) {
-    listDatabasesWithSecret(argv);
+    return listDatabasesWithSecret(argv);
   } else {
-    listDatabasesWithAccountAPI(argv);
+    return listDatabasesWithAccountAPI(argv);
   }
 }
 

--- a/src/commands/database/list.mjs
+++ b/src/commands/database/list.mjs
@@ -1,30 +1,89 @@
 //@ts-check
 
+import { FaunaError } from "fauna";
 import { container } from "../../cli.mjs";
+import { throwForError } from "../../lib/fauna.mjs";
 import { yargsWithCommonQueryOptions } from "../../lib/command-helpers.mjs";
 import { FaunaAccountClient } from "../../lib/fauna-account-client.mjs";
 
-async function listDatabases() {
-  const logger = container.resolve("logger");
+const OUTPUT_FIELDS = ["name"];
 
-  // query the account api
-  const accountClient = new FaunaAccountClient();
-  const databases = await accountClient.listDatabases();
-  logger.stdout(databases);
-
-  // see what credentials are being used
-  const credentials = container.resolve("credentials");
-  logger.debug(
-    `
-    Account Key: ${credentials.accountKeys.key}\n
-    Database Key: ${credentials.databaseKeys.key}`,
-    "creds",
+function pickOutputFields(databases) {
+  return databases.map((d) =>
+    OUTPUT_FIELDS.reduce((acc, field) => {
+      acc[field] = d[field];
+      return acc;
+    }, {}),
   );
+}
+
+async function listDatabasesWithAccountAPI(argv) {
+  const { pageSize, database, json } = argv;
+  const accountClient = new FaunaAccountClient();
+  const response = await accountClient.listDatabases({
+    pageSize,
+    path: database,
+  });
+  const output = pickOutputFields(response.results);
+  if (json) {
+    container.resolve("logger").stdout(JSON.stringify(output));
+  } else {
+    container.resolve("logger").stdout(output);
+  }
+}
+
+async function listDatabasesWithSecret(argv) {
+  const { url, secret, pageSize, json } = argv;
+  const { runQueryFromString, formatQueryResponse } =
+    container.resolve("faunaClientV10");
+
+  try {
+    const result = await runQueryFromString({
+      url,
+      secret,
+      // This gives us back an array of database names. If we want to
+      // provide the after token at some point this query will need to be updated.
+      expression: `Database.all().paginate(${pageSize}).data { ${OUTPUT_FIELDS} }`,
+    });
+    container.resolve("logger").stdout(formatQueryResponse(result, { json }));
+  } catch (e) {
+    if (e instanceof FaunaError) {
+      throwForError(e);
+    }
+    throw e;
+  }
+}
+
+async function listDatabases(argv) {
+  if (argv.secret) {
+    return listDatabasesWithSecret(argv);
+  } else {
+    await listDatabasesWithAccountAPI(argv);
+  }
 }
 
 function buildListCommand(yargs) {
   return yargsWithCommonQueryOptions(yargs)
-    .help("help", "show help");
+    .options({
+      pageSize: {
+        type: "number",
+        default: 1000,
+      },
+    })
+    .help("help", "show help")
+    .example([
+      ["$0 database list", "list all databases"],
+      [
+        "$0 database list --database us-std/example",
+        "list all databases under us-std/example",
+      ],
+      [
+        "$0 database list --secret 'my-secret'",
+        "list all databases using the provided database secret",
+      ],
+      ["$0 database list --json", "list all databases and output as JSON"],
+      ["$0 database list --pageSize 10", "list the first 10 databases"],
+    ]);
 }
 
 export default {

--- a/src/commands/database/list.mjs
+++ b/src/commands/database/list.mjs
@@ -1,7 +1,6 @@
 //@ts-check
 
 import { FaunaError } from "fauna";
-
 import { container } from "../../cli.mjs";
 import { throwForError } from "../../lib/fauna.mjs";
 import { yargsWithCommonQueryOptions } from "../../lib/command-helpers.mjs";

--- a/src/config/setup-test-container.mjs
+++ b/src/config/setup-test-container.mjs
@@ -86,7 +86,7 @@ export function setupTestContainer() {
     fetch: awilix.asValue(stub().resolves(f({}))),
     gatherFSL: awilix.asValue(stub().resolves([])),
     makeFaunaRequest: awilix.asValue(spy(makeFaunaRequest)),
-    makeAccountRequest: awilix.asValue(spy(makeAccountRequest)),
+    makeAccountRequest: awilix.asValue(stub()),
     runQueryFromString: awilix.asValue(stub().resolves({})),
     formatError: awilix.asValue(stub()),
     formatQueryResponse: awilix.asValue(stub()),

--- a/src/config/setup-test-container.mjs
+++ b/src/config/setup-test-container.mjs
@@ -8,7 +8,6 @@ import { spy, stub } from "sinon";
 
 import { f, InMemoryWritableStream } from "../../test/helpers.mjs";
 import { parseYargs } from "../cli.mjs";
-import { makeAccountRequest } from "../lib/account.mjs";
 import { makeFaunaRequest } from "../lib/db.mjs";
 import * as faunaClientV10 from "../lib/fauna.mjs";
 import * as faunaClientV4 from "../lib/faunadb.mjs";

--- a/src/lib/fauna-account-client.mjs
+++ b/src/lib/fauna-account-client.mjs
@@ -157,7 +157,7 @@ export class FaunaAccountClient {
     const { account_key: newAccountKey, refresh_token: newRefreshToken } =
       await makeAccountRequest({
         method: "POST",
-        path: "/session/refre`sh",
+        path: "/session/refresh",
         secret: refreshToken,
       });
     return { accountKey: newAccountKey, refreshToken: newRefreshToken };

--- a/src/lib/fauna-account-client.mjs
+++ b/src/lib/fauna-account-client.mjs
@@ -157,7 +157,7 @@ export class FaunaAccountClient {
     const { account_key: newAccountKey, refresh_token: newRefreshToken } =
       await makeAccountRequest({
         method: "POST",
-        path: "/session/refresh",
+        path: "/session/refre`sh",
         secret: refreshToken,
       });
     return { accountKey: newAccountKey, refreshToken: newRefreshToken };
@@ -166,15 +166,19 @@ export class FaunaAccountClient {
   /**
    * Lists databases associated with the given account key.
    *
-   * @returns {Promise<Object[]>} - The list of databases.
+   * @param {Object} params - The list databases request parameters.
+   * @param {string} [params.path] - The path of the database, including region group.
+   * @param {number} [params.pageSize] - The number of databases to return. Default 1000.
+   * @returns {Promise<{results: Array<{name: string, path: string, region_group: string, has_children: boolean}>, next_token: string | undefined}>} - The list of databases.
    * @throws {Error} - Throws an error if there is an issue during the request.
    */
-  async listDatabases() {
+  async listDatabases({ path, pageSize = 1000 }) {
     try {
       return this.retryableAccountRequest({
         method: "GET",
         path: "/databases",
         secret: this.accountKeys.key,
+        params: { max_results: pageSize, ...(path && { path }) },
       });
     } catch (err) {
       err.message = `Failure to list databases: ${err.message}`;

--- a/src/lib/fauna-account-client.mjs
+++ b/src/lib/fauna-account-client.mjs
@@ -178,6 +178,7 @@ export class FaunaAccountClient {
         method: "GET",
         path: "/databases",
         secret: this.accountKeys.key,
+        // eslint-disable-next-line - the API expects max_results
         params: { max_results: pageSize, ...(path && { path }) },
       });
     } catch (err) {

--- a/src/lib/fauna-account-client.mjs
+++ b/src/lib/fauna-account-client.mjs
@@ -178,7 +178,8 @@ export class FaunaAccountClient {
         method: "GET",
         path: "/databases",
         secret: this.accountKeys.key,
-        // eslint-disable-next-line - the API expects max_results
+        // The API expects max_results
+        // eslint-disable-next-line camelcase
         params: { max_results: pageSize, ...(path && { path }) },
       });
     } catch (err) {

--- a/src/lib/fauna.mjs
+++ b/src/lib/fauna.mjs
@@ -170,7 +170,8 @@ export const formatQueryResponse = (res, opts = {}) => {
 /**
  * Error handler for errors thrown by the V10 driver. Custom handlers
  * can be provided for different types of errors, and a default error
- * message is thrown if no handler is provided.
+ * message is thrown if no handler is provided. This may be used when we run
+ * commands on the users behalf and want to provide a more helpful error message.
  *
  * @param {import("fauna").FaunaError} e - The Fauna error to handle
  * @param {object} [handlers] - Optional error handlers

--- a/src/lib/fauna.mjs
+++ b/src/lib/fauna.mjs
@@ -128,9 +128,9 @@ export const formatError = (err, opts = {}) => {
   // If the error has a queryInfo object with a summary property, we can format it.
   // Doing this check allows this code to avoid a fauna direct dependency.
   if (
-    err
-    && typeof err.queryInfo === 'object'
-    && typeof err.queryInfo.summary === 'string'
+    err &&
+    typeof err.queryInfo === "object" &&
+    typeof err.queryInfo.summary === "string"
   ) {
     // If you want extra information, use util.inspect to get the full error object.
     if (extra) {
@@ -142,11 +142,11 @@ export const formatError = (err, opts = {}) => {
   } else {
     return err.message;
   }
-}
+};
 
 /**
  * Formats a V10 Fauna query response.
- * @par [ am {import("fauna").QuerySuccess<any>} res 
+ * @par [ am {import("fauna").QuerySuccess<any>} res
  * @param {object} [opts]
  * @param {boolean} [opts.extra] - Whether to include extra information
  * @param {boolean} [opts.json] - Whether to return the response as a JSON string
@@ -165,7 +165,7 @@ export const formatQueryResponse = (res, opts = {}) => {
 
   // Otherwise, return the response as a pretty-printed JSON string.
   return formatObjectForShell(data);
-}
+};
 
 /**
  * Error handler for errors thrown by the V10 driver. Custom handlers

--- a/test/database/list.mjs
+++ b/test/database/list.mjs
@@ -1,17 +1,14 @@
 //@ts-check
 
-import sinon from "sinon";
 import { expect } from "chai";
 import { ServiceError } from "fauna";
+import sinon from "sinon";
+
 import { run } from "../../src/cli.mjs";
 import { setupTestContainer as setupContainer } from "../../src/config/setup-test-container.mjs";
 
 describe("database list", () => {
-  let container,
-    logger,
-    runQueryFromString,
-    formatQueryResponse,
-    makeAccountRequest;
+  let container, logger, runQueryFromString, formatQueryResponse;
 
   beforeEach(() => {
     // reset the container before each test
@@ -20,7 +17,6 @@ describe("database list", () => {
     runQueryFromString = container.resolve("faunaClientV10").runQueryFromString;
     formatQueryResponse =
       container.resolve("faunaClientV10").formatQueryResponse;
-    makeAccountRequest = container.resolve("makeAccountRequest");
   });
 
   [

--- a/test/database/list.mjs
+++ b/test/database/list.mjs
@@ -1,0 +1,81 @@
+//@ts-check
+
+import sinon from "sinon";
+import { expect } from "chai";
+import { ServiceError } from "fauna";
+import { run } from "../../src/cli.mjs";
+import { setupTestContainer as setupContainer } from "../../src/config/setup-test-container.mjs";
+
+describe("database list", () => {
+  let container,
+    logger,
+    runQueryFromString,
+    formatQueryResponse,
+    makeAccountRequest;
+
+  beforeEach(() => {
+    // reset the container before each test
+    container = setupContainer();
+    logger = container.resolve("logger");
+    runQueryFromString = container.resolve("faunaClientV10").runQueryFromString;
+    formatQueryResponse =
+      container.resolve("faunaClientV10").formatQueryResponse;
+    makeAccountRequest = container.resolve("makeAccountRequest");
+  });
+
+  [
+    {
+      args: "--secret 'secret'",
+      expected: { secret: "secret" },
+    },
+    {
+      args: "--secret 'secret' --pageSize 10",
+      expected: { secret: "secret", pageSize: 10 },
+    },
+    {
+      args: "--secret 'secret' --json",
+      expected: { secret: "secret", json: true },
+    },
+  ].forEach(({ args, expected }) => {
+    it(`calls fauna with ${args}`, async () => {
+      const stubedResponse = { data: [{ name: "testdb" }] };
+      runQueryFromString.resolves(stubedResponse);
+
+      await run(`database list ${args}`, container);
+
+      expect(runQueryFromString).to.have.been.calledOnceWith({
+        url: sinon.match.string,
+        secret: expected.secret,
+        expression: `Database.all().paginate(${expected.pageSize ?? 1000}).data { name }`,
+      });
+
+      expect(logger.stdout).to.have.been.calledOnceWith(
+        formatQueryResponse(stubedResponse, {
+          json: expected.json ?? false,
+        }),
+      );
+    });
+  });
+
+  [
+    {
+      error: new ServiceError({
+        error: { code: "unauthorized", message: "whatever" },
+      }),
+      expectedMessage:
+        "Authentication failed: Please either log in using 'fauna login' or provide a valid database secret with '--secret'.",
+    },
+  ].forEach(({ error, expectedMessage }) => {
+    it(`handles ${error.code} errors when calling fauna`, async () => {
+      runQueryFromString.rejects(error);
+
+      try {
+        await run(`database list --secret 'secret'`, container);
+      } catch (e) {}
+
+      expect(logger.stderr).to.have.been.calledWith(
+        sinon.match(expectedMessage),
+      );
+    });
+  });
+});

--- a/test/database/list.mjs
+++ b/test/database/list.mjs
@@ -1,77 +1,142 @@
 //@ts-check
 
+import sinon from "sinon";
 import { expect } from "chai";
 import { ServiceError } from "fauna";
-import sinon from "sinon";
-
 import { run } from "../../src/cli.mjs";
 import { setupTestContainer as setupContainer } from "../../src/config/setup-test-container.mjs";
 
-describe("database list", () => {
-  let container, logger, runQueryFromString, formatQueryResponse;
+describe.only("database list", () => {
+  let container,
+    fs,
+    logger,
+    runQueryFromString,
+    formatQueryResponse,
+    makeAccountRequest;
+
+  const mockCredentialsFile = (fs) => {
+    const mockedFile =
+      '{"default": { "accountKey": "valid-account-key", "refreshToken": "valid-refresh-token"}}';
+    fs.readFileSync.withArgs(sinon.match(/access_keys/)).returns(mockedFile);
+  };
 
   beforeEach(() => {
     // reset the container before each test
     container = setupContainer();
+    fs = container.resolve("fs");
     logger = container.resolve("logger");
     runQueryFromString = container.resolve("faunaClientV10").runQueryFromString;
     formatQueryResponse =
       container.resolve("faunaClientV10").formatQueryResponse;
+    makeAccountRequest = container.resolve("makeAccountRequest");
   });
 
-  [
-    {
-      args: "--secret 'secret'",
-      expected: { secret: "secret" },
-    },
-    {
-      args: "--secret 'secret' --pageSize 10",
-      expected: { secret: "secret", pageSize: 10 },
-    },
-    {
-      args: "--secret 'secret' --json",
-      expected: { secret: "secret", json: true },
-    },
-  ].forEach(({ args, expected }) => {
-    it(`calls fauna with ${args}`, async () => {
-      const stubedResponse = { data: [{ name: "testdb" }] };
-      runQueryFromString.resolves(stubedResponse);
+  describe("when --secret is provided", () => {
+    [
+      {
+        args: "--secret 'secret'",
+        expected: { secret: "secret" },
+      },
+      {
+        args: "--secret 'secret' --pageSize 10",
+        expected: { secret: "secret", pageSize: 10 },
+      },
+      {
+        args: "--secret 'secret' --json",
+        expected: { secret: "secret", json: true },
+      },
+    ].forEach(({ args, expected }) => {
+      it(`calls fauna with the correct args: ${args}`, async () => {
+        const stubedResponse = { data: [{ name: "testdb" }] };
+        runQueryFromString.resolves(stubedResponse);
 
-      await run(`database list ${args}`, container);
+        await run(`database list ${args}`, container);
 
-      expect(runQueryFromString).to.have.been.calledOnceWith({
-        url: sinon.match.string,
-        secret: expected.secret,
-        expression: `Database.all().paginate(${expected.pageSize ?? 1000}).data { name }`,
+        expect(runQueryFromString).to.have.been.calledOnceWith({
+          url: sinon.match.string,
+          secret: expected.secret,
+          expression: `Database.all().paginate(${expected.pageSize ?? 1000}).data { name }`,
+        });
+
+        expect(logger.stdout).to.have.been.calledOnceWith(
+          formatQueryResponse(stubedResponse, {
+            json: expected.json ?? false,
+          }),
+        );
+
+        expect(makeAccountRequest).to.not.have.been.called;
       });
+    });
 
-      expect(logger.stdout).to.have.been.calledOnceWith(
-        formatQueryResponse(stubedResponse, {
-          json: expected.json ?? false,
+    [
+      {
+        error: new ServiceError({
+          error: { code: "unauthorized", message: "whatever" },
         }),
-      );
+        expectedMessage:
+          "Authentication failed: Please either log in using 'fauna login' or provide a valid database secret with '--secret'.",
+      },
+    ].forEach(({ error, expectedMessage }) => {
+      it(`handles ${error.code} errors when calling fauna`, async () => {
+        runQueryFromString.rejects(error);
+
+        try {
+          await run(`database list --secret 'secret'`, container);
+        } catch (e) {}
+
+        expect(logger.stderr).to.have.been.calledWith(
+          sinon.match(expectedMessage),
+        );
+      });
     });
   });
 
-  [
-    {
-      error: new ServiceError({
-        error: { code: "unauthorized", message: "whatever" },
-      }),
-      expectedMessage:
-        "Authentication failed: Please either log in using 'fauna login' or provide a valid database secret with '--secret'.",
-    },
-  ].forEach(({ error, expectedMessage }) => {
-    it(`handles ${error.code} errors when calling fauna`, async () => {
-      runQueryFromString.rejects(error);
+  describe("when --secret is not provided", () => {
+    [
+      {
+        args: "",
+        expected: {},
+      },
+      {
+        args: "--pageSize 10",
+        expected: { pageSize: 10 },
+      },
+      {
+        args: "--database 'us-std/example'",
+        expected: { database: "us-std/example" },
+      },
+      {
+        args: "--database 'us-std/example' --json",
+        expected: { database: "us-std/example", json: true },
+      },
+    ].forEach(({ args, expected }) => {
+      it(`calls the account api with the correct args: ${args}`, async () => {
+        mockCredentialsFile(fs);
+        const stubbedResponse = { results: [{ name: "test" }] };
+        makeAccountRequest.resolves(stubbedResponse);
 
-      try {
-        await run(`database list --secret 'secret'`, container);
-      } catch (e) {}
+        await run(`database list ${args}`, container);
 
-      expect(logger.stderr).to.have.been.calledWith(
-        sinon.match(expectedMessage),
-      );
+        expect(makeAccountRequest).to.have.been.calledOnceWith({
+          method: "GET",
+          path: "/databases",
+          secret: sinon.match.string,
+          params: {
+            max_results: expected.pageSize ?? 1000,
+            ...(expected.database && { path: expected.database }),
+          },
+        });
+
+        const expectedOutput = stubbedResponse.results.map((d) => ({
+          name: d.name,
+          // region group is only returned when listing top level databases
+          ...(!expected.database && { region_group: sinon.match.any }),
+        }));
+
+        expect(logger.stdout).to.have.been.calledOnceWith(
+          expected.json ? JSON.stringify(expectedOutput) : expectedOutput,
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
Ticket(s): FE-6126

## Problem
The `database list` command does not support `--secret` or `--database`.

## Solution
Support the `--secret` and `--database` flags by using the account API if no secret is given.

## Result
The `database list` command supports all expected flags.

For example, the following commands should now all work:
1. `fauna database list`
2. `fauna database list --secret 'my-secret'`
3. `fauna database list --database 'us-std/my-db'`
4. `fauna database list --json`
5. `fauna database list --pageSize 10`

## Testing
<img width="1438" alt="Screenshot 2024-12-02 at 4 22 06 PM" src="https://github.com/user-attachments/assets/8cbe9018-2cbc-4e13-b024-80582900a63e">
