### PR TITLE
Improve error handling

### DIFF
--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { util } from "chai";
 import chalk from "chalk";
 import yargs from "yargs";
 
@@ -60,14 +61,15 @@ export async function run(_argvInput, _container) {
         );
         epilogue = `\n${BUG_REPORT_MESSAGE}`;
 
-        logger.debug(`unknown error thrown: ${e.name}`);
+        logger.debug(`unknown error thrown: ${e.name}`, "error");
+        logger.debug(util.inspect(e, true, 2, false), "error");
       } else {
         // Otherwise, just use the error message
         subMessage = chalk.red(e.message);
       }
     }
 
-    // If the error has a truthy displayHelp property, render the help text. Otherwise, just use the error message.
+    // If the error has a truthy hideHelp property, do not render the help text. Otherwise, just use the error message.
     logger.stderr(
       `${e.hideHelp ? "" : `${chalk.reset(await builtYargs.getHelp())}\n\n`}${subMessage}`,
     );
@@ -78,7 +80,7 @@ export async function run(_argvInput, _container) {
 
     // Log the stack if it exists
     logger.fatal(e.stack, "error");
-    logger.fatal(e.cause?.stack, "cause");
+    logger.fatal(e.cause?.stack, "error");
 
     // If the error has an exitCode property, use that. Otherwise, use 1.
     container.resolve("errorHandler")(

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -80,7 +80,9 @@ export async function run(_argvInput, _container) {
 
     // Log the stack if it exists
     logger.fatal(e.stack, "error");
-    logger.fatal(e.cause?.stack, "error");
+    if (e.cause) {
+      logger.fatal(e.cause?.stack, "error");
+    }
 
     // If the error has an exitCode property, use that. Otherwise, use 1.
     container.resolve("errorHandler")(

--- a/src/commands/query.mjs
+++ b/src/commands/query.mjs
@@ -2,25 +2,34 @@
 
 import { container } from "../cli.mjs";
 import {
+  CommandError,
+  isUnknownError,
   validateDatabaseOrSecret,
+  ValidationError,
   yargsWithCommonConfigurableQueryOptions,
 } from "../lib/command-helpers.mjs";
-import { formatError, formatQueryResponse, getSecret } from "../lib/fauna-client.mjs";
+import {
+  formatError,
+  formatQueryResponse,
+  getSecret,
+} from "../lib/fauna-client.mjs";
 
 function validate(argv) {
   const { existsSync, accessSync, constants } = container.resolve("fs");
   const dirname = container.resolve("dirname");
 
   if (argv.input && argv.fql) {
-    throw new Error("Cannot specify both --input and [fql]");
+    throw new ValidationError("Cannot specify both --input and [fql]");
   }
 
   if (!argv.input && !argv.fql) {
-    throw new Error("No query specified. Pass [fql] or --input.");
+    throw new ValidationError("No query specified. Pass [fql] or --input.");
   }
 
   if (argv.input && !existsSync(argv.input)) {
-    throw new Error(`File passed to --input does not exist: ${argv.input}`);
+    throw new ValidationError(
+      `File passed to --input does not exist: ${argv.input}`,
+    );
   }
 
   if (argv.output) {
@@ -28,7 +37,9 @@ function validate(argv) {
     try {
       accessSync(outputDir, constants.W_OK);
     } catch (e) {
-      throw new Error(`Unable to write to output directory: ${outputDir}`);
+      throw new ValidationError(
+        `Unable to write to output directory: ${outputDir}`,
+      );
     }
   }
 }
@@ -49,10 +60,10 @@ const resolveInput = (argv) => {
 
   logger.debug("no --input specified, using [fql]", "argv");
   return argv.fql;
-}
+};
 
 async function queryCommand(argv) {
-  // validate the arguments and throw if they are invalid
+  // Run validation here instead of via check for more control over output
   validateDatabaseOrSecret(argv);
   validate(argv);
 
@@ -90,9 +101,14 @@ async function queryCommand(argv) {
 
     return results;
   } catch (err) {
+    if (!isUnknownError(err)) {
+      throw err;
+    }
+
     const { apiVersion, extra, color } = argv;
-    err.message = formatError(err, { apiVersion, extra, color }); 
-    throw err;
+    throw new CommandError(formatError(err, { apiVersion, extra, color }), {
+      cause: err,
+    });
   }
 }
 

--- a/src/commands/schema/abandon.mjs
+++ b/src/commands/schema/abandon.mjs
@@ -1,7 +1,7 @@
 //@ts-check
 
 import { container } from "../../cli.mjs";
-import { yargsWithCommonQueryOptions } from "../../lib/command-helpers.mjs";
+import { CommandError, yargsWithCommonQueryOptions } from "../../lib/command-helpers.mjs";
 
 async function doAbandon(argv) {
   const makeFaunaRequest = container.resolve("makeFaunaRequest");
@@ -32,7 +32,7 @@ async function doAbandon(argv) {
     });
 
     if (response.status === "none")
-      throw new Error("There is no staged schema to abandon");
+      throw new CommandError("There is no staged schema to abandon");
 
     logger.stdout(response.diff);
 

--- a/src/commands/schema/commit.mjs
+++ b/src/commands/schema/commit.mjs
@@ -1,7 +1,7 @@
 //@ts-check
 
 import { container } from "../../cli.mjs";
-import { yargsWithCommonQueryOptions } from "../../lib/command-helpers.mjs";
+import { CommandError, yargsWithCommonQueryOptions } from "../../lib/command-helpers.mjs";
 
 async function doCommit(argv) {
   const makeFaunaRequest = container.resolve("makeFaunaRequest");
@@ -33,12 +33,12 @@ async function doCommit(argv) {
     });
 
     if (response.status === "none")
-      throw new Error("There is no staged schema to commit");
+      throw new CommandError("There is no staged schema to commit");
 
     logger.stdout(response.diff);
 
     if (response.status !== "ready")
-      throw new Error("Schema is not ready to be committed");
+      throw new CommandError("Schema is not ready to be committed");
 
     const confirmed = await confirm({
       message: "Accept and commit these changes?",

--- a/src/commands/schema/diff.mjs
+++ b/src/commands/schema/diff.mjs
@@ -3,7 +3,7 @@
 import chalk from "chalk";
 
 import { container } from "../../cli.mjs";
-import { yargsWithCommonQueryOptions } from "../../lib/command-helpers.mjs";
+import { ValidationError, yargsWithCommonQueryOptions } from "../../lib/command-helpers.mjs";
 import { reformatFSL } from "../../lib/schema.mjs";
 
 /**
@@ -15,7 +15,7 @@ function parseTarget(argv) {
   }
 
   if (argv.active && argv.staged) {
-    throw new Error("Cannot specify both --active and --staged");
+    throw new ValidationError("Cannot specify both --active and --staged");
   }
 
   if (argv.active) {
@@ -23,7 +23,7 @@ function parseTarget(argv) {
   } else if (argv.staged) {
     return ["active", "staged"];
   } else {
-    throw new Error("Invalid target. Expected: active or staged");
+    throw new ValidationError("Invalid target. Expected: active or staged");
   }
 }
 

--- a/src/commands/schema/pull.mjs
+++ b/src/commands/schema/pull.mjs
@@ -1,7 +1,7 @@
 //@ts-check
 
 import { container } from "../../cli.mjs";
-import { yargsWithCommonQueryOptions } from "../../lib/command-helpers.mjs";
+import { CommandError, yargsWithCommonQueryOptions } from "../../lib/command-helpers.mjs";
 import { makeFaunaRequest } from "../../lib/db.mjs";
 
 async function determineFileState(argv, filenames) {
@@ -77,11 +77,11 @@ async function doPull(argv) {
   // getting active FSL while staged FSL exists is not yet
   // implemented at the service level.
   if (statusResponse.status !== "none" && argv.active) {
-    throw new Error(
+    throw new CommandError(
       "There is a staged schema change. Remove the --active flag to pull it.",
     );
   } else if (statusResponse.status === "none" && !argv.active) {
-    throw new Error("There are no staged schema changes to pull.");
+    throw new CommandError("There are no staged schema changes to pull.");
   }
 
   const { adds, deletes, overwrites } = await determineFileState(

--- a/src/commands/schema/status.mjs
+++ b/src/commands/schema/status.mjs
@@ -3,7 +3,7 @@
 import chalk from "chalk";
 
 import { container } from "../../cli.mjs";
-import { yargsWithCommonQueryOptions } from "../../lib/command-helpers.mjs";
+import { CommandError, yargsWithCommonQueryOptions } from "../../lib/command-helpers.mjs";
 import { reformatFSL } from "../../lib/schema.mjs";
 
 async function doStatus(argv) {
@@ -45,7 +45,7 @@ async function doStatus(argv) {
 
   if (validationResponse.error) {
     logger.stdout(`Local changes:`);
-    throw new Error(validationResponse.error.message);
+    throw new CommandError(validationResponse.error.message);
   } else if (validationResponse.diff === "") {
     logger.stdout(`Local changes: ${chalk.bold("none")}\n`);
   } else {

--- a/src/lib/auth/accountKeys.mjs
+++ b/src/lib/auth/accountKeys.mjs
@@ -1,4 +1,5 @@
 import { container } from "../../cli.mjs";
+import { CommandError } from "../command-helpers.mjs";
 import { FaunaAccountClient } from "../fauna-account-client.mjs";
 import { AccountKeyStorage } from "../file-util.mjs";
 import { InvalidCredsError } from "../misc.mjs";
@@ -23,7 +24,7 @@ export class AccountKeys {
 
     // Let users know if the creds they provided are invalid (empty)
     if (!key && keySource !== "credentials-file") {
-      throw new Error(
+      throw new CommandError(
         `The account key provided by '${keySource}' is invalid. Please provide an updated value.`,
       );
     }
@@ -55,10 +56,8 @@ export class AccountKeys {
    * Prompt re-authentication and exit the program;
    */
   promptLogin() {
-    throw new Error(
-      `The requested user '${this.user || ""}' is not signed in or has expired.\nPlease re-authenticate\n\n
-      To sign in, run:\n\nfauna login\n
-      `,
+    throw new CommandError(
+      `The requested user '${this.user || ""}' is not signed in or has expired. Please re-authenticate.\n\nTo sign in, run: fauna login`,
     );
   }
 
@@ -68,7 +67,7 @@ export class AccountKeys {
    */
   async onInvalidCreds() {
     if (this.keySource !== "credentials-file") {
-      throw new Error(
+      throw new CommandError(
         `Account key provided by '${this.keySource}' is invalid. Please provide an updated account key.`,
       );
     }

--- a/src/lib/auth/credentials.mjs
+++ b/src/lib/auth/credentials.mjs
@@ -1,19 +1,20 @@
 import { asValue, Lifetime } from "awilix";
 
 import { container } from "../../cli.mjs";
+import { ValidationError } from "../command-helpers.mjs";
 import { FaunaAccountClient } from "../fauna-account-client.mjs";
 import { AccountKeys } from "./accountKeys.mjs";
 import { DatabaseKeys } from "./databaseKeys.mjs";
 
 const validateCredentialArgs = (argv) => {
   if (argv.database && argv.secret) {
-    throw new Error(
+    throw new ValidationError(
       "Cannot use both the '--secret' and '--database' options together. Please specify only one.",
     );
   } else if (argv.role && argv.secret) {
     // The '--role' option is not supported when using a secret. Secrets have an
     // implicit role.
-    throw new Error(
+    throw new ValidationError(
       "The '--role' option is not supported when using a '--secret'. Please specify only one.",
     );
   }

--- a/src/lib/auth/databaseKeys.mjs
+++ b/src/lib/auth/databaseKeys.mjs
@@ -1,4 +1,5 @@
 import { container } from "../../cli.mjs";
+import { CommandError } from "../command-helpers.mjs";
 import { FaunaAccountClient } from "../fauna-account-client.mjs";
 import { SecretKeyStorage } from "../file-util.mjs";
 
@@ -32,7 +33,7 @@ export class DatabaseKeys {
     }
 
     if (!key && keySource !== "credentials-file") {
-      throw new Error(
+      throw new CommandError(
         `The database secret provided by ${keySource} is invalid. Please provide an updated secret.`,
       );
     }
@@ -49,7 +50,7 @@ export class DatabaseKeys {
     // argv.secret comes from flag, config, or FAUNA_SECRET
     if (argv.secret) {
       key = argv.secret;
-      keySource = "user";
+      keySource = "--secret";
     } else {
       key = storedKey;
       keySource = "credentials-file";
@@ -75,7 +76,7 @@ export class DatabaseKeys {
   // This method guarantees settings this.dbKey to a valid key
   async onInvalidCreds() {
     if (this.keySource !== "credentials-file") {
-      throw new Error(
+      throw new CommandError(
         `Secret provided by ${this.keySource} is invalid. Please provide an updated secret.`,
       );
     }

--- a/src/lib/command-helpers.mjs
+++ b/src/lib/command-helpers.mjs
@@ -1,10 +1,11 @@
 //@ts-check
 
-// used for queries customers can't configure that are made on their behalf
+// used for queries customers can't config  ure that are made on their behalf
 const COMMON_QUERY_OPTIONS = {
   local: {
-    type: 'boolean',
-    describe: 'Indicates a local Fauna container is being used. Sets the URL to http://localhost:8443 if --url is not provided. Use --url to set a custom url for your container.',
+    type: "boolean",
+    describe:
+      "Indicates a local Fauna container is being used. Sets the URL to http://localhost:8443 if --url is not provided. Use --url to set a custom url for your container.",
     default: false,
   },
   url: {
@@ -42,9 +43,79 @@ const COMMON_QUERY_OPTIONS = {
   role: {
     alias: "r",
     type: "string",
-    description: "a role"
+    description: "a role",
   },
 };
+
+/**
+ * An error that is thrown by commands that is not a validation error, but
+ * a known error state that should be communicated to the user.
+ */
+export class CommandError extends Error {
+  /**
+   * @param {string} message
+   * @param {object} [opts]
+   * @param {number} [opts.exitCode]
+   * @param {boolean} [opts.hideHelp]
+   * @param {Error} [opts.cause]
+   */
+  constructor(message, { exitCode = 1, hideHelp = true, cause } = {}) {
+    super(message);
+    this.exitCode = exitCode;
+    this.hideHelp = hideHelp;
+    this.cause = cause;
+  }
+}
+
+/**
+ * An error that is thrown when the user provides invalid input, but
+ * isn't caught until command execution.
+ */
+export class ValidationError extends CommandError {
+  /**
+   * @param {string} message
+   * @param {object} [opts]
+   * @param {number} [opts.exitCode]
+   * @param {boolean} [opts.hideHelp]
+   * @param {Error} [opts.cause]
+   */
+  constructor(message, { exitCode = 1, hideHelp = false, cause } = {}) {
+    super(message, { exitCode, hideHelp, cause });
+  }
+}
+
+/**
+ * Returns true if the error is an error potentially thrown by yargs
+ * @param {Error} error
+ * @returns {boolean}
+ */
+function isYargsError(error) {
+  // Sometimes they are named YError. This seems to the case in middleware.
+  if (error.name === "YError") {
+    return true;
+  }
+
+  // Usage errors from yargs are thrown as plain old Error. The best
+  // you can do is check for the message.
+  if (
+    error.message &&
+    (error.message.startsWith("Unknown argument") ||
+      error.message.startsWith("Missing required argument"))
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Returns true if the error is not an error yargs or one we've thrown ourselves in a command
+ * @param {Error} error
+ * @returns {boolean}
+ */
+export function isUnknownError(error) {
+  return !isYargsError(error) && !(error instanceof CommandError);
+}
 
 
 /**
@@ -54,10 +125,13 @@ const COMMON_QUERY_OPTIONS = {
  * @param {object} argv 
  * @param {string} argv.database - The database to use
  * @param {string} argv.secret - The secret to use
+ * @param {boolean} argv.local - Whether to use a local Fauna container
  */
 export const validateDatabaseOrSecret = (argv) => {
   if (!argv.database && !argv.secret && !argv.local) {
-    throw new Error("No database or secret specified. Pass either --database, or --secret, or --local.");
+    throw new ValidationError(
+      "No database or secret specified. Pass either --database, or --secret, or --local.",
+    );
   }
 }
 

--- a/src/lib/command-helpers.mjs
+++ b/src/lib/command-helpers.mjs
@@ -1,6 +1,6 @@
 //@ts-check
 
-// used for queries customers can't config  ure that are made on their behalf
+// used for queries customers can't configure that are made on their behalf
 const COMMON_QUERY_OPTIONS = {
   local: {
     type: "boolean",

--- a/src/lib/config/config.mjs
+++ b/src/lib/config/config.mjs
@@ -2,6 +2,7 @@ import yaml from "yaml";
 import yargs from "yargs";
 
 import { argvInput, container } from "../../cli.mjs";
+import { ValidationError } from "../command-helpers.mjs";
 
 export const validDefaultConfigNames = [
   "fauna.config.yaml",
@@ -20,7 +21,7 @@ export function getConfig(path) {
     fileBody = fs.readFileSync(path, { encoding: "utf8" });
   } catch (fsError) {
     if (fsError.code === "ENOENT") {
-      throw new Error(`Config file not found at path ${path}.`);
+      throw new ValidationError(`Config file not found at path ${path}.`);
     }
 
     throw fsError;
@@ -38,7 +39,7 @@ function checkForDefaultConfig(path) {
   );
   if (files.length > 1) {
     const names = files.map((file) => file.name).join(", ");
-    throw new Error(
+    throw new ValidationError(
       `Multiple config files found with valid default names (${names}). Either specify one with "--config FILENAME" or delete the unused config files.`,
     );
   } else if (files.length === 1) {
@@ -55,13 +56,13 @@ function checkForDefaultConfig(path) {
 
 function validateConfig(profileName, profileBody, configPath) {
   if (profileName === "default" && !profileBody) {
-    throw new Error(
+    throw new ValidationError(
       `No "default" profile found in config file at ${configPath}. Either specify a profile with "--profile NAME" or add a "default" profile.`,
     );
   }
 
   if (!profileBody && profileName !== "default") {
-    throw new Error(
+    throw new ValidationError(
       `Could not find profile "${profileName}" in config file at ${configPath}.`,
     );
   }

--- a/src/lib/fauna.mjs
+++ b/src/lib/fauna.mjs
@@ -2,6 +2,7 @@
 /**
  * @fileoverview Fauna V10 client utilities for query execution and error handling.
  */
+
 import {
   ClientClosedError,
   ClientError,
@@ -11,6 +12,7 @@ import {
 } from "fauna";
 
 import { container } from "../cli.mjs";
+import { CommandError, ValidationError } from "./command-helpers.mjs";
 import { formatFullErrorForShell, formatObjectForShell } from "./misc.mjs";
 
 /**
@@ -46,7 +48,9 @@ export const getClient = ({ url, secret }) => {
 
   // Check for required arguments.
   if (!secret) {
-    throw new Error("No secret provided. Pass --secret or --database.");
+    throw new ValidationError(
+      "No secret provided. Pass --secret or --database.",
+    );
   }
   // Create the client.
   return new Client({ secret, endpoint: url ? new URL(url) : undefined });
@@ -73,7 +77,7 @@ export const runQuery = async ({
 }) => {
   // Check for required arguments.
   if (!query) {
-    throw new Error("A query is required.");
+    throw new CommandError("A query is required.");
   }
 
   // Create the client if one wasn't provided.
@@ -139,9 +143,9 @@ export const formatError = (err, opts = {}) => {
     }
 
     // Otherwise, return the summary and fall back to the message.
-    return err.queryInfo?.summary ?? err.message;
+    return `The query failed with the following error:\n\n${err.queryInfo?.summary ?? err.message}`;
   } else {
-    return err.message;
+    return `The query failed unexpectedly with the following error:\n\n${err.message}`;
   }
 };
 

--- a/src/lib/fauna.mjs
+++ b/src/lib/fauna.mjs
@@ -12,7 +12,7 @@ import {
 } from "fauna";
 
 import { container } from "../cli.mjs";
-import { CommandError, ValidationError } from "./command-helpers.mjs";
+import { ValidationError } from "./command-helpers.mjs";
 import { formatFullErrorForShell, formatObjectForShell } from "./misc.mjs";
 
 /**
@@ -77,7 +77,7 @@ export const runQuery = async ({
 }) => {
   // Check for required arguments.
   if (!query) {
-    throw new CommandError("A query is required.");
+    throw new ValidationError("A query is required.");
   }
 
   // Create the client if one wasn't provided.

--- a/test/database/delete.mjs
+++ b/test/database/delete.mjs
@@ -1,11 +1,10 @@
 //@ts-check
 
 import { expect } from "chai";
-import chalk from "chalk";
 import { fql, ServiceError } from "fauna";
 import sinon from "sinon";
 
-import { builtYargs, run } from "../../src/cli.mjs";
+import { run } from "../../src/cli.mjs";
 import { setupTestContainer as setupContainer } from "../../src/config/setup-test-container.mjs";
 
 describe("database delete", () => {
@@ -25,10 +24,9 @@ describe("database delete", () => {
           await run(command, container);
         } catch (e) {}
 
-        const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
-          `Missing required argument: ${missing}`,
-        )}`;
-        expect(logger.stderr).to.have.been.calledWith(message);
+        expect(logger.stderr).to.have.been.calledWith(
+          sinon.match(`Missing required argument: ${missing}`),
+        );
         expect(container.resolve("parseYargs")).to.have.been.calledOnce;
       });
     },
@@ -78,7 +76,9 @@ describe("database delete", () => {
         );
       } catch (e) {}
 
-      expect(logger.stderr).to.have.been.calledWith(sinon.match(expectedMessage));
+      expect(logger.stderr).to.have.been.calledWith(
+        sinon.match(expectedMessage),
+      );
     });
   });
 });

--- a/test/general-cli.mjs
+++ b/test/general-cli.mjs
@@ -17,10 +17,11 @@ import { f } from "./helpers.mjs";
 const __dirname = import.meta.dirname;
 
 describe("cli operations", function () {
-  let container;
+  let container, stderr;
 
   beforeEach(() => {
     container = setupContainer();
+    stderr = container.resolve("stderrStream");
   });
 
   it("should exit with a helpful message if a flag is not provided", async function () {
@@ -97,9 +98,9 @@ describe("cli operations", function () {
 
     expect(logger.stdout).to.not.be.called;
     const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
-      "this is a test error",
+      "An unexpected error occurred...\n\nthis is a test error\n\nIf you believe this is a bug, please report this issue on GitHub: https://github.com/fauna/fauna-shell/issues",
     )}`;
-    expect(logger.stderr).to.have.been.calledWith(message);
+    expect(stderr.getWritten().trim()).to.equal(message);
     expect(container.resolve("parseYargs")).to.have.been.calledOnce;
   });
 
@@ -113,9 +114,9 @@ describe("cli operations", function () {
 
     expect(logger.stdout).to.not.be.called;
     const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
-      "this is a rejected promise",
+      "An unexpected error occurred...\n\nthis is a rejected promise\n\nIf you believe this is a bug, please report this issue on GitHub: https://github.com/fauna/fauna-shell/issues",
     )}`;
-    expect(logger.stderr).to.have.been.calledWith(message);
+    expect(stderr.getWritten().trim()).to.equal(message);
     expect(container.resolve("parseYargs")).to.have.been.calledOnce;
   });
 
@@ -179,7 +180,7 @@ describe("cli operations", function () {
 
     // the dev script should emit warnings
     expect(stderr).to.include(
-      "Warning: this is a warning emited on the node process",
+      "Warning: this is a warning emitted on the node process",
     );
   });
 

--- a/test/schema/abandon.mjs
+++ b/test/schema/abandon.mjs
@@ -5,7 +5,7 @@ import chalk from "chalk";
 import sinon from "sinon";
 import tryToCatch from "try-to-catch";
 
-import { builtYargs, run } from "../../src/cli.mjs";
+import { run } from "../../src/cli.mjs";
 import { setupTestContainer as setupContainer } from "../../src/config/setup-test-container.mjs";
 import { buildUrl, commonFetchParams, f } from "../helpers.mjs";
 
@@ -89,9 +89,7 @@ describe("schema abandon", function () {
 
     expect(error).to.have.property("code", 1);
     expect(fetch).to.have.been.calledOnce;
-    const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
-      "There is no staged schema to abandon",
-    )}`;
+    const message = `${chalk.red("There is no staged schema to abandon")}`;
     expect(logger.stderr).to.have.been.calledWith(message);
 
     expect(fetch).to.have.been.calledWith(

--- a/test/schema/commit.mjs
+++ b/test/schema/commit.mjs
@@ -5,7 +5,7 @@ import chalk from "chalk";
 import sinon from "sinon";
 import tryToCatch from "try-to-catch";
 
-import { builtYargs, run } from "../../src/cli.mjs";
+import { run } from "../../src/cli.mjs";
 import { setupTestContainer as setupContainer } from "../../src/config/setup-test-container.mjs";
 import { buildUrl, commonFetchParams, f } from "../helpers.mjs";
 
@@ -85,9 +85,7 @@ describe("schema commit", function () {
       { ...commonFetchParams, method: "GET" },
     );
     expect(logger.stdout).to.not.have.been.called;
-    const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
-      "There is no staged schema to commit",
-    )}`;
+    const message = `${chalk.red("There is no staged schema to commit")}`;
     expect(logger.stderr).to.have.been.calledWith(message);
     expect(confirm).to.not.have.been.called;
   });
@@ -107,9 +105,7 @@ describe("schema commit", function () {
       { ...commonFetchParams, method: "GET" },
     );
     expect(logger.stdout).to.have.been.calledWith(diff);
-    const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
-      "Schema is not ready to be committed",
-    )}`;
+    const message = `${chalk.red("Schema is not ready to be committed")}`;
     expect(logger.stderr).to.have.been.calledWith(message);
     expect(confirm).to.not.have.been.called;
   });


### PR DESCRIPTION
## Problem

All errors are thrown and treated the same. This means validation errors, known error states, and unexpected errors get the same treatment.

## Solution

This PR updates our error handling for adding capabilities for three classes of errors:

* Validation errors (ours and yargs): Arguments or options are invalid. Print help, display the validation error.
* Command errors:  Errors we intentionally throw in commands or middleware. Print the error only.
* Unknown errors: Errors that are not validation, yargs, or command errors. So things we haven't thrown. Tell the user it's unexpected, print the error, and display a message for bug reports.

Additionally, for debugging purposes, if `cause` is available on an error that will be outputted as well.

## Result

Validation error/unknown argument (ignore the red background, that's my shell):
![Screenshot 2024-12-04 at 10 59 59 AM](https://github.com/user-attachments/assets/44ccef55-26f2-4fe0-839f-c39af373bb68)

Command error/not logged in
![Screenshot 2024-12-04 at 11 00 33 AM](https://github.com/user-attachments/assets/57f8346d-8265-4bcf-b34c-55b9aeec2121)

Command error/bad query syntax
![Screenshot 2024-12-04 at 11 02 16 AM](https://github.com/user-attachments/assets/9cfb09f8-3e9e-4acb-af69-046b2c36a0a8)

Unknown error/throw
![Screenshot 2024-12-04 at 11 22 08 AM](https://github.com/user-attachments/assets/de0ca24d-e27b-4785-8b1b-02f9750bc972)

With verbosity
![Screenshot 2024-12-04 at 11 56 43 AM](https://github.com/user-attachments/assets/3630c64a-96ec-4ebf-8de4-c7048d8c3697)


## Testing

The tests have been updated to reflect this new behavior.
