### PR TITLE
[FE-6155] - Support `--database` in database commands

### DIFF
--- a/src/commands/database/create.mjs
+++ b/src/commands/database/create.mjs
@@ -5,14 +5,11 @@ import { FaunaError } from "fauna";
 import { container } from "../../cli.mjs";
 import { throwForError } from "../../lib/fauna.mjs";
 import { formatObjectForShell } from "../../lib/misc.mjs";
+import { validateSecretOrDatabase } from "./database.mjs";
 import { getSecret, retryInvalidCredsOnce } from "../../lib/fauna-client.mjs";
 
 function validate(argv) {
-  if (!argv.secret && !argv.database) {
-    throw new Error(
-      "No secret or database provided. Please use either --secret or --database.",
-    );
-  }
+  validateSecretOrDatabase(argv);
   return true;
 }
 

--- a/src/commands/database/create.mjs
+++ b/src/commands/database/create.mjs
@@ -37,15 +37,9 @@ async function createDatabase(argv) {
   const logger = container.resolve("logger");
 
   try {
-    if (argv.secret === secret) {
-      // If we are using a user provided secret, we should not
-      // try to refresh it if it is bad.
-      await runCreateQuery(secret, argv);
-    } else {
-      await retryInvalidCredsOnce(secret, async (secret) =>
-        runCreateQuery(secret, argv),
-      );
-    }
+    await retryInvalidCredsOnce(secret, async (secret) =>
+      runCreateQuery(secret, argv),
+    );
 
     logger.stderr(`Database successfully created.`);
 

--- a/src/commands/database/create.mjs
+++ b/src/commands/database/create.mjs
@@ -4,9 +4,9 @@ import { FaunaError } from "fauna";
 
 import { container } from "../../cli.mjs";
 import { throwForError } from "../../lib/fauna.mjs";
+import { getSecret, retryInvalidCredsOnce } from "../../lib/fauna-client.mjs";
 import { formatObjectForShell } from "../../lib/misc.mjs";
 import { validateSecretOrDatabase } from "./database.mjs";
-import { getSecret, retryInvalidCredsOnce } from "../../lib/fauna-client.mjs";
 
 function validate(argv) {
   validateSecretOrDatabase(argv);

--- a/src/commands/database/database.mjs
+++ b/src/commands/database/database.mjs
@@ -15,6 +15,17 @@ function buildDatabase(yargs) {
     .help("help", "Show help.");
 }
 
+export function validateSecretOrDatabase(argv) {
+  // Makes sure the user has provided either a secret or a database so we can
+  // successfully authenticate them.
+  if (!argv.secret && !argv.database) {
+    throw new Error(
+      "No secret or database provided. Please provide either --secret or --database.",
+    );
+  }
+  return true;
+}
+
 export default {
   command: "database <method>",
   aliases: ["db"],

--- a/src/commands/database/database.mjs
+++ b/src/commands/database/database.mjs
@@ -20,7 +20,7 @@ export function validateSecretOrDatabase(argv) {
   // successfully authenticate them.
   if (!argv.secret && !argv.database) {
     throw new Error(
-      "No secret or database provided. Please provide either --secret or --database.",
+      "No secret or database provided. Please use either --secret or --database.",
     );
   }
   return true;

--- a/src/commands/database/delete.mjs
+++ b/src/commands/database/delete.mjs
@@ -30,15 +30,9 @@ async function deleteDatabase(argv) {
   const logger = container.resolve("logger");
 
   try {
-    if (argv.secret === secret) {
-      // If we are using a user provided secret, we should not
-      // try to refresh it if it is bad.
-      await runDeleteQuery(secret, argv);
-    } else {
-      await retryInvalidCredsOnce(secret, async (secret) =>
-        runDeleteQuery(secret, argv),
-      );
-    }
+    await retryInvalidCredsOnce(secret, async (secret) =>
+      runDeleteQuery(secret, argv),
+    );
 
     // We use stderr for messaging and there's no stdout output for a deleted database
     logger.stderr(`Database '${argv.name}' was successfully deleted.`);

--- a/src/commands/database/delete.mjs
+++ b/src/commands/database/delete.mjs
@@ -4,14 +4,11 @@ import { FaunaError } from "fauna";
 
 import { container } from "../../cli.mjs";
 import { throwForError } from "../../lib/fauna.mjs";
+import { validateSecretOrDatabase } from "./database.mjs";
 import { getSecret, retryInvalidCredsOnce } from "../../lib/fauna-client.mjs";
 
 function validate(argv) {
-  if (!argv.secret && !argv.database) {
-    throw new Error(
-      "No secret or database provided. Please use either --secret or --database.",
-    );
-  }
+  validateSecretOrDatabase(argv);
   return true;
 }
 

--- a/src/commands/database/delete.mjs
+++ b/src/commands/database/delete.mjs
@@ -50,10 +50,9 @@ function buildDeleteCommand(yargs) {
         description: "Name of the database to delete.",
       },
     })
-    .check(validate)
     .version(false)
     .help("help", "show help")
-    .example(
+    .example([
       [
         "$0 database delete --name 'my-database' --database 'us-std/example'",
         "Delete a database named 'my-database' under `us-std/example`.",
@@ -62,7 +61,7 @@ function buildDeleteCommand(yargs) {
         "$0 database delete --name 'my-database' --secret 'my-secret'",
         "Delete a database named 'my-database' scoped to a secret.",
       ],
-    );
+    ]);
 }
 
 export default {

--- a/src/commands/database/delete.mjs
+++ b/src/commands/database/delete.mjs
@@ -40,7 +40,8 @@ async function deleteDatabase(argv) {
       );
     }
 
-    logger.stdout(`Database '${argv.name}' was successfully deleted.`);
+    // We use stderr for messaging and there's no stdout output for a deleted database
+    logger.stderr(`Database '${argv.name}' was successfully deleted.`);
   } catch (e) {
     if (e instanceof FaunaError) {
       throwForError(e, {

--- a/src/commands/database/delete.mjs
+++ b/src/commands/database/delete.mjs
@@ -4,8 +4,8 @@ import { FaunaError } from "fauna";
 
 import { container } from "../../cli.mjs";
 import { throwForError } from "../../lib/fauna.mjs";
-import { validateSecretOrDatabase } from "./database.mjs";
 import { getSecret, retryInvalidCredsOnce } from "../../lib/fauna-client.mjs";
+import { validateSecretOrDatabase } from "./database.mjs";
 
 function validate(argv) {
   validateSecretOrDatabase(argv);

--- a/src/lib/auth/databaseKeys.mjs
+++ b/src/lib/auth/databaseKeys.mjs
@@ -73,11 +73,11 @@ export class DatabaseKeys {
   }
 
   // This method guarantees settings this.dbKey to a valid key
-  async onInvalidCreds() {
+  async onInvalidCreds(error) {
     if (this.keySource !== "credentials-file") {
-      throw new Error(
-        `Secret provided by ${this.keySource} is invalid. Please provide an updated secret.`,
-      );
+      // If this is a user supplied secret, we don't need to refresh it
+      // and should just re-throw the error so it can be handled by the caller.
+      throw error;
     }
     await this.refreshKey();
   }

--- a/src/lib/fauna-client.mjs
+++ b/src/lib/fauna-client.mjs
@@ -127,13 +127,14 @@ export const runQueryFromString = (expression, argv) => {
     );
   } else {
     const { secret, url, timeout, ...rest } = argv;
-    // eslint-disable-next-line camelcase
+
     return retryInvalidCredsOnce(secret, (secret) =>
       faunaV10.runQueryFromString({
         expression,
         secret,
         url,
         client: undefined,
+        // eslint-disable-next-line camelcase
         options: { query_timeout_ms: timeout, ...rest },
       }),
     );

--- a/src/lib/fauna-client.mjs
+++ b/src/lib/fauna-client.mjs
@@ -89,17 +89,20 @@ export const retryInvalidCredsOnce = async (initialSecret, fn) => {
   } catch (err) {
     // If it's a 401, we need to refresh the secret. Let's just do type narrowing here
     // vs doing another v4 vs v10 check.
-    if (err && (err.httpStatus === 401 || err.requestResult?.statusCode === 401)) {
+    if (
+      err &&
+      (err.httpStatus === 401 || err.requestResult?.statusCode === 401)
+    ) {
       const credentials = container.resolve("credentials");
 
-      await credentials.databaseKeys.onInvalidCreds();
+      await credentials.databaseKeys.onInvalidCreds(err);
       const refreshedSecret = await credentials.databaseKeys.getOrRefreshKey();
 
       return fn(refreshedSecret);
     }
     throw err;
   }
-}
+};
 
 /**
  * Runs a query from a string expression.
@@ -113,11 +116,27 @@ export const runQueryFromString = (expression, argv) => {
 
   if (argv.apiVersion === "4") {
     const { secret, url, timeout } = argv;
-    return retryInvalidCredsOnce(secret, (secret) => faunaV4.runQueryFromString({ expression, secret, url, client: undefined, options: { queryTimeout: timeout } }));
+    return retryInvalidCredsOnce(secret, (secret) =>
+      faunaV4.runQueryFromString({
+        expression,
+        secret,
+        url,
+        client: undefined,
+        options: { queryTimeout: timeout },
+      }),
+    );
   } else {
-    const { secret, url, timeout,...rest } = argv;
+    const { secret, url, timeout, ...rest } = argv;
     // eslint-disable-next-line camelcase
-    return retryInvalidCredsOnce(secret, (secret) => faunaV10.runQueryFromString({ expression, secret, url, client: undefined, options: { query_timeout_ms: timeout, ...rest } }));
+    return retryInvalidCredsOnce(secret, (secret) =>
+      faunaV10.runQueryFromString({
+        expression,
+        secret,
+        url,
+        client: undefined,
+        options: { query_timeout_ms: timeout, ...rest },
+      }),
+    );
   }
 };
 
@@ -137,7 +156,7 @@ export const formatError = (err, { apiVersion, extra, color }) => {
   if (apiVersion === "4") {
     return faunaV4.formatError(err, { extra, color });
   } else {
-    return faunaV10.formatError(err, { extra, color }); 
+    return faunaV10.formatError(err, { extra, color });
   }
 };
 
@@ -151,7 +170,10 @@ export const formatError = (err, { apiVersion, extra, color }) => {
  * @param {boolean} opts.color - Whether to colorize the response
  * @returns {object}
  */
-export const formatQueryResponse = (res, { apiVersion, extra, json, color }) => {
+export const formatQueryResponse = (
+  res,
+  { apiVersion, extra, json, color },
+) => {
   const faunaV4 = container.resolve("faunaClientV4");
   const faunaV10 = container.resolve("faunaClientV10");
 

--- a/test/database/create.mjs
+++ b/test/database/create.mjs
@@ -116,6 +116,34 @@ describe("database create", () => {
         expect(makeAccountRequest).to.not.have.been.called;
       });
     });
+
+    it("does not try to refresh the secret if it is invalid", async () => {
+      runQuery.rejects(
+        new ServiceError(
+          {
+            error: {
+              code: "unauthorized",
+              message: "invalid secret",
+            },
+          },
+          401,
+        ),
+      );
+
+      try {
+        await run(
+          `database create --name 'testdb' --secret 'secret' --verbosity=9001`,
+          container,
+        );
+      } catch (e) {}
+
+      expect(makeAccountRequest).to.not.have.been.called;
+      expect(logger.stderr).to.have.been.calledWith(
+        sinon.match(
+          "Authentication failed: Please either log in using 'fauna login' or provide a valid database secret with '--secret'.",
+        ),
+      );
+    });
   });
 
   describe("if --database is provided", () => {

--- a/test/database/create.mjs
+++ b/test/database/create.mjs
@@ -5,8 +5,8 @@ import { fql, ServiceError } from "fauna";
 import sinon from "sinon";
 
 import { run } from "../../src/cli.mjs";
-import { mockAccessKeysFile } from "../helpers.mjs";
 import { setupTestContainer as setupContainer } from "../../src/config/setup-test-container.mjs";
+import { mockAccessKeysFile } from "../helpers.mjs";
 
 describe("database create", () => {
   let container, logger, runQuery, makeAccountRequest;
@@ -135,7 +135,7 @@ describe("database create", () => {
         expected: { name: "testdb", database: "us-std/example", priority: 10 },
       },
     ].forEach(({ args, expected }) => {
-      it(`calls fauna with ${args}`, async () => {
+      it(`calls fauna with the correct args: ${args}`, async () => {
         mockAccessKeysFile({ fs: container.resolve("fs") });
         // We will attempt to mint a new database key, mock the response
         // so we can verify that the new key is used.

--- a/test/database/create.mjs
+++ b/test/database/create.mjs
@@ -19,20 +19,30 @@ describe("database create", () => {
     makeAccountRequest = container.resolve("makeAccountRequest");
   });
 
-  [{ missing: "name", command: "database create --secret 'secret'" }].forEach(
-    ({ missing, command }) => {
-      it(`requires a ${missing}`, async () => {
-        try {
-          await run(command, container);
-        } catch (e) {}
-
-        expect(logger.stderr).to.have.been.calledWith(
-          sinon.match(`Missing required argument: ${missing}`),
-        );
-        expect(container.resolve("parseYargs")).to.have.been.calledOnce;
-      });
+  [
+    {
+      command: "database create --secret 'secret'",
+      message: "Missing required argument: name",
     },
-  );
+    {
+      command: "database create --database 'us-std/example'",
+      message: "Missing required argument: name",
+    },
+    {
+      command: "database create --name 'testdb'",
+      message:
+        "No secret or database provided. Please use either --secret or --database.",
+    },
+  ].forEach(({ command, message }) => {
+    it(`validates invalid arguments: ${command}`, async () => {
+      try {
+        await run(command, container);
+      } catch (e) {}
+
+      expect(logger.stderr).to.have.been.calledWith(sinon.match(message));
+      expect(container.resolve("parseYargs")).to.have.been.calledOnce;
+    });
+  });
 
   [
     {

--- a/test/database/database.mjs
+++ b/test/database/database.mjs
@@ -6,7 +6,7 @@ import chalk from "chalk";
 import { builtYargs, run } from "../../src/cli.mjs";
 import { setupTestContainer as setupContainer } from "../../src/config/setup-test-container.mjs";
 
-describe("database create", () => {
+describe("database", () => {
   let container, logger;
 
   beforeEach(() => {

--- a/test/database/delete.mjs
+++ b/test/database/delete.mjs
@@ -5,8 +5,8 @@ import { fql, ServiceError } from "fauna";
 import sinon from "sinon";
 
 import { run } from "../../src/cli.mjs";
-import { mockAccessKeysFile } from "../helpers.mjs";
 import { setupTestContainer as setupContainer } from "../../src/config/setup-test-container.mjs";
+import { mockAccessKeysFile } from "../helpers.mjs";
 
 describe("database delete", () => {
   let container, logger, runQuery, makeAccountRequest;

--- a/test/database/delete.mjs
+++ b/test/database/delete.mjs
@@ -7,15 +7,17 @@ import sinon from "sinon";
 
 import { builtYargs, run } from "../../src/cli.mjs";
 import { setupTestContainer as setupContainer } from "../../src/config/setup-test-container.mjs";
+import { mockAccessKeysFile } from "../helpers.mjs";
 
 describe("database delete", () => {
-  let container, logger, runQuery;
+  let container, logger, runQuery, makeAccountRequest;
 
   beforeEach(() => {
     // reset the container before each test
     container = setupContainer();
     logger = container.resolve("logger");
     runQuery = container.resolve("faunaClientV10").runQuery;
+    makeAccountRequest = container.resolve("makeAccountRequest");
   });
 
   [{ missing: "name", command: "database delete --secret 'secret'" }].forEach(
@@ -33,24 +35,6 @@ describe("database delete", () => {
       });
     },
   );
-
-  [
-    {
-      args: "--name 'testdb' --secret 'secret'",
-      expected: { name: "testdb", secret: "secret" },
-    },
-  ].forEach(({ args, expected }) => {
-    describe("calls fauna with the user specified arguments", () => {
-      it(`${args}`, async () => {
-        await run(`database delete ${args}`, container);
-        expect(runQuery).to.have.been.calledOnceWith({
-          url: sinon.match.string,
-          secret: expected.secret,
-          query: fql`Database.byName(${expected.name}).delete()`,
-        });
-      });
-    });
-  });
 
   [
     {
@@ -81,6 +65,62 @@ describe("database delete", () => {
       expect(logger.stderr).to.have.been.calledWith(
         sinon.match(expectedMessage),
       );
+    });
+  });
+
+  describe("if --secret is provided", () => {
+    [
+      {
+        args: "--name 'testdb' --secret 'secret'",
+        expected: { name: "testdb", secret: "secret" },
+      },
+    ].forEach(({ args, expected }) => {
+      it(`calls fauna with the correct args: ${args}`, async () => {
+        await run(`database delete ${args}`, container);
+
+        expect(runQuery).to.have.been.calledOnceWith({
+          url: sinon.match.string,
+          secret: expected.secret,
+          query: fql`Database.byName(${expected.name}).delete()`,
+        });
+
+        // If we are using a user provided secret, we should not
+        // need to call the account api to mint or refresh a key.
+        expect(makeAccountRequest).to.not.have.been.called;
+      });
+    });
+  });
+
+  describe("if --database is provided", () => {
+    [
+      {
+        args: "--name 'testdb' --database 'us-std/example'",
+        expected: { name: "testdb", database: "us-std/example" },
+      },
+    ].forEach(({ args, expected }) => {
+      it(`calls fauna with the correct args: ${args}`, async () => {
+        mockAccessKeysFile({ fs: container.resolve("fs") });
+        // We will attempt to mint a new database key, mock the response
+        // so we can verify that the new key is used.
+        makeAccountRequest.resolves({ secret: "new-secret" });
+
+        await run(`database delete ${args}`, container);
+
+        // Verify that we made a request to mint a new database key.
+        expect(makeAccountRequest).to.have.been.calledOnceWith({
+          method: "POST",
+          path: "/databases/keys",
+          body: sinon.match((value) => value.includes(expected.database)),
+          secret: sinon.match.string,
+        });
+
+        // Verify that we made a request to delete the database with the new key.
+        expect(runQuery).to.have.been.calledOnceWith({
+          secret: "new-secret",
+          url: sinon.match.string,
+          query: fql`Database.byName(${expected.name}).delete()`,
+        });
+      });
     });
   });
 });

--- a/test/database/delete.mjs
+++ b/test/database/delete.mjs
@@ -97,6 +97,34 @@ describe("database delete", () => {
         expect(makeAccountRequest).to.not.have.been.called;
       });
     });
+
+    it("does not try to refresh the secret if it is invalid", async () => {
+      runQuery.rejects(
+        new ServiceError(
+          {
+            error: {
+              code: "unauthorized",
+              message: "invalid secret",
+            },
+          },
+          401,
+        ),
+      );
+
+      try {
+        await run(
+          `database delete --name 'testdb' --secret 'secret' --verbosity=9001`,
+          container,
+        );
+      } catch (e) {}
+
+      expect(makeAccountRequest).to.not.have.been.called;
+      expect(logger.stderr).to.have.been.calledWith(
+        sinon.match(
+          "Authentication failed: Please either log in using 'fauna login' or provide a valid database secret with '--secret'.",
+        ),
+      );
+    });
   });
 
   describe("if --database is provided", () => {

--- a/test/database/delete.mjs
+++ b/test/database/delete.mjs
@@ -42,7 +42,7 @@ describe("database delete", () => {
   ].forEach(({ args, expected }) => {
     describe("calls fauna with the user specified arguments", () => {
       it(`${args}`, async () => {
-        await run(`database create ${args}`, container);
+        await run(`database delete ${args}`, container);
         expect(runQuery).to.have.been.calledOnceWith({
           url: sinon.match.string,
           secret: expected.secret,
@@ -78,7 +78,9 @@ describe("database delete", () => {
         );
       } catch (e) {}
 
-      expect(logger.stderr).to.have.been.calledWith(sinon.match(expectedMessage));
+      expect(logger.stderr).to.have.been.calledWith(
+        sinon.match(expectedMessage),
+      );
     });
   });
 });

--- a/test/database/list.mjs
+++ b/test/database/list.mjs
@@ -5,9 +5,9 @@ import { ServiceError } from "fauna";
 import sinon from "sinon";
 
 import { run } from "../../src/cli.mjs";
-import { mockAccessKeysFile } from "../helpers.mjs";
 import { setupTestContainer as setupContainer } from "../../src/config/setup-test-container.mjs";
 import { formatObjectForShell } from "../../src/lib/misc.mjs";
+import { mockAccessKeysFile } from "../helpers.mjs";
 
 describe("database list", () => {
   let container,

--- a/test/database/list.mjs
+++ b/test/database/list.mjs
@@ -164,7 +164,16 @@ describe("database list", () => {
     ].forEach(({ args, expected }) => {
       it(`calls the account api with the correct args: ${args}`, async () => {
         mockAccessKeysFile({ fs });
-        const stubbedResponse = { results: [{ name: "test" }] };
+        const stubbedResponse = {
+          results: [
+            {
+              name: "test",
+              ...(expected.regionGroup
+                ? { region_group: expected.regionGroup }
+                : {}),
+            },
+          ],
+        };
         makeAccountRequest.resolves(stubbedResponse);
 
         await run(`database list ${args}`, container);

--- a/test/helpers.mjs
+++ b/test/helpers.mjs
@@ -1,8 +1,9 @@
 //@ts-check
 
-import sinon from "sinon";
 import { join } from "node:path";
 import { Writable } from "node:stream";
+
+import sinon from "sinon";
 
 // small helper for sinon to wrap your return value
 // in the shape fetch would return it from the network

--- a/test/helpers.mjs
+++ b/test/helpers.mjs
@@ -1,5 +1,6 @@
 //@ts-check
 
+import sinon from "sinon";
 import { join } from "node:path";
 import { Writable } from "node:stream";
 
@@ -131,23 +132,23 @@ export const createV10QuerySuccess = (data) => {
       storage_bytes_read: 510,
       storage_bytes_write: 0,
       rate_limits_hit: [],
-      attempts: 1
+      attempts: 1,
     },
-    schema_version: 0
-  }
-}
+    schema_version: 0,
+  };
+};
 
 export const createV10QueryFailure = (summary) => {
   return {
     error: {
       code: "test_error",
       message: "test error",
-      constraint_failures: []
+      constraint_failures: [],
     },
     httpStatus: 400,
     summary,
-  }
-}
+  };
+};
 
 export const createV4QuerySuccess = (data) => ({
   value: data,
@@ -156,21 +157,48 @@ export const createV4QuerySuccess = (data) => ({
     "x-byte-write-ops": 0,
     "x-compute-ops": 1,
     "x-query-time": 15,
-    "x-txn-retries": 0
-  }
-})
+    "x-txn-retries": 0,
+  },
+});
 
 export const createV4QueryFailure = (error) => ({
   requestResult: {
     responseRaw: JSON.stringify({
-      errors: [error]
+      errors: [error],
     }),
     responseContent: { errors: [error] },
     statusCode: 400,
     headers: {},
-    method: 'POST',
-    path: '/',
-    query: '',
-    requestRaw: ''
-  }
-})
+    method: "POST",
+    path: "/",
+    query: "",
+    requestRaw: "",
+  },
+});
+
+export const mockAccessKeysFile = ({
+  fs,
+  accountKey = "account-key",
+  refreshToken = "refresh-token",
+}) => {
+  fs.readFileSync
+    .withArgs(sinon.match(/access_keys/))
+    .returns(
+      `{"default": { "accountKey": "${accountKey}", "refreshToken": "${refreshToken}"}}`,
+    );
+};
+
+export const mockSecretKeysFile = ({
+  fs,
+  accountKey = "account-key",
+  path = "us-std",
+  role = "admin",
+  secret = "secret",
+  expiresAt = Date.now() + 1000 * 60 * 60 * 24,
+}) => {
+  fs.readFileSync
+    .withArgs(sinon.match(/secret_keys/))
+    .returns(
+      `{${accountKey}: { "${path}:${role}": {"secret": "${secret}", "expiresAt": ${expiresAt}}}}`,
+    );
+};


### PR DESCRIPTION
Ticket(s): FE-6155

## Problem
The `database create` and `database delete` commands do not support specifying a target database using `--database`.

## Solution
Update the commands to support this flag by using the `getSecret` helper. Ensure bad creds are only retried/refreshed if we are not using a user provided secret. Some validation was also included to check that at least one of these flags is provided.

## Result
The `--database` flag is supported by `database create` and `database delete`.

## Testing
Added tests to cover the usage of `--database`.
