### PR TITLE
Add dynamic key support to schema

### DIFF
--- a/src/commands/schema/abandon.mjs
+++ b/src/commands/schema/abandon.mjs
@@ -2,11 +2,13 @@
 
 import { container } from "../../cli.mjs";
 import { yargsWithCommonQueryOptions } from "../../lib/command-helpers.mjs";
+import { getSecret } from "../../lib/fauna-client.mjs";
 
 async function doAbandon(argv) {
   const makeFaunaRequest = container.resolve("makeFaunaRequest");
   const logger = container.resolve("logger");
   const confirm = container.resolve("confirm");
+  const secret = await getSecret();
 
   if (!argv.input) {
     const params = new URLSearchParams({
@@ -18,6 +20,7 @@ async function doAbandon(argv) {
       path: "/schema/1/staged/abandon",
       params,
       method: "POST",
+      secret,
     });
     logger.stdout("Schema has been abandoned");
   } else {
@@ -29,6 +32,7 @@ async function doAbandon(argv) {
       path: "/schema/1/staged/status",
       params,
       method: "GET",
+      secret,
     });
 
     if (response.status === "none")
@@ -49,6 +53,7 @@ async function doAbandon(argv) {
         path: "/schema/1/staged/abandon",
         params,
         method: "POST",
+        secret,
       });
 
       logger.stdout("Schema has been abandoned");

--- a/src/commands/schema/commit.mjs
+++ b/src/commands/schema/commit.mjs
@@ -2,11 +2,13 @@
 
 import { container } from "../../cli.mjs";
 import { yargsWithCommonQueryOptions } from "../../lib/command-helpers.mjs";
+import { getSecret } from "../../lib/fauna-client.mjs";
 
 async function doCommit(argv) {
   const makeFaunaRequest = container.resolve("makeFaunaRequest");
   const logger = container.resolve("logger");
   const confirm = container.resolve("confirm");
+  const secret = await getSecret();
 
   if (!argv.input) {
     const params = new URLSearchParams({
@@ -18,6 +20,7 @@ async function doCommit(argv) {
       path: "/schema/1/staged/commit",
       params,
       method: "POST",
+      secret,
     });
 
     logger.stdout("Schema has been committed");
@@ -30,6 +33,7 @@ async function doCommit(argv) {
       path: "/schema/1/staged/status",
       params,
       method: "GET",
+      secret,
     });
 
     if (response.status === "none")
@@ -53,6 +57,7 @@ async function doCommit(argv) {
         path: "/schema/1/staged/commit",
         params,
         method: "POST",
+        secret,
       });
 
       logger.stdout("Schema has been committed");

--- a/src/commands/schema/diff.mjs
+++ b/src/commands/schema/diff.mjs
@@ -4,6 +4,7 @@ import chalk from "chalk";
 
 import { container } from "../../cli.mjs";
 import { yargsWithCommonQueryOptions } from "../../lib/command-helpers.mjs";
+import { getSecret } from "../../lib/fauna-client.mjs";
 import { reformatFSL } from "../../lib/schema.mjs";
 
 /**
@@ -59,7 +60,7 @@ async function doDiff(argv) {
   const gatherFSL = container.resolve("gatherFSL");
   const logger = container.resolve("logger");
   const makeFaunaRequest = container.resolve("makeFaunaRequest");
-
+  const secret = await getSecret();
   const files = reformatFSL(await gatherFSL(argv.dir));
 
   const { version, status, diff } = await makeFaunaRequest({
@@ -67,6 +68,7 @@ async function doDiff(argv) {
     path: "/schema/1/staged/status",
     params: buildStatusParams(argv),
     method: "GET",
+    secret,
   });
 
   if (target === "staged") {
@@ -85,6 +87,7 @@ async function doDiff(argv) {
       params: buildValidateParams(argv, version),
       body: files,
       method: "POST",
+      secret,
     });
 
     if (status === "none") {

--- a/src/commands/schema/pull.mjs
+++ b/src/commands/schema/pull.mjs
@@ -1,8 +1,10 @@
 //@ts-check
 
 import { container } from "../../cli.mjs";
-import { CommandError, yargsWithCommonQueryOptions } from "../../lib/command-helpers.mjs";
-import { makeFaunaRequest } from "../../lib/db.mjs";
+import {
+  CommandError,
+  yargsWithCommonQueryOptions,
+} from "../../lib/command-helpers.mjs";
 import { getSecret } from "../../lib/fauna-client.mjs";
 
 async function determineFileState(argv, filenames) {
@@ -52,6 +54,7 @@ function logDiff({ argv, adds, overwrites, deletes }) {
 async function doPull(argv) {
   const logger = container.resolve("logger");
   const confirm = container.resolve("confirm");
+  const makeFaunaRequest = container.resolve("makeFaunaRequest");
   const secret = await getSecret();
 
   // fetch the list of remote FSL files

--- a/src/commands/schema/pull.mjs
+++ b/src/commands/schema/pull.mjs
@@ -3,6 +3,7 @@
 import { container } from "../../cli.mjs";
 import { yargsWithCommonQueryOptions } from "../../lib/command-helpers.mjs";
 import { makeFaunaRequest } from "../../lib/db.mjs";
+import { getSecret } from "../../lib/fauna-client.mjs";
 
 async function determineFileState(argv, filenames) {
   const gatherFSL = container.resolve("gatherFSL");
@@ -51,12 +52,14 @@ function logDiff({ argv, adds, overwrites, deletes }) {
 async function doPull(argv) {
   const logger = container.resolve("logger");
   const confirm = container.resolve("confirm");
+  const secret = await getSecret();
 
   // fetch the list of remote FSL files
   const filesResponse = await makeFaunaRequest({
     argv,
     path: "/schema/1/files",
     method: "GET",
+    secret,
   });
 
   // sort for consistent order (it's nice for tests)
@@ -71,6 +74,7 @@ async function doPull(argv) {
     path: "/schema/1/staged/status",
     params: new URLSearchParams({ version: filesResponse.version }),
     method: "GET",
+    secret,
   });
 
   // if there's a staged schema, cannot use the --active flag.

--- a/src/commands/schema/push.mjs
+++ b/src/commands/schema/push.mjs
@@ -2,16 +2,18 @@
 
 import { container } from "../../cli.mjs";
 import { yargsWithCommonQueryOptions } from "../../lib/command-helpers.mjs";
+import { getSecret } from "../../lib/fauna-client.mjs";
 import { reformatFSL } from "../../lib/schema.mjs";
 
 async function doPush(argv) {
   const logger = container.resolve("logger");
   const makeFaunaRequest = container.resolve("makeFaunaRequest");
-
   const gatherFSL = container.resolve("gatherFSL");
-  const fsl = reformatFSL(await gatherFSL(argv.dir));
 
   const isStagedPush = !argv.active;
+  const secret = await getSecret();
+
+  const fsl = reformatFSL(await gatherFSL(argv.dir));
 
   if (!argv.input) {
     const params = new URLSearchParams({
@@ -25,6 +27,7 @@ async function doPush(argv) {
       params,
       body: fsl,
       method: "POST",
+      secret,
     });
   } else {
     // Confirm diff, then push it. `force` is set on `validate` so we don't
@@ -40,6 +43,7 @@ async function doPush(argv) {
       params,
       body: fsl,
       method: "POST",
+      secret,
     });
 
     let message = isStagedPush
@@ -72,6 +76,7 @@ async function doPush(argv) {
         params,
         body: fsl,
         method: "POST",
+        secret,
       });
     } else {
       logger.stdout("Push cancelled");

--- a/src/commands/schema/status.mjs
+++ b/src/commands/schema/status.mjs
@@ -4,6 +4,7 @@ import chalk from "chalk";
 
 import { container } from "../../cli.mjs";
 import { yargsWithCommonQueryOptions } from "../../lib/command-helpers.mjs";
+import { getSecret } from "../../lib/fauna-client.mjs";
 import { reformatFSL } from "../../lib/schema.mjs";
 
 async function doStatus(argv) {
@@ -11,6 +12,7 @@ async function doStatus(argv) {
   const makeFaunaRequest = container.resolve("makeFaunaRequest");
 
   let params = new URLSearchParams({ diff: "summary" });
+  const secret = await getSecret();
   const gatherFSL = container.resolve("gatherFSL");
   const fsl = reformatFSL(await gatherFSL(argv.dir));
 
@@ -19,6 +21,7 @@ async function doStatus(argv) {
     path: "/schema/1/staged/status",
     params,
     method: "GET",
+    secret,
   });
 
   params = new URLSearchParams({
@@ -32,6 +35,7 @@ async function doStatus(argv) {
     params,
     method: "POST",
     body: fsl,
+    secret,
   });
 
   logger.stdout(`Staged changes: ${chalk.bold(statusResponse.status)}`);

--- a/src/config/setup-container.mjs
+++ b/src/config/setup-container.mjs
@@ -16,7 +16,7 @@ import { parseYargs } from "../cli.mjs";
 import { makeAccountRequest } from "../lib/account.mjs";
 import { Credentials } from "../lib/auth/credentials.mjs";
 import OAuthClient from "../lib/auth/oauth-client.mjs";
-import { makeFaunaRequest } from "../lib/db.mjs";
+import { makeRetryableFaunaRequest } from "../lib/db.mjs";
 import * as faunaV10 from "../lib/fauna.mjs";
 import { formatError, runQueryFromString } from "../lib/fauna-client.mjs";
 import * as faunaV4 from "../lib/faunadb.mjs";
@@ -70,8 +70,8 @@ export const injectables = {
   logger: awilix.asFunction(buildLogger, { lifetime: Lifetime.SINGLETON }),
   oauthClient: awilix.asClass(OAuthClient, { lifetime: Lifetime.SCOPED }),
   makeAccountRequest: awilix.asValue(makeAccountRequest),
-  makeFaunaRequest: awilix.asValue(makeFaunaRequest),
-  errorHandler: awilix.asValue((error, exitCode) => exit(exitCode)),
+  makeFaunaRequest: awilix.asValue(makeRetryableFaunaRequest),
+  errorHandler: awilix.asValue((_error, exitCode) => exit(exitCode)),
 
   // While we inject the class instance before this in middleware,
   //  we need to register it here to resolve types.

--- a/src/config/setup-test-container.mjs
+++ b/src/config/setup-test-container.mjs
@@ -8,7 +8,7 @@ import { spy, stub } from "sinon";
 
 import { f, InMemoryWritableStream } from "../../test/helpers.mjs";
 import { parseYargs } from "../cli.mjs";
-import { makeFaunaRequest } from "../lib/db.mjs";
+import { makeRetryableFaunaRequest } from "../lib/db.mjs";
 import * as faunaClientV10 from "../lib/fauna.mjs";
 import * as faunaClientV4 from "../lib/faunadb.mjs";
 import buildLogger from "../lib/logger.mjs";
@@ -88,7 +88,7 @@ export function setupTestContainer() {
     normalize: awilix.asValue(spy(path.normalize)),
     fetch: awilix.asValue(stub().resolves(f({}))),
     gatherFSL: awilix.asValue(stub().resolves([])),
-    makeFaunaRequest: awilix.asValue(spy(makeFaunaRequest)),
+    makeFaunaRequest: awilix.asValue(spy(makeRetryableFaunaRequest)),
     makeAccountRequest: awilix.asValue(stub()),
     runQueryFromString: awilix.asValue(stub().resolves({})),
     formatError: awilix.asValue(stub()),

--- a/src/lib/fauna-client.mjs
+++ b/src/lib/fauna-client.mjs
@@ -1,5 +1,6 @@
 //@ts-check
 
+
 import { container } from "../cli.mjs";
 
 export default class FaunaClient {
@@ -91,7 +92,9 @@ export const retryInvalidCredsOnce = async (initialSecret, fn) => {
     // vs doing another v4 vs v10 check.
     if (
       err &&
-      (err.httpStatus === 401 || err.requestResult?.statusCode === 401)
+      (err.name === "unauthorized" ||
+        err.httpStatus === 401 ||
+        err.requestResult?.statusCode === 401)
     ) {
       const credentials = container.resolve("credentials");
 

--- a/src/lib/schema.mjs
+++ b/src/lib/schema.mjs
@@ -4,6 +4,7 @@ import * as path from "path";
 
 import { container } from "../cli.mjs";
 import { makeFaunaRequest } from "../lib/db.mjs";
+import { getSecret } from "./fauna-client.mjs";
 import { dirExists, dirIsWriteable } from "./file-util.mjs";
 
 /**
@@ -173,12 +174,14 @@ export async function getAllSchemaFileContents(filenames, argv) {
   const promises = [];
   /** @type Record<string, string> */
   const fileContentCollection = {};
+  const secret = await getSecret();
   for (const filename of filenames) {
     promises.push(
       makeFaunaRequest({
         argv,
         path: `/schema/1/files/${encodeURIComponent(filename)}`,
         method: "GET",
+        secret,
       }).then(({ content }) => {
         fileContentCollection[filename] = content;
       }),

--- a/test/shell.mjs
+++ b/test/shell.mjs
@@ -151,7 +151,7 @@ describe("shell", function () {
         registerHomedir(container, "clear-history");
 
         // start the shell
-        const runPromise = run(`shell --secret "secret"`, container);
+        const runPromise = run(`shell --secret "secret" --no-color`, container);
         // Wait for the shell to start (print ">")
         // sleep for a little bit to let the shell get started
         // for some reason this is needed for the stdout to be read from predictably
@@ -241,7 +241,7 @@ describe("shell", function () {
       let query = "Database.all().take(1)";
 
       // start the shell
-      const runPromise = run(`shell --secret "secret"`, container);
+      const runPromise = run(`shell --secret "secret" --no-color`, container);
       // Wait for the shell to start (print ">")
       // sleep for a little bit to let the shell get started
       // for some reason this is needed for the stdout to be read from predictably
@@ -277,7 +277,7 @@ describe("shell", function () {
       return runPromise;
     });
 
-    it.skip("does not colorize output if --no-color is used", async function () { });
+    it.skip("does not colorize output if --no-color is used", async function () {});
 
     it.skip("can eval a query with typechecking enabled", async function () {
       container.resolve("performV10Query").resolves(v10Object1);


### PR DESCRIPTION
## Problem

Schema commands do not support dynamic database keys.

## Solution

Add support for dynamic database keys via `getSecret()` and `retryInvalidCredsOnce`.

## Result

```
➜  fauna-shell (v3-db-schema) ./src/user-entrypoint.mjs schema pull -d us-std/demo --dir /tmp/schema -p dev                                                                                                                                           ✱
Pull will make the following changes:
overwrite: collections.fsl
overwrite: functions.fsl
overwrite: main.fsl
✔ Accept the changes? yes
➜  fauna-shell (v3-db-schema) ls -la /tmp/schema/                                                                                                                                                                                                     ✱
total 32
drwxr-xr-x  5 ericcooper  wheel   160 Dec  4 12:45 .
drwxrwxrwt  5 root        wheel   160 Dec  4 12:45 ..
-rw-r--r--  1 ericcooper  wheel  2780 Dec  4 12:49 collections.fsl
-rw-r--r--  1 ericcooper  wheel  4539 Dec  4 12:49 functions.fsl
-rw-r--r--  1 ericcooper  wheel   263 Dec  4 12:49 main.fsl
➜  fauna-shell (v3-db-schema)      
```

## Testing

Existing tests should work as-is since this should be a transparent change.

## Follow-up
* Consider combining `getSecret` and `retryInvalidCredsOnce` into one wrapper. 
