### PR TITLE
enable --version flag

### DIFF
--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -166,6 +166,6 @@ function buildYargs(argvInput) {
     .help("help", "Show help.")
     .fail(false)
     .exitProcess(false)
-    .version(false)
+    .version()
     .completion();
 }

--- a/src/commands/database/create.mjs
+++ b/src/commands/database/create.mjs
@@ -81,7 +81,6 @@ function buildCreateCommand(yargs) {
       },
     })
     .check(validate)
-    .version(false)
     .help("help", "show help")
     .example([
       [

--- a/src/commands/database/database.mjs
+++ b/src/commands/database/database.mjs
@@ -11,7 +11,6 @@ function buildDatabase(yargs) {
     .command(createCommand)
     .command(deleteCommand)
     .demandCommand()
-    .version(false)
     .help("help", "Show help.");
 }
 

--- a/src/commands/database/delete.mjs
+++ b/src/commands/database/delete.mjs
@@ -54,8 +54,7 @@ function buildDeleteCommand(yargs) {
       },
     })
     .check(validate)
-    .version(false)
-    .help("help", "show help")
+    .help("help", "Show help.")
     .example([
       [
         "$0 database delete --name 'my-database' --database 'us-std/example'",

--- a/src/commands/query.mjs
+++ b/src/commands/query.mjs
@@ -128,7 +128,6 @@ function buildQueryCommand(yargs) {
       ['$0 query -i /path/to/queries.fql --output /tmp/result.json --database us-std/example', "Run the query and write the results to a file"],
       ['$0 query -i /path/to/queries.fql --extra --output /tmp/result.json --database us-std/example', "Run the query and write the full API response to a file"],
     ])
-    .version(false)
     .help("help", "Show help.");
 }
 

--- a/src/commands/schema/abandon.mjs
+++ b/src/commands/schema/abandon.mjs
@@ -68,7 +68,6 @@ function buildAbandonCommand(yargs) {
       },
     })
     .example([["$0 schema abandon"]])
-    .version(false)
     .help("help", "Show help.");
 }
 

--- a/src/commands/schema/commit.mjs
+++ b/src/commands/schema/commit.mjs
@@ -72,7 +72,6 @@ function buildCommitCommand(yargs) {
       },
     })
     .example([["$0 schema commit"]])
-    .version(false)
     .help("help", "Show help.");
 }
 

--- a/src/commands/schema/diff.mjs
+++ b/src/commands/schema/diff.mjs
@@ -131,7 +131,6 @@ function buildDiffCommand(yargs) {
       ["$0 schema diff --staged"],
       ["$0 schema diff --active --text"],
     ])
-    .version(false)
     .help("help", "Show help.");
 }
 

--- a/src/commands/schema/pull.mjs
+++ b/src/commands/schema/pull.mjs
@@ -140,7 +140,6 @@ function buildPullCommand(yargs) {
       ["$0 schema pull --active"],
       ["$0 schema pull --delete"],
     ])
-    .version(false)
     .help("help", "Show help.");
 }
 

--- a/src/commands/schema/push.mjs
+++ b/src/commands/schema/push.mjs
@@ -99,7 +99,6 @@ function buildPushCommand(yargs) {
       ["$0 schema push --dir schemas/myschema"],
       ["$0 schema push --active"],
     ])
-    .version(false)
     .help("help", "Show help.");
 }
 

--- a/src/commands/schema/schema.mjs
+++ b/src/commands/schema/schema.mjs
@@ -25,7 +25,6 @@ function buildSchema(yargs) {
     .command(pullCommand)
     .command(statusCommand)
     .demandCommand()
-    .version(false)
     .help("help", "Show help.");
 }
 

--- a/src/commands/schema/status.mjs
+++ b/src/commands/schema/status.mjs
@@ -59,7 +59,6 @@ async function doStatus(argv) {
 function buildStatusCommand(yargs) {
   return yargsWithCommonQueryOptions(yargs)
     .example([["$0 schema status"]])
-    .version(false)
     .help("help", "Show help.");
 }
 


### PR DESCRIPTION
previously, we'd disabled the --version flag on all commands to not conflict with the --version flag that switched between FQL v4 and FQL v10 behavior. now that the flag that does that switching is named --api-version, we can implement the more standard --version behavior by showing the CLI application version.