### PR TITLE
improve pre-argv parsing

### DIFF
--- a/src/lib/config/config.mjs
+++ b/src/lib/config/config.mjs
@@ -82,6 +82,7 @@ export function configParser(path) {
   const argv = yargs(argvInput).options({
     profile: {
       default: "default",
+      alias: ["p"],
       type: "string",
     },
   }).argv;

--- a/src/lib/logger.mjs
+++ b/src/lib/logger.mjs
@@ -2,8 +2,7 @@ import chalk from "chalk";
 import { Console } from "console";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-
-import { builtYargs } from "../cli.mjs";
+import yargsParser from "yargs-parser";
 
 /**
  * @typedef argv
@@ -38,12 +37,19 @@ export function log({
 
   // this case only occurs when an error is thrown and not caught _or_ a command is called with
   // the `--help` flag (where checkForDefaultConfig calls this)
-  if (!argv && builtYargs.parsed) {
-    argv = builtYargs.parsed.argv;
+  if (!argv) {
+    argv = yargsParser(process.argv.slice(2), {
+      array: ["verboseComponent"],
+      alias: {
+        profile: ["p"],
+        config: ["c"],
+      },
+    });
   }
 
   if (
     argv &&
+    argv.verboseComponent &&
     (argv.verbosity >= verbosity || argv.verboseComponent.includes(component))
   ) {
     const prefix = chalk.reset("[") + formatter(component) + chalk.reset("]: ");


### PR DESCRIPTION
there are a bunch of places where we want to rely on argv _before_ yargs is formally done parsing them. in those situations we rely on a patchwork of different strategies, with different failings.

this commit moves towards a new strategy - using yargs-parser 'raw' (not through yargs). this is primarily to prevent yargs' parsing side effects (running command handlers, overwriting help text, etc).

from a customer-facing perspective, this change allows us to emit verbose debugging logs earlier - without it, verbose debugging doesn't work in steps like config parsing.