### PR TITLE
disable strict options parsing

### DIFF
--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -150,7 +150,7 @@ function buildYargs(argvInput) {
     .command(schemaCommand)
     .command(databaseCommand)
     .demandCommand()
-    .strict(true)
+    .strictCommands(true)
     .options({
       color: {
         description:

--- a/src/lib/command-helpers.mjs
+++ b/src/lib/command-helpers.mjs
@@ -110,7 +110,8 @@ function isYargsError(error) {
   if (
     error.message &&
     (error.message.startsWith("Unknown argument") ||
-      error.message.startsWith("Missing required argument"))
+      error.message.startsWith("Missing required argument") ||
+      error.message.startsWith("Unknown command"))
   ) {
     return true;
   }

--- a/test/general-cli.mjs
+++ b/test/general-cli.mjs
@@ -40,7 +40,7 @@ describe("cli operations", function () {
     expect(container.resolve("parseYargs")).to.have.been.calledOnce;
   });
 
-  it("should exit with a helpful message if a non-existent flag is provided", async function () {
+  it.skip("should exit with a helpful message if a non-existent flag is provided", async function () {
     const logger = container.resolve("logger");
 
     // the halflight flag doesn't exist
@@ -66,7 +66,7 @@ describe("cli operations", function () {
 
     expect(logger.stdout).to.not.be.called;
     const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
-      "Unknown argument: inland-empire",
+      "Unknown command: inland-empire",
     )}`;
     expect(logger.stderr).to.have.been.calledWith(message);
     expect(container.resolve("parseYargs")).to.have.been.calledOnce;
@@ -166,7 +166,7 @@ describe("cli operations", function () {
       timeout: 5000,
     });
 
-    expect(stderr).to.include("Unknown argument: throw");
+    expect(stderr).to.include("Unknown command: throw");
   });
 
   it("enables nodeJS warnings from the dev entrypoint", async function () {


### PR DESCRIPTION
env variables for query settings (FAUNA_SECRET, etc) are too useful to not
have set, but they fail strict options parsing for commands that don't
use them. this commit turns off strict options parsing for now while we find a
better way to address this.