### PR TITLE
[FE-6169] Support Shorthand Region Groups

### DIFF
--- a/src/commands/database/create.mjs
+++ b/src/commands/database/create.mjs
@@ -84,8 +84,8 @@ function buildCreateCommand(yargs) {
     .help("help", "show help")
     .example([
       [
-        "$0 database create --name 'my-database' --database 'us-std/example'",
-        "Create a database named 'my-database' under `us-std/example`.",
+        "$0 database create --name 'my-database' --database 'us/example'",
+        "Create a database named 'my-database' under `us/example`.",
       ],
       [
         "$0 database create --name 'my-database' --secret 'my-secret'",

--- a/src/commands/database/delete.mjs
+++ b/src/commands/database/delete.mjs
@@ -57,8 +57,8 @@ function buildDeleteCommand(yargs) {
     .help("help", "Show help.")
     .example([
       [
-        "$0 database delete --name 'my-database' --database 'us-std/example'",
-        "Delete a database named 'my-database' under `us-std/example`.",
+        "$0 database delete --name 'my-database' --database 'us/example'",
+        "Delete a database named 'my-database' under `us/example`.",
       ],
       [
         "$0 database delete --name 'my-database' --secret 'my-secret'",

--- a/src/commands/database/list.mjs
+++ b/src/commands/database/list.mjs
@@ -57,7 +57,9 @@ async function listDatabasesWithSecret(argv) {
       // provide the after token at some point this query will need to be updated.
       expression: `Database.all().paginate(${pageSize}).data { ${getOutputFields(argv)} }`,
     });
-    container.resolve("logger").stdout(formatQueryResponse(result, { json, color }));
+    container
+      .resolve("logger")
+      .stdout(formatQueryResponse(result, { json, color }));
   } catch (e) {
     if (e instanceof FaunaError) {
       throwForError(e);
@@ -87,15 +89,21 @@ function buildListCommand(yargs) {
     .example([
       ["$0 database list", "List all top-level databases"],
       [
-        "$0 database list --database 'us-std/example'",
-        "list all child databases under `us-std/example`",
+        "$0 database list --database 'us/example'",
+        "list all child databases under `us/example`",
       ],
       [
         "$0 database list --secret 'my-secret'",
         "List all child databases for the database scoped to a secret",
       ],
-      ["$0 database list --json", "List all top-level databases and output as JSON"],
-      ["$0 database list --pageSize 10", "List the first 10 top-level databases"],
+      [
+        "$0 database list --json",
+        "List all top-level databases and output as JSON",
+      ],
+      [
+        "$0 database list --pageSize 10",
+        "List the first 10 top-level databases",
+      ],
     ]);
 }
 

--- a/src/commands/query.mjs
+++ b/src/commands/query.mjs
@@ -140,23 +140,23 @@ function buildQueryCommand(yargs) {
     })
     .example([
       [
-        '$0 query "Collection.all()" --database us-std/example',
+        '$0 query "Collection.all()" --database us/example',
         "Run the query and write the results to stdout ",
       ],
       [
-        "$0 query -i /path/to/query.fql --database us-std/example",
+        "$0 query -i /path/to/query.fql --database us/example",
         "Run the query from a file",
       ],
       [
-        'echo "1 + 1" | $0 query - --database us-std/example',
+        'echo "1 + 1" | $0 query - --database us/example',
         "Run the query from stdin",
       ],
       [
-        "$0 query -i /path/to/queries.fql --output /tmp/result.json --database us-std/example",
+        "$0 query -i /path/to/queries.fql --output /tmp/result.json --database us/example",
         "Run the query and write the results to a file",
       ],
       [
-        "$0 query -i /path/to/queries.fql --extra --output /tmp/result.json --database us-std/example",
+        "$0 query -i /path/to/queries.fql --extra --output /tmp/result.json --database us/example",
         "Run the query and write the full API response to a file",
       ],
     ])

--- a/src/commands/shell.mjs
+++ b/src/commands/shell.mjs
@@ -147,10 +147,7 @@ async function buildCustomEval(argv) {
 
 function buildShellCommand(yargs) {
   return yargsWithCommonConfigurableQueryOptions(yargs)
-    .example([
-      ["$0 shell"],
-      ["$0 shell --database us-std/example --role admin"],
-    ])
+    .example([["$0 shell"], ["$0 shell --database us/example --role admin"]])
     .version(false)
     .help("help", "Show help.");
 }

--- a/src/lib/fauna-account-client.mjs
+++ b/src/lib/fauna-account-client.mjs
@@ -220,17 +220,17 @@ export class FaunaAccountClient {
    * Transforms database paths to standardize region group naming conventions expected by
    * the account API.
    *
-   * @param {string} databasePath - The database path to standardize
-   * @returns {string} The standardized path
+   * @param {string} [databasePath] - The database path to standardize
+   * @returns {string | undefined} The standardized path
    * @example
    * // Returns "us-std/my-database"
-   * standardizeRegion("us/my-database")
+   * FaunaAccountClient.standardizeRegion("us/my-database")
    *
    * // Returns "eu-std/my-database"
-   * standardizeRegion("eu/my-database")
+   * FaunaAccountClient.standardizeRegion("eu/my-database")
    *
    * // Returns "global/my-database"
-   * standardizeRegion("classic/my-database")
+   * FaunaAccountClient.standardizeRegion("classic/my-database")
    *
    * @throws {TypeError} If databasePath is provided but not a string
    */

--- a/src/lib/fauna-account-client.mjs
+++ b/src/lib/fauna-account-client.mjs
@@ -179,10 +179,10 @@ export class FaunaAccountClient {
         path: "/databases",
         secret: this.accountKeys.key,
         // The API expects max_results
-        // eslint-disable-next-line camelcase
         params: {
+          // eslint-disable-next-line camelcase
           max_results: pageSize,
-          ...(path && { path: this.standardizeRegion(path) }),
+          ...(path && { path: FaunaAccountClient.standardizeRegion(path) }),
         },
       });
     } catch (err) {
@@ -208,7 +208,7 @@ export class FaunaAccountClient {
       path: "/databases/keys",
       body: JSON.stringify({
         role,
-        path: this.standardizeRegion(path),
+        path: FaunaAccountClient.standardizeRegion(path),
         ttl: ttl || new Date(Date.now() + TTL_DEFAULT_MS).toISOString(),
         name: "System generated shell key",
       }),
@@ -234,7 +234,7 @@ export class FaunaAccountClient {
    *
    * @throws {TypeError} If databasePath is provided but not a string
    */
-  standardizeRegion(databasePath) {
+  static standardizeRegion(databasePath) {
     if (!databasePath) return databasePath;
     if (typeof databasePath !== "string") {
       throw new TypeError("Database path must be a string");

--- a/src/lib/fauna-account-client.mjs
+++ b/src/lib/fauna-account-client.mjs
@@ -180,7 +180,10 @@ export class FaunaAccountClient {
         secret: this.accountKeys.key,
         // The API expects max_results
         // eslint-disable-next-line camelcase
-        params: { max_results: pageSize, ...(path && { path }) },
+        params: {
+          max_results: pageSize,
+          ...(path && { path: this.standardizeRegion(path) }),
+        },
       });
     } catch (err) {
       err.message = `Failure to list databases: ${err.message}`;
@@ -204,12 +207,50 @@ export class FaunaAccountClient {
       method: "POST",
       path: "/databases/keys",
       body: JSON.stringify({
-        path,
         role,
+        path: this.standardizeRegion(path),
         ttl: ttl || new Date(Date.now() + TTL_DEFAULT_MS).toISOString(),
         name: "System generated shell key",
       }),
       secret: this.accountKeys.key,
     });
+  }
+
+  /**
+   * Transforms database paths to standardize region group naming conventions expected by
+   * the account API.
+   *
+   * @param {string} databasePath - The database path to standardize
+   * @returns {string} The standardized path
+   * @example
+   * // Returns "us-std/my-database"
+   * standardizeRegion("us/my-database")
+   *
+   * // Returns "eu-std/my-database"
+   * standardizeRegion("eu/my-database")
+   *
+   * // Returns "global/my-database"
+   * standardizeRegion("classic/my-database")
+   *
+   * @throws {TypeError} If databasePath is provided but not a string
+   */
+  standardizeRegion(databasePath) {
+    if (!databasePath) return databasePath;
+    if (typeof databasePath !== "string") {
+      throw new TypeError("Database path must be a string");
+    }
+
+    const parts = databasePath.split("/");
+    const region = parts[0].toLowerCase();
+    const rest = parts.slice(1).join("/");
+
+    const regionMap = {
+      us: "us-std",
+      eu: "eu-std",
+      classic: "global",
+    };
+
+    const standardRegion = regionMap[region] || region;
+    return `${standardRegion}/${rest}`;
   }
 }

--- a/src/lib/fauna-account-client.mjs
+++ b/src/lib/fauna-account-client.mjs
@@ -240,7 +240,8 @@ export class FaunaAccountClient {
       throw new TypeError("Database path must be a string");
     }
 
-    const parts = databasePath.split("/");
+    const trimmed = databasePath.replace(/^\/|\/$/g, "");
+    const parts = trimmed.split("/");
     const region = parts[0].toLowerCase();
     const rest = parts.slice(1).join("/");
 
@@ -251,6 +252,6 @@ export class FaunaAccountClient {
     };
 
     const standardRegion = regionMap[region] || region;
-    return `${standardRegion}/${rest}`;
+    return rest ? `${standardRegion}/${rest}` : standardRegion;
   }
 }

--- a/test/database/create.mjs
+++ b/test/database/create.mjs
@@ -149,11 +149,11 @@ describe("database create", () => {
   describe("if --database is provided", () => {
     [
       {
-        args: "--name 'testdb' --database 'us-std/example'",
+        args: "--name 'testdb' --database 'us/example'",
         expected: { name: "testdb", database: "us-std/example" },
       },
       {
-        args: "--name 'testdb' --database 'us-std/example' --typechecked",
+        args: "--name 'testdb' --database 'us/example' --typechecked",
         expected: {
           name: "testdb",
           database: "us-std/example",
@@ -161,7 +161,7 @@ describe("database create", () => {
         },
       },
       {
-        args: "--name 'testdb' --database 'us-std/example' --protected",
+        args: "--name 'testdb' --database 'us/example' --protected",
         expected: {
           name: "testdb",
           database: "us-std/example",
@@ -169,7 +169,7 @@ describe("database create", () => {
         },
       },
       {
-        args: "--name 'testdb' --database 'us-std/example' --priority 10",
+        args: "--name 'testdb' --database 'us/example' --priority 10",
         expected: { name: "testdb", database: "us-std/example", priority: 10 },
       },
     ].forEach(({ args, expected }) => {

--- a/test/database/delete.mjs
+++ b/test/database/delete.mjs
@@ -130,7 +130,7 @@ describe("database delete", () => {
   describe("if --database is provided", () => {
     [
       {
-        args: "--name 'testdb' --database 'us-std/example'",
+        args: "--name 'testdb' --database 'us/example'",
         expected: { name: "testdb", database: "us-std/example" },
       },
     ].forEach(({ args, expected }) => {

--- a/test/database/list.mjs
+++ b/test/database/list.mjs
@@ -154,11 +154,11 @@ describe("database list", () => {
         expected: { pageSize: 10, regionGroup: "us-std" },
       },
       {
-        args: "--database 'us-std/example'",
+        args: "--database 'us/example'",
         expected: { database: "us-std/example" },
       },
       {
-        args: "--database 'us-std/example' --json",
+        args: "--database 'us/example' --json",
         expected: { database: "us-std/example", json: true },
       },
     ].forEach(({ args, expected }) => {

--- a/test/fauna-account-client.mjs
+++ b/test/fauna-account-client.mjs
@@ -1,0 +1,41 @@
+//@ts-check
+
+import { expect } from "chai";
+
+import { FaunaAccountClient } from "../src/lib/fauna-account-client.mjs";
+
+describe("FaunaAccountClient", () => {
+  let client;
+
+  beforeEach(() => {
+    client = new FaunaAccountClient();
+  });
+
+  [
+    // Edge cases
+    { original: undefined, expected: undefined },
+    { original: null, expected: null },
+    { original: "", expected: "" },
+    { original: "/", expected: "" },
+    { original: "us/", expected: "us-std" },
+    { original: "/us", expected: "us-std" },
+    // Standardizes shorthand to full region group
+    { original: "us", expected: "us-std" },
+    { original: "us/example", expected: "us-std/example" },
+    { original: "eu", expected: "eu-std" },
+    { original: "eu/example", expected: "eu-std/example" },
+    { original: "classic", expected: "global" },
+    { original: "classic/example", expected: "global/example" },
+    // Leaves full region group unchanged
+    { original: "us-std", expected: "us-std" },
+    { original: "us-std/example", expected: "us-std/example" },
+    { original: "eu-std", expected: "eu-std" },
+    { original: "eu-std/example", expected: "eu-std/example" },
+    { original: "global", expected: "global" },
+    { original: "global/example", expected: "global/example" },
+  ].forEach(({ original, expected }) => {
+    it(`standardizes ${original} to ${expected}`, () => {
+      expect(client.standardizeRegion(original)).to.equal(expected);
+    });
+  });
+});

--- a/test/fauna-account-client.mjs
+++ b/test/fauna-account-client.mjs
@@ -5,16 +5,9 @@ import { expect } from "chai";
 import { FaunaAccountClient } from "../src/lib/fauna-account-client.mjs";
 
 describe("FaunaAccountClient", () => {
-  let client;
-
-  beforeEach(() => {
-    client = new FaunaAccountClient();
-  });
-
   [
     // Edge cases
     { original: undefined, expected: undefined },
-    { original: null, expected: null },
     { original: "", expected: "" },
     { original: "/", expected: "" },
     { original: "us/", expected: "us-std" },
@@ -35,7 +28,7 @@ describe("FaunaAccountClient", () => {
     { original: "global/example", expected: "global/example" },
   ].forEach(({ original, expected }) => {
     it(`standardizes ${original} to ${expected}`, () => {
-      expect(client.standardizeRegion(original)).to.equal(expected);
+      expect(FaunaAccountClient.standardizeRegion(original)).to.equal(expected);
     });
   });
 });


### PR DESCRIPTION
Ticket(s): FE-6169

## Problem
You must use the region groups that the account api expects as input to the `--database` arg. eg. `--database us-std/my-database`. We do not often expose the name `us-std` to customers and it will likely be more natural to use `--database us/my-database` as that is what is presented in the dashboard.

## Solution
Standardize region groups before they are passed to the account API. This allows the usage of `--database us-std/my-database` or `--database us/my-database`.

## Result
You can use whatever region group reference you prefer.

## Testing
Updated existing tests.
