### PR TITLE
Confirm correct usage of Fauna instead of the Account API when --local used.

### DIFF
--- a/src/commands/database/list.mjs
+++ b/src/commands/database/list.mjs
@@ -1,9 +1,10 @@
 //@ts-check
 
 import { FaunaError } from "fauna";
+
 import { container } from "../../cli.mjs";
-import { throwForError } from "../../lib/fauna.mjs";
 import { yargsWithCommonQueryOptions } from "../../lib/command-helpers.mjs";
+import { throwForError } from "../../lib/fauna.mjs";
 import { FaunaAccountClient } from "../../lib/fauna-account-client.mjs";
 
 // Narrow the output fields based on the provided flags.

--- a/test/database/list.mjs
+++ b/test/database/list.mjs
@@ -7,7 +7,7 @@ import sinon from "sinon";
 import { run } from "../../src/cli.mjs";
 import { setupTestContainer as setupContainer } from "../../src/config/setup-test-container.mjs";
 
-describe.only("database list", () => {
+describe("database list", () => {
   let container,
     fs,
     logger,


### PR DESCRIPTION

## Problem

We need to confirm that --local correctly applies to list database.

## Solution

Write a test that does that.
## Result

We can be confident --local points the command at the local fauna.
## Testing

Ran all the tests