### PR TITLE
lint and prettify on PR push/change

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
-name: Lint
+name: Lint and prettify
 
 on:
   # temporarily "v3"; change to "main" after merge
@@ -23,9 +23,5 @@ jobs:
           node-version: 22.x
           cache: "npm"
       - run: npm ci
+      - run: npm run format:check
       - run: npm run lint
-        env:
-          TERM: xterm-256color
-          # Set to the correct color level; 2 is 256 colors
-          # https://github.com/chalk/chalk?tab=readme-ov-file#supportscolor
-          FORCE_COLOR: 2

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm run format && npm run lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,5 @@
 ### Quick Start
+
 Install dependencies and verify you can execute the CLI:
 
 Sanity check your local setup:

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "esbuild": "^0.24.0",
         "eslint-config-prettier": "^9.1.0",
         "globals": "^15.10.0",
-        "husky": "^9.1.6",
+        "husky": "^9.1.7",
         "mocha": "^10.7.3",
         "mocha-junit-reporter": "^2.2.1",
         "mocha-multi-reporters": "^1.5.1",
@@ -1842,7 +1842,9 @@
       }
     },
     "node_modules/husky": {
-      "version": "9.1.6",
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "test": "npm run test:local",
     "test:local": "mocha --recursive ./test --require ./test/mocha-root-hooks.mjs --reporter mocha-multi-reporters --reporter-options configFile=./test/config/reporter.json",
     "pretest:ci": "npm run build:app",
-    "test:ci": "mocha --recursive ./test --require ./test/mocha-root-hooks.mjs --reporter mocha-multi-reporters --reporter-options configFile=./test/config/reporter.json",
+    "test:ci": "mocha --forbid-only --recursive ./test --require ./test/mocha-root-hooks.mjs --reporter mocha-multi-reporters --reporter-options configFile=./test/config/reporter.json",
     "build": "npm run build:app && npm run build:sea",
     "build:app": "esbuild --bundle ./src/user-entrypoint.mjs --platform=node --outfile=./dist/cli.cjs --format=cjs --inject:./sea/import-meta-url.js --define:import.meta.url=importMetaUrl --define:process.env.NODE_ENV=\\\"production\\\"",
     "build:sea": "node ./sea/build.cjs",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "build": "npm run build:app && npm run build:sea",
     "build:app": "esbuild --bundle ./src/user-entrypoint.mjs --platform=node --outfile=./dist/cli.cjs --format=cjs --inject:./sea/import-meta-url.js --define:import.meta.url=importMetaUrl --define:process.env.NODE_ENV=\\\"production\\\"",
     "build:sea": "node ./sea/build.cjs",
-    "format": "prettier -w ."
+    "format": "prettier -w .",
+    "format:check": "prettier -c ."
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "esbuild": "^0.24.0",
     "eslint-config-prettier": "^9.1.0",
     "globals": "^15.10.0",
-    "husky": "^9.1.6",
+    "husky": "^9.1.7",
     "mocha": "^10.7.3",
     "mocha-junit-reporter": "^2.2.1",
     "mocha-multi-reporters": "^1.5.1",
@@ -77,8 +77,9 @@
     "build": "npm run build:app && npm run build:sea",
     "build:app": "esbuild --bundle ./src/user-entrypoint.mjs --platform=node --outfile=./dist/cli.cjs --format=cjs --inject:./sea/import-meta-url.js --define:import.meta.url=importMetaUrl --define:process.env.NODE_ENV=\\\"production\\\"",
     "build:sea": "node ./sea/build.cjs",
-    "format": "prettier -w .",
-    "format:check": "prettier -c ."
+    "format": "prettier -w --log-level silent .",
+    "format:check": "prettier -c .",
+    "prepare": "husky"
   },
   "husky": {
     "hooks": {

--- a/src/lib/db.mjs
+++ b/src/lib/db.mjs
@@ -1,7 +1,5 @@
 //@ts-check
 
-
-
 import { container } from "../cli.mjs";
 import { CommandError } from "./command-helpers.mjs";
 import { retryInvalidCredsOnce } from "./fauna-client.mjs";

--- a/src/lib/fauna-client.mjs
+++ b/src/lib/fauna-client.mjs
@@ -1,6 +1,5 @@
 //@ts-check
 
-
 import { container } from "../cli.mjs";
 
 export default class FaunaClient {

--- a/src/lib/faunadb.mjs
+++ b/src/lib/faunadb.mjs
@@ -16,7 +16,7 @@ export const getClient = async (argv) => {
   const { Client } = container.resolve("faunadb");
   const { hostname, port, protocol } = new URL(argv.url);
   const scheme = protocol?.replace(/:$/, "");
-  
+
   return new Client({
     domain: hostname,
     port: Number(port),
@@ -27,7 +27,7 @@ export const getClient = async (argv) => {
     headers: {
       "x-fauna-shell-builtin": "true",
       "x-fauna-source": "Fauna Shell",
-    }
+    },
   });
 };
 
@@ -69,8 +69,8 @@ export const runQuery = async ({
   options = {},
 }) => {
   validateQueryParams({ query, client, url, secret });
-  let _client = client ?? await getClient({ url, secret });
- 
+  let _client = client ?? (await getClient({ url, secret }));
+
   try {
     return await _client.queryWithMetrics(query, options);
   } finally {
@@ -93,16 +93,16 @@ export const formatError = (err, opts = {}) => {
 
   // By doing this we can avoid requiring a faunadb direct dependency
   if (
-    err 
-    && typeof err.requestResult === 'object' 
-    && typeof err.requestResult.responseContent === 'object'
-    && Array.isArray(err.requestResult.responseContent.errors)
+    err &&
+    typeof err.requestResult === "object" &&
+    typeof err.requestResult.responseContent === "object" &&
+    Array.isArray(err.requestResult.responseContent.errors)
   ) {
     // If extra is on, return the full error.
     if (extra) {
       return formatFullErrorForShell(err, { color });
     }
-    
+
     const { errors } = err.requestResult.responseContent;
     if (!errors) {
       return err.message;
@@ -110,12 +110,12 @@ export const formatError = (err, opts = {}) => {
 
     const messages = [];
     errors.forEach(({ code, description, position }) => {
-       messages.push(`${code}: ${description} at ${position.join(', ')}\n`);
+      messages.push(`${code}: ${description} at ${position.join(", ")}\n`);
     });
 
-    return messages.join('\n').trim();
+    return messages.join("\n").trim();
   }
-  
+
   return err.message;
 };
 
@@ -136,7 +136,7 @@ export const formatQueryResponse = (res, opts = {}) => {
   }
 
   return formatObjectForShell(data, { color });
-}
+};
 
 /**
  * Runs a V4 Fauna query from a string expression.

--- a/src/lib/middleware.mjs
+++ b/src/lib/middleware.mjs
@@ -57,20 +57,32 @@ export function checkForUpdates(argv) {
  * set to 'secret'.
  * @param {import('yargs').Arguments} argv
  * @returns {void}
-*/
+ */
 export function applyLocalArg(argv) {
   const logger = container.resolve("logger");
   if (!argv.url) {
     if (argv.local) {
       argv.url = LOCAL_URL;
-      logger.debug(`Set url to '${LOCAL_URL}' as --local was given and --url was not`, "argv", argv);
+      logger.debug(
+        `Set url to '${LOCAL_URL}' as --local was given and --url was not`,
+        "argv",
+        argv,
+      );
     } else {
       argv.url = DEFAULT_URL;
-      logger.debug(`Defaulted url to '${DEFAULT_URL}' no --url was provided`, "argv", argv);
+      logger.debug(
+        `Defaulted url to '${DEFAULT_URL}' no --url was provided`,
+        "argv",
+        argv,
+      );
     }
   }
   if (!argv.secret && argv.local) {
     argv.secret = LOCAL_SECRET;
-    logger.debug(`Set secret to '${LOCAL_SECRET}' as --local was given and --secret was not`, "argv", argv);
+    logger.debug(
+      `Set secret to '${LOCAL_SECRET}' as --local was given and --secret was not`,
+      "argv",
+      argv,
+    );
   }
 }

--- a/src/lib/misc.mjs
+++ b/src/lib/misc.mjs
@@ -55,7 +55,7 @@ export function formatObjectForShell(obj, { color = true } = {}) {
 
 /**
  * Formats an error for display in the shell. Use this when you want to see
- * the full error object. Use specific formatting logic in your commands 
+ * the full error object. Use specific formatting logic in your commands
  * if you are creating a summary message. This is best used with --extra.
  * @param {any} err - The error to format
  * @param {object} [opts] - Options

--- a/test/config.mjs
+++ b/test/config.mjs
@@ -42,12 +42,12 @@ const databaseObject = {
   data: [
     {
       name: "test",
-      coll: 'Database',
+      coll: "Database",
       ts: "2024-07-16T19:16:15.980Z",
       global_id: "asd7zi8pharfn",
     },
   ],
-}
+};
 
 describe("configuration file", function () {
   let container, stderr, stdout, fs;
@@ -100,7 +100,9 @@ describe("configuration file", function () {
 
     // We colorize output in the shell, so we strip ANSI codes for testing since these
     // tests aren't focused on testing the shell output specifically
-    expect(stripAnsi(stdout.getWritten())).to.equal(`${JSON.stringify(objectToReturn, null, 2)}\n`);
+    expect(stripAnsi(stdout.getWritten())).to.equal(
+      `${JSON.stringify(objectToReturn, null, 2)}\n`,
+    );
     expect(stderr.getWritten()).to.equal("");
   }
 
@@ -290,10 +292,7 @@ describe("configuration file", function () {
         .throws(fakeFSError);
 
       try {
-        await run(
-          `eval --config ./dev.yaml "Database.all()"`,
-          container,
-        );
+        await run(`eval --config ./dev.yaml "Database.all()"`, container);
       } catch (e) {}
 
       const errorText = `Config file not found at path ${configPath}.`;

--- a/test/lib/middleware.mjs
+++ b/test/lib/middleware.mjs
@@ -6,17 +6,15 @@ import { setupTestContainer } from "../../src/config/setup-test-container.mjs";
 import { applyLocalArg } from "../../src/lib/middleware.mjs";
 
 describe("middlewares", function () {
-
   describe("applyLocalArg", function () {
+    const baseArgv = { _: [], $0: "", verboseComponent: [] };
 
-    const baseArgv = {  _: [], $0: '', verboseComponent: []};
-    
     beforeEach(() => {
       setupTestContainer();
     });
 
     it("should set url to localhost:8443 when --local is true and no url provided", function () {
-      const argv = { ...baseArgv, local: true, };
+      const argv = { ...baseArgv, local: true };
       applyLocalArg(argv);
       expect(argv.url).to.equal("http://localhost:8443");
       expect(argv.secret).to.equal("secret");
@@ -37,7 +35,7 @@ describe("middlewares", function () {
     });
 
     it("should not modify secret if already provided", function () {
-      const argv = { ...baseArgv, local: true, secret: "custom-secret", };
+      const argv = { ...baseArgv, local: true, secret: "custom-secret" };
       applyLocalArg(argv);
       expect(argv.url).to.equal("http://localhost:8443");
       expect(argv.secret).to.equal("custom-secret");

--- a/test/query.mjs
+++ b/test/query.mjs
@@ -8,7 +8,12 @@ import sinon from "sinon";
 import { run } from "../src/cli.mjs";
 import { setupTestContainer as setupContainer } from "../src/config/setup-test-container.mjs";
 import { formatObjectForShell } from "../src/lib/misc.mjs";
-import { createV4QueryFailure, createV4QuerySuccess, createV10QueryFailure, createV10QuerySuccess } from "./helpers.mjs";
+import {
+  createV4QueryFailure,
+  createV4QuerySuccess,
+  createV10QueryFailure,
+  createV10QuerySuccess,
+} from "./helpers.mjs";
 
 describe("query", function () {
   let container, logger, runQueryFromString;
@@ -28,15 +33,22 @@ describe("query", function () {
         await run(`query --secret=foo`, container);
       } catch (e) {}
 
-      expect(logger.stderr).to.have.been.calledWith(sinon.match("No query specified. Pass [fql] or --input."));
+      expect(logger.stderr).to.have.been.calledWith(
+        sinon.match("No query specified. Pass [fql] or --input."),
+      );
     });
 
     it("does not allow both --input and [fql]", async function () {
       try {
-        await run(`query --secret=foo --input "test.fql" "Database.all()"`, container);
+        await run(
+          `query --secret=foo --input "test.fql" "Database.all()"`,
+          container,
+        );
       } catch (e) {}
 
-      expect(logger.stderr).to.have.been.calledWith(sinon.match("Cannot specify both --input and [fql]"));
+      expect(logger.stderr).to.have.been.calledWith(
+        sinon.match("Cannot specify both --input and [fql]"),
+      );
     });
 
     it("requires a file passed to --input to exist", async function () {
@@ -44,7 +56,9 @@ describe("query", function () {
         await run(`query --secret=foo --input "nonexistent.fql"`, container);
       } catch (e) {}
 
-      expect(logger.stderr).to.have.been.calledWith(sinon.match("File passed to --input does not exist: nonexistent.fql"));
+      expect(logger.stderr).to.have.been.calledWith(
+        sinon.match("File passed to --input does not exist: nonexistent.fql"),
+      );
     });
 
     it("requires write access to the directory passed to --output", async function () {
@@ -52,10 +66,15 @@ describe("query", function () {
       container.resolve("dirname").returns("/var/nonexistent");
 
       try {
-        await run(`query --secret=foo --output "/var/nonexistent/result.json" "Database.all()"`, container);
+        await run(
+          `query --secret=foo --output "/var/nonexistent/result.json" "Database.all()"`,
+          container,
+        );
       } catch (e) {}
 
-      expect(logger.stderr).to.have.been.calledWith(sinon.match("Unable to write to output directory: /var/nonexistent"));
+      expect(logger.stderr).to.have.been.calledWith(
+        sinon.match("Unable to write to output directory: /var/nonexistent"),
+      );
     });
 
     it("can read from stdin if - is provided", async function () {
@@ -77,7 +96,7 @@ describe("query", function () {
 
       expect(existsSync).to.have.been.calledWith("test.fql");
       expect(readFileSync).to.have.been.calledWith("test.fql", "utf8");
-      expect(runQueryFromString).to.have.been.calledWith("Database.all()")
+      expect(runQueryFromString).to.have.been.calledWith("Database.all()");
     });
 
     it("can output results to a file", async function () {
@@ -87,30 +106,45 @@ describe("query", function () {
         coll: "Database",
         ts: 'Time("2024-07-16T19:16:15.980Z")',
         global_id: "asd7zi8pharfn",
-      }
+      };
       const testResponse = createV10QuerySuccess(testData);
       runQueryFromString.resolves(testResponse);
 
-      await run(`query --secret=foo --output "result.json" "Database.all()"`, container);
+      await run(
+        `query --secret=foo --output "result.json" "Database.all()"`,
+        container,
+      );
 
-      expect(writeFileSync).to.have.been.calledWith("result.json", JSON.stringify(testData, null, 2));
+      expect(writeFileSync).to.have.been.calledWith(
+        "result.json",
+        JSON.stringify(testData, null, 2),
+      );
     });
 
     it("can provide a timeout option", async function () {
-      await run(`query "Database.all()" --secret=foo --timeout 9000`, container);
-      expect(runQueryFromString).to.have.been.calledWith("\"Database.all()\"", sinon.match({
-        timeout: 9000
-      }));
+      await run(
+        `query "Database.all()" --secret=foo --timeout 9000`,
+        container,
+      );
+      expect(runQueryFromString).to.have.been.calledWith(
+        '"Database.all()"',
+        sinon.match({
+          timeout: 9000,
+        }),
+      );
     });
 
     it("uses 10 for the default apiVersion", async function () {
       await run(`query "Database.all()" --secret=foo`, container);
-      expect(runQueryFromString).to.have.been.calledWith(sinon.match.string, sinon.match({
-        apiVersion: '10'
-      }));
+      expect(runQueryFromString).to.have.been.calledWith(
+        sinon.match.string,
+        sinon.match({
+          apiVersion: "10",
+        }),
+      );
     });
 
-    // This test is skipped for now because we need to figure out a clean way to 
+    // This test is skipped for now because we need to figure out a clean way to
     // toggle whether our test stdout is a TTY or not.
     it.skip("can colorize output by default", async function () {
       runQueryFromString.resolves({ data: [] });
@@ -121,14 +155,16 @@ describe("query", function () {
     it("does not colorize output if --no-color is used", async function () {
       runQueryFromString.resolves({ data: [] });
       await run(`query "Database.all()" --secret=foo --no-color`, container);
-      expect(logger.stdout).to.have.been.calledWith(JSON.stringify([], null, 2));
+      expect(logger.stdout).to.have.been.calledWith(
+        JSON.stringify([], null, 2),
+      );
     });
 
     // This test is disabled because the argv fallback requires a real process.argv
     // and there's no way blessed way to override it in the test environment.
     it.skip("can mute stderr if --quiet is used", async function () {
-      runQueryFromString.rejects(new Error('test error'));
-      
+      runQueryFromString.rejects(new Error("test error"));
+
       try {
         await run(`query "Database.all()" --quiet --secret=foo`, container);
       } catch (e) {}
@@ -145,17 +181,22 @@ describe("query", function () {
         coll: "Database",
         ts: "2024-10-30T21:31:32.770Z",
         data: {},
-        global_id: "ys6ydpq14yynr"
-      }
+        global_id: "ys6ydpq14yynr",
+      };
       const testResponse = createV10QuerySuccess(testData);
       runQueryFromString.resolves(testResponse);
 
       await run(`query "Database.all()" --secret=foo`, container);
 
-      expect(runQueryFromString).to.have.been.calledWith("\"Database.all()\"", sinon.match({
-        apiVersion: '10'
-      }));
-      expect(logger.stdout).to.have.been.calledWith(formatObjectForShell(testData));
+      expect(runQueryFromString).to.have.been.calledWith(
+        '"Database.all()"',
+        sinon.match({
+          apiVersion: "10",
+        }),
+      );
+      expect(logger.stdout).to.have.been.calledWith(
+        formatObjectForShell(testData),
+      );
       expect(logger.stderr).to.not.be.called;
     });
 
@@ -165,20 +206,22 @@ describe("query", function () {
         coll: "Database",
         ts: 'Time("2024-07-16T19:16:15.980Z")',
         global_id: "asd7zi8pharfn",
-      }
+      };
       const testResponse = createV10QuerySuccess(testData);
       runQueryFromString.resolves(testResponse);
 
       await run(`query "Database.all()" --extra --secret=foo`, container);
 
-      expect(logger.stdout).to.have.been.calledWith(formatObjectForShell(testResponse));
+      expect(logger.stdout).to.have.been.calledWith(
+        formatObjectForShell(testResponse),
+      );
       expect(logger.stderr).to.not.be.called;
     });
 
     it("can output an error message", async function () {
       const testSummary = createV10QueryFailure("test query");
       runQueryFromString.rejects(new ServiceError(testSummary));
-      
+
       try {
         await run(`query "Database.all()" --secret=foo`, container);
       } catch (e) {}
@@ -187,12 +230,11 @@ describe("query", function () {
       expect(logger.stderr).to.have.been.calledWith(sinon.match(/test query/));
     });
 
-
     it("can output the full error object when --extra is used", async function () {
       const failure = createV10QueryFailure("test query");
       const error = new ServiceError(failure);
       runQueryFromString.rejects(error);
-      
+
       try {
         await run(`query "Database.all()" --extra --secret=foo`, container);
       } catch (e) {}
@@ -203,9 +245,12 @@ describe("query", function () {
 
     it("can set the typecheck option to true", async function () {
       await run(`query "Database.all()" --typecheck --secret=foo`, container);
-      expect(runQueryFromString).to.have.been.calledWith("\"Database.all()\"", sinon.match({
-        typecheck: true
-      }));
+      expect(runQueryFromString).to.have.been.calledWith(
+        '"Database.all()"',
+        sinon.match({
+          typecheck: true,
+        }),
+      );
     });
   });
 
@@ -213,43 +258,56 @@ describe("query", function () {
     it("can output the result of a query", async function () {
       const testData = {
         "@ref": {
-          "id": "test",
-          "collection": {
+          id: "test",
+          collection: {
             "@ref": {
-              "id": "collections"
-            }
-          }
-        }
-      }
+              id: "collections",
+            },
+          },
+        },
+      };
       const testResponse = createV4QuerySuccess(testData);
       runQueryFromString.resolves(testResponse);
 
-      await run(`query "Collection('test')" --apiVersion 4 --secret=foo`, container);
+      await run(
+        `query "Collection('test')" --apiVersion 4 --secret=foo`,
+        container,
+      );
 
-      expect(runQueryFromString).to.have.been.calledWith("\"Collection('test')\"", sinon.match({
-        apiVersion: '4'
-      }));
-      expect(logger.stdout).to.have.been.calledWith(formatObjectForShell(testData));
+      expect(runQueryFromString).to.have.been.calledWith(
+        "\"Collection('test')\"",
+        sinon.match({
+          apiVersion: "4",
+        }),
+      );
+      expect(logger.stdout).to.have.been.calledWith(
+        formatObjectForShell(testData),
+      );
       expect(logger.stderr).to.not.be.called;
     });
 
     it("can output additional response fields via --extra", async function () {
       const testData = {
         "@ref": {
-          "id": "test",
-          "collection": {
+          id: "test",
+          collection: {
             "@ref": {
-              "id": "collections"
-            }
-          }
-        }
-      }
+              id: "collections",
+            },
+          },
+        },
+      };
       const testResponse = createV4QuerySuccess(testData);
       runQueryFromString.resolves(testResponse);
 
-      await run(`query "Collection('test')" --extra --apiVersion 4 --secret=foo`, container);
+      await run(
+        `query "Collection('test')" --extra --apiVersion 4 --secret=foo`,
+        container,
+      );
 
-      expect(logger.stdout).to.have.been.calledWith(formatObjectForShell(testResponse));
+      expect(logger.stdout).to.have.been.calledWith(
+        formatObjectForShell(testResponse),
+      );
       expect(logger.stderr).to.not.be.called;
     });
 
@@ -257,37 +315,48 @@ describe("query", function () {
       const testError = createV4QueryFailure({
         position: ["paginate", "collections"],
         code: "invalid argument",
-        description: "Database Ref or Null expected, String provided."
+        description: "Database Ref or Null expected, String provided.",
       });
 
       // @ts-ignore
       runQueryFromString.rejects(testError);
-  
+
       try {
-        await run(`query "Paginate(Collection('x'))" --apiVersion 4 --secret=foo`, container);
+        await run(
+          `query "Paginate(Collection('x'))" --apiVersion 4 --secret=foo`,
+          container,
+        );
       } catch (e) {}
 
       expect(logger.stdout).to.not.be.called;
-      expect(logger.stderr).to.have.been.calledWith(sinon.match("invalid argument: Database Ref or Null expected, String provided. at paginate, collections"));
+      expect(logger.stderr).to.have.been.calledWith(
+        sinon.match(
+          "invalid argument: Database Ref or Null expected, String provided. at paginate, collections",
+        ),
+      );
     });
-
 
     it("can output the full error object when --extra is used", async function () {
       const testError = createV4QueryFailure({
         position: ["paginate", "collections"],
         code: "invalid argument",
-        description: "Database Ref or Null expected, String provided."
+        description: "Database Ref or Null expected, String provided.",
       });
 
       // @ts-ignore
       runQueryFromString.rejects(testError);
-  
+
       try {
-        await run(`query "Paginate(Collection('x'))" --apiVersion 4 --extra --secret=foo`, container);
+        await run(
+          `query "Paginate(Collection('x'))" --apiVersion 4 --extra --secret=foo`,
+          container,
+        );
       } catch (e) {}
 
       expect(logger.stdout).to.not.be.called;
-      expect(logger.stderr).to.have.been.calledWith(sinon.match(/requestResult/));
+      expect(logger.stderr).to.have.been.calledWith(
+        sinon.match(/requestResult/),
+      );
     });
   });
 });


### PR DESCRIPTION
this change updates the linting github action to fail if prettier _or_ eslint suggest any changes.

to make this manageable, this change also adds a husky hook that runs on commit and re-formats and lints (without committing the resulting changes). this should help keep the codebase consistently prettified.