### PR TITLE
Consolidate Validation Helpers

### DIFF
--- a/src/commands/database/create.mjs
+++ b/src/commands/database/create.mjs
@@ -6,10 +6,10 @@ import { container } from "../../cli.mjs";
 import { throwForError } from "../../lib/fauna.mjs";
 import { getSecret, retryInvalidCredsOnce } from "../../lib/fauna-client.mjs";
 import { formatObjectForShell } from "../../lib/misc.mjs";
-import { validateSecretOrDatabase } from "./database.mjs";
+import { validateDatabaseOrSecret } from "../../lib/command-helpers.mjs";
 
 function validate(argv) {
-  validateSecretOrDatabase(argv);
+  validateDatabaseOrSecret(argv);
   return true;
 }
 

--- a/src/commands/database/create.mjs
+++ b/src/commands/database/create.mjs
@@ -8,11 +8,6 @@ import { getSecret, retryInvalidCredsOnce } from "../../lib/fauna-client.mjs";
 import { formatObjectForShell } from "../../lib/misc.mjs";
 import { validateDatabaseOrSecret } from "../../lib/command-helpers.mjs";
 
-function validate(argv) {
-  validateDatabaseOrSecret(argv);
-  return true;
-}
-
 async function runCreateQuery(secret, argv) {
   const { fql } = container.resolve("fauna");
   const { runQuery } = container.resolve("faunaClientV10");
@@ -80,7 +75,7 @@ function buildCreateCommand(yargs) {
         description: "User-defined priority for the database.",
       },
     })
-    .check(validate)
+    .check(validateDatabaseOrSecret)
     .help("help", "show help")
     .example([
       [

--- a/src/commands/database/database.mjs
+++ b/src/commands/database/database.mjs
@@ -14,17 +14,6 @@ function buildDatabase(yargs) {
     .help("help", "Show help.");
 }
 
-export function validateSecretOrDatabase(argv) {
-  // Makes sure the user has provided either a secret or a database so we can
-  // successfully authenticate them.
-  if (!argv.secret && !argv.database) {
-    throw new Error(
-      "No secret or database provided. Please use either --secret or --database.",
-    );
-  }
-  return true;
-}
-
 export default {
   command: "database <method>",
   aliases: ["db"],

--- a/src/commands/database/delete.mjs
+++ b/src/commands/database/delete.mjs
@@ -5,10 +5,10 @@ import { FaunaError } from "fauna";
 import { container } from "../../cli.mjs";
 import { throwForError } from "../../lib/fauna.mjs";
 import { getSecret, retryInvalidCredsOnce } from "../../lib/fauna-client.mjs";
-import { validateSecretOrDatabase } from "./database.mjs";
+import { validateDatabaseOrSecret } from "../../lib/command-helpers.mjs";
 
 function validate(argv) {
-  validateSecretOrDatabase(argv);
+  validateDatabaseOrSecret(argv);
   return true;
 }
 

--- a/src/commands/database/delete.mjs
+++ b/src/commands/database/delete.mjs
@@ -7,11 +7,6 @@ import { throwForError } from "../../lib/fauna.mjs";
 import { getSecret, retryInvalidCredsOnce } from "../../lib/fauna-client.mjs";
 import { validateDatabaseOrSecret } from "../../lib/command-helpers.mjs";
 
-function validate(argv) {
-  validateDatabaseOrSecret(argv);
-  return true;
-}
-
 async function runDeleteQuery(secret, argv) {
   const { fql } = container.resolve("fauna");
   const { runQuery } = container.resolve("faunaClientV10");
@@ -53,7 +48,7 @@ function buildDeleteCommand(yargs) {
         description: "Name of the database to delete.",
       },
     })
-    .check(validate)
+    .check(validateDatabaseOrSecret)
     .help("help", "Show help.")
     .example([
       [

--- a/src/lib/command-helpers.mjs
+++ b/src/lib/command-helpers.mjs
@@ -152,7 +152,7 @@ export function isUnknownError(error) {
 export const validateDatabaseOrSecret = (argv) => {
   if (!argv.database && !argv.secret && !argv.local) {
     throw new ValidationError(
-      "No database or secret specified. Please specify either --database, --secret, or --local to connect to your desired Fauna database.",
+      "No database or secret specified. Please use either --database, --secret, or --local to connect to your desired Fauna database.",
     );
   }
 };

--- a/src/lib/command-helpers.mjs
+++ b/src/lib/command-helpers.mjs
@@ -131,6 +131,7 @@ export function isUnknownError(error) {
  * Validate that the user has specified either a database or a secret.
  * This check is not required for commands that can operate at a
  * "root" level.
+ *
  * @param {object} argv
  * @param {string} argv.database - The database to use
  * @param {string} argv.secret - The secret to use
@@ -139,7 +140,7 @@ export function isUnknownError(error) {
 export const validateDatabaseOrSecret = (argv) => {
   if (!argv.database && !argv.secret && !argv.local) {
     throw new ValidationError(
-      "No database or secret specified. Pass either --database, or --secret, or --local.",
+      "No database or secret specified. Please specify either --database, --secret, or --local to connect to your desired Fauna database.",
     );
   }
 };

--- a/src/lib/command-helpers.mjs
+++ b/src/lib/command-helpers.mjs
@@ -155,6 +155,7 @@ export const validateDatabaseOrSecret = (argv) => {
       "No database or secret specified. Please use either --database, --secret, or --local to connect to your desired Fauna database.",
     );
   }
+  return true;
 };
 
 // used for queries customers can configure

--- a/test/database/create.mjs
+++ b/test/database/create.mjs
@@ -31,7 +31,7 @@ describe("database create", () => {
     {
       command: "database create --name 'testdb'",
       message:
-        "No secret or database provided. Please use either --secret or --database.",
+        "No database or secret specified. Please use either --database, --secret, or --local to connect to your desired Fauna database.",
     },
   ].forEach(({ command, message }) => {
     it(`validates invalid arguments: ${command}`, async () => {

--- a/test/database/delete.mjs
+++ b/test/database/delete.mjs
@@ -31,7 +31,7 @@ describe("database delete", () => {
     {
       command: "database delete --name 'testdb'",
       message:
-        "No secret or database provided. Please use either --secret or --database.",
+        "No database or secret specified. Please use either --database, --secret, or --local to connect to your desired Fauna database.",
     },
   ].forEach(({ command, message }) => {
     it(`validates invalid arguments: ${command}`, async () => {


### PR DESCRIPTION
Ticket(s): FE-6162

## Problem
We have a `validateDatabaseOrSecret` helper and a `validateSecretOrDatabase` helper. We don't need both.

## Solution
Consolidate onto just one of these.

## Result
We have one place where we tell users they need to specify `--database`, `--secret` or `--local` for commands that need to talk to a specific database, eg `database create` or `database delete`.