### PR TITLE
Align schema commands with public schema endpoints

### DIFF
--- a/src/commands/schema/abandon.mjs
+++ b/src/commands/schema/abandon.mjs
@@ -9,20 +9,16 @@ async function doAbandon(argv) {
   const confirm = container.resolve("confirm");
 
   if (!argv.input) {
-    const params = new URLSearchParams({
-      force: "true", // Just abandon, don't pass a schema version through.
-    });
-
+    // Just abandon, don't pass a schema version through.
     await makeFaunaRequest({
       argv,
       path: "/schema/1/staged/abandon",
-      params,
       method: "POST",
     });
     logger.stdout("Schema has been abandoned");
   } else {
     // Show status to confirm.
-    const params = new URLSearchParams({ diff: "true" });
+    const params = new URLSearchParams({ format: "semantic" });
 
     const response = await makeFaunaRequest({
       argv,

--- a/src/commands/schema/commit.mjs
+++ b/src/commands/schema/commit.mjs
@@ -9,21 +9,17 @@ async function doCommit(argv) {
   const confirm = container.resolve("confirm");
 
   if (!argv.input) {
-    const params = new URLSearchParams({
-      force: "true", // Just commit, don't pass a schema version through.
-    });
-
+    // Just commit, don't pass a schema version through.
     await makeFaunaRequest({
       argv,
       path: "/schema/1/staged/commit",
-      params,
       method: "POST",
     });
 
     logger.stdout("Schema has been committed");
   } else {
     // Show status to confirm.
-    const params = new URLSearchParams({ diff: "true" });
+    const params = new URLSearchParams({ format: "semantic" });
 
     const response = await makeFaunaRequest({
       argv,

--- a/src/commands/schema/diff.mjs
+++ b/src/commands/schema/diff.mjs
@@ -41,15 +41,12 @@ function buildValidateParams(argv, version) {
   const [source] = parseTarget(argv);
   const diffKind = argv.text ? "textual" : "semantic";
   const params = new URLSearchParams({
-    diff: diffKind,
+    format: diffKind,
     staged: String(source === "staged"),
   });
   if (version) {
     params.set("version", version);
-  } else {
-    params.set("force", "true");
   }
-
   return params;
 }
 
@@ -81,7 +78,7 @@ async function doDiff(argv) {
   } else {
     const { diff } = await makeFaunaRequest({
       argv,
-      path: "/schema/1/validate",
+      path: "/schema/1/diff",
       params: buildValidateParams(argv, version),
       body: files,
       method: "POST",

--- a/src/commands/schema/push.mjs
+++ b/src/commands/schema/push.mjs
@@ -15,7 +15,6 @@ async function doPush(argv) {
 
   if (!argv.input) {
     const params = new URLSearchParams({
-      force: "true",
       staged: argv.active ? "false" : "true",
     });
 
@@ -27,16 +26,15 @@ async function doPush(argv) {
       method: "POST",
     });
   } else {
-    // Confirm diff, then push it. `force` is set on `validate` so we don't
+    // Confirm diff, then push it. Don't
     // need to pass the last known schema version through.
     const params = new URLSearchParams({
-      force: "true",
       staged: argv.active ? "false" : "true",
     });
 
     const response = await makeFaunaRequest({
       argv,
-      path: "/schema/1/validate",
+      path: "/schema/1/diff",
       params,
       body: fsl,
       method: "POST",

--- a/src/commands/schema/status.mjs
+++ b/src/commands/schema/status.mjs
@@ -10,7 +10,7 @@ async function doStatus(argv) {
   const logger = container.resolve("logger");
   const makeFaunaRequest = container.resolve("makeFaunaRequest");
 
-  let params = new URLSearchParams({ diff: "summary" });
+  let params = new URLSearchParams({ format: "summary" });
   const gatherFSL = container.resolve("gatherFSL");
   const fsl = reformatFSL(await gatherFSL(argv.dir));
 
@@ -22,13 +22,13 @@ async function doStatus(argv) {
   });
 
   params = new URLSearchParams({
-    diff: "summary",
+    format: "summary",
     staged: "true",
     version: statusResponse.version,
   });
   const validationResponse = await makeFaunaRequest({
     argv,
-    path: "/schema/1/validate",
+    path: "/schema/1/diff",
     params,
     method: "POST",
     body: fsl,

--- a/src/commands/shell.mjs
+++ b/src/commands/shell.mjs
@@ -24,6 +24,7 @@ async function shellCommand(argv) {
     prompt: `${argv.db_path || ""}> `,
     ignoreUndefined: true,
     preview: argv.apiVersion !== "10",
+    // eslint-disable-next-line no-warning-comments
     // TODO: integrate with fql-analyzer for completions
     completer: argv.apiVersion === "10" ? () => [] : undefined,
     output: container.resolve("stdoutStream"),

--- a/src/lib/account.mjs
+++ b/src/lib/account.mjs
@@ -79,6 +79,7 @@ async function parseResponse(response, shouldThrow) {
     }
     switch (response.status) {
       case 401:
+        // eslint-disable-next-line no-warning-comments
         // TODO: try and refresh creds and then redo the call, if not then throw.
         throw new InvalidCredsError(message);
       case 403:

--- a/src/lib/auth/accountKeys.mjs
+++ b/src/lib/auth/accountKeys.mjs
@@ -82,6 +82,7 @@ export class AccountKeys {
   async getOrRereshKey() {
     if (this.keySource === "credentials-file") {
       const key = this.keyStore.get();
+      // eslint-disable-next-line no-warning-comments
       // TODO: track ttl for account and refresh keys
       if (!key || (key.expiresAt && key.expiresAt < Date.now())) {
         this.logger.debug(

--- a/src/lib/auth/credentials.mjs
+++ b/src/lib/auth/credentials.mjs
@@ -54,6 +54,7 @@ export class Credentials {
     this.accountKeys.keyStore.save({
       accountKey,
       refreshToken,
+      // eslint-disable-next-line no-warning-comments
       // TODO: set expiration
     });
     this.accountKeys.key = accountKey;

--- a/src/lib/auth/oauth-client.mjs
+++ b/src/lib/auth/oauth-client.mjs
@@ -52,6 +52,7 @@ class OAuthClient {
   }
 
   // req: IncomingMessage, res: ServerResponse
+  // eslint-disable-next-line complexity
   _handleRequest(req, res) {
     const logger = container.resolve("logger");
     const allowedOrigins = [

--- a/src/lib/db.mjs
+++ b/src/lib/db.mjs
@@ -3,7 +3,7 @@
 import { container } from "../cli.mjs";
 
 function buildParamsString({ argv, params, path }) {
-  const routesWithColor = ["/schema/1/staged/status", "/schema/1/validate"];
+  const routesWithColor = ["/schema/1/staged/status", "/schema/1/diff"];
   if (params && argv.color && routesWithColor.includes(path))
     params.set("color", "ansi");
   if (params && params.sort) params.sort();

--- a/src/lib/fauna-account-client.mjs
+++ b/src/lib/fauna-account-client.mjs
@@ -129,6 +129,7 @@ export class FaunaAccountClient {
    * @throws {Error} - Throws an error if there is an issue during session retrieval.
    */
 
+  // eslint-disable-next-line no-warning-comments
   // TODO: get/set expiration details
   static async getSession(accessToken) {
     const makeAccountRequest = container.resolve("makeAccountRequest");
@@ -146,6 +147,7 @@ export class FaunaAccountClient {
     }
   }
 
+  // eslint-disable-next-line no-warning-comments
   // TODO: get/set expiration details
   /**
    * Uses refreshToken to get a new accountKey and refreshToken.

--- a/src/lib/fauna-client.mjs
+++ b/src/lib/fauna-client.mjs
@@ -12,6 +12,7 @@ export default class FaunaClient {
 
   // query<T>(query: string, opts?: format?: string; typecheck?: boolean; secret?: string;
   // returns Promise<QueryResponse<T>>
+  // eslint-disable-next-line complexity
   async query(query, opts) {
     const fetch = container.resolve("fetch");
 

--- a/src/lib/middleware.mjs
+++ b/src/lib/middleware.mjs
@@ -27,6 +27,7 @@ export function fixPaths(argv) {
 }
 
 export function checkForUpdates(argv) {
+  // eslint-disable-next-line no-warning-comments
   // TODO: figure out upgrade path for SEA installations
   if (isSea()) return argv;
 

--- a/test/general-cli.mjs
+++ b/test/general-cli.mjs
@@ -128,7 +128,6 @@ describe("cli operations", function () {
         status: "none",
         diff: "Staged schema: none",
         pending_summary: "",
-        text_diff: "",
       }),
     );
     fetch.onCall(1).resolves(

--- a/test/schema/abandon.mjs
+++ b/test/schema/abandon.mjs
@@ -12,8 +12,6 @@ import { buildUrl, commonFetchParams, f } from "../helpers.mjs";
 describe("schema abandon", function () {
   let diff =
     "\u001b[1;34m* Modifying collection `Customer`\u001b[0m at collections.fsl:2:1:\n  * Defined fields:\n\u001b[31m  - drop field `.age`\u001b[0m\n\n";
-  let textDiff =
-    "\u001b[1mcollections.fsl\u001b[22m\n\u001b[36m@ line 9 to 14\u001b[0m\n      postalCode: String,\n      country: String\n    }\n\u001b[31m-   age: Number?\u001b[0m\n\n    compute cart: Order? = (customer => Order.byCustomerAndStatus(customer, 'cart').first())\n\n\u001b[36m@ line 24 to 30\u001b[0m\n\n    migrations {\n      add .age\n\u001b[32m+     drop .age\u001b[0m\n    }\n  }\n\n";
   let container, fetch, logger, confirm;
 
   beforeEach(() => {

--- a/test/schema/abandon.mjs
+++ b/test/schema/abandon.mjs
@@ -30,7 +30,6 @@ describe("schema abandon", function () {
         status: "ready",
         pending_summary: "",
         diff: diff,
-        text_diff: textDiff,
       }),
     );
 
@@ -38,7 +37,7 @@ describe("schema abandon", function () {
 
     expect(fetch).to.have.been.calledOnce;
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/staged/abandon", { force: "true" }),
+      buildUrl("/schema/1/staged/abandon"),
       { ...commonFetchParams, method: "POST" },
     );
     expect(logger.stdout).to.have.been.calledWith("Schema has been abandoned");
@@ -54,7 +53,6 @@ describe("schema abandon", function () {
         status: "ready",
         pending_summary: "",
         diff: diff,
-        text_diff: textDiff,
       }),
     );
     fetch.onCall(1).resolves(f({ version: 1728679966220000 }));
@@ -65,7 +63,7 @@ describe("schema abandon", function () {
     await run(`schema abandon --secret "secret"`, container);
 
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/staged/status", { diff: "true", color: "ansi" }),
+      buildUrl("/schema/1/staged/status", { format: "semantic", color: "ansi" }),
       { ...commonFetchParams, method: "GET" },
     );
     expect(fetch).to.have.been.calledWith(
@@ -93,7 +91,7 @@ describe("schema abandon", function () {
     expect(logger.stderr).to.have.been.calledWith(message);
 
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/staged/status", { diff: "true", color: "ansi" }),
+      buildUrl("/schema/1/staged/status", { format: "semantic", color: "ansi" }),
       { ...commonFetchParams, method: "GET" },
     );
   });
@@ -105,7 +103,6 @@ describe("schema abandon", function () {
         status: "ready",
         pending_summary: "",
         diff: diff,
-        text_diff: textDiff,
       }),
     );
     fetch.onCall(1).resolves(f({ version: 1728679966220000 }));
@@ -117,7 +114,7 @@ describe("schema abandon", function () {
 
     expect(fetch).to.have.been.calledOnce;
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/staged/status", { diff: "true", color: "ansi" }),
+      buildUrl("/schema/1/staged/status", { format: "semantic", color: "ansi" }),
       { ...commonFetchParams, method: "GET" },
     );
     expect(logger.stdout).to.have.been.calledWith("Abandon cancelled");

--- a/test/schema/commit.mjs
+++ b/test/schema/commit.mjs
@@ -10,8 +10,6 @@ import { setupTestContainer as setupContainer } from "../../src/config/setup-tes
 import { buildUrl, commonFetchParams, f } from "../helpers.mjs";
 
 describe("schema commit", function () {
-  const textDiff =
-    "\u001b[1mcollections.fsl\u001b[22m\n\u001b[36m@ line 9 to 14\u001b[0m\n      postalCode: String,\n      country: String\n    }\n\u001b[31m-   age: Number?\u001b[0m\n\n    compute cart: Order? = (customer => Order.byCustomerAndStatus(customer, 'cart').first())\n\n\u001b[36m@ line 24 to 30\u001b[0m\n\n    migrations {\n      add .age\n\u001b[32m+     drop .age\u001b[0m\n    }\n  }\n\n";
   const diff =
     "\u001b[1;34m* Modifying collection `Customer`\u001b[0m at collections.fsl:2:1:\n  * Defined fields:\n\u001b[31m  - drop field `.age`\u001b[0m\n\n";
   let container, fetch, logger, confirm;
@@ -90,6 +88,7 @@ describe("schema commit", function () {
   });
 
   it("errors if the schema is not in a ready state", async function () {
+    // eslint-disable-next-line no-warning-comments
     // TODO: what are the valid statuses? !none, !ready results in this case
     fetch.onCall(0).resolves(f({ status: "building", diff: diff }));
 

--- a/test/schema/commit.mjs
+++ b/test/schema/commit.mjs
@@ -30,7 +30,6 @@ describe("schema commit", function () {
         status: "ready",
         pending_summary: "",
         diff: diff,
-        text_diff: textDiff,
       }),
     );
 
@@ -42,7 +41,7 @@ describe("schema commit", function () {
     await run(`schema commit --secret "secret"`, container);
 
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/staged/status", { diff: "true", color: "ansi" }),
+      buildUrl("/schema/1/staged/status", { format: "semantic", color: "ansi" }),
       { ...commonFetchParams, method: "GET" },
     );
     expect(fetch).to.have.been.calledWith(
@@ -63,7 +62,7 @@ describe("schema commit", function () {
 
     expect(fetch).to.have.been.calledOnce;
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/staged/commit", { force: "true" }),
+      buildUrl("/schema/1/staged/commit"),
       { ...commonFetchParams, method: "POST" },
     );
     expect(logger.stdout).to.have.been.calledWith("Schema has been committed");
@@ -81,7 +80,7 @@ describe("schema commit", function () {
     expect(error).to.have.property("code", 1);
     expect(fetch).to.have.been.calledOnce;
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/staged/status", { diff: "true", color: "ansi" }),
+      buildUrl("/schema/1/staged/status", { format: "semantic", color: "ansi" }),
       { ...commonFetchParams, method: "GET" },
     );
     expect(logger.stdout).to.not.have.been.called;
@@ -101,7 +100,7 @@ describe("schema commit", function () {
     expect(error).to.have.property("code", 1);
     expect(fetch).to.have.been.calledOnce;
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/staged/status", { diff: "true", color: "ansi" }),
+      buildUrl("/schema/1/staged/status", { format: "semantic", color: "ansi" }),
       { ...commonFetchParams, method: "GET" },
     );
     expect(logger.stdout).to.have.been.calledWith(diff);
@@ -117,7 +116,6 @@ describe("schema commit", function () {
         status: "ready",
         pending_summary: "",
         diff: diff,
-        text_diff: textDiff,
       }),
     );
 
@@ -128,7 +126,7 @@ describe("schema commit", function () {
 
     expect(fetch).to.have.been.calledOnce;
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/staged/status", { diff: "true", color: "ansi" }),
+      buildUrl("/schema/1/staged/status", { format: "semantic", color: "ansi" }),
       { ...commonFetchParams, method: "GET" },
     );
     expect(logger.stdout).to.have.been.calledWith("Commit cancelled");

--- a/test/schema/diff.mjs
+++ b/test/schema/diff.mjs
@@ -45,10 +45,9 @@ describe("schema diff", function () {
       { ...commonFetchParams, method: "GET" },
     );
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/validate", {
+      buildUrl("/schema/1/diff", {
         color: "ansi",
-        diff: "semantic",
-        force: "true",
+        format: "semantic",
         staged: "true",
       }),
       { ...commonFetchParams, method: "POST", body: reformatFSL(fsl) },
@@ -72,10 +71,9 @@ describe("schema diff", function () {
       { ...commonFetchParams, method: "GET" },
     );
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/validate", {
+      buildUrl("/schema/1/diff", {
         color: "ansi",
-        diff: "semantic",
-        force: "true",
+        format: "semantic",
         staged: "false",
       }),
       { ...commonFetchParams, method: "POST", body: reformatFSL(fsl) },
@@ -99,10 +97,9 @@ describe("schema diff", function () {
       method: "GET",
     });
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/validate", {
-        force: "true",
+      buildUrl("/schema/1/diff", {
         staged: "true",
-        diff: "semantic",
+        format: "semantic",
       }),
       { ...commonFetchParams, method: "POST", body: reformatFSL(fsl) },
     );
@@ -125,11 +122,10 @@ describe("schema diff", function () {
       { ...commonFetchParams, method: "GET" },
     );
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/validate", {
-        force: "true",
+      buildUrl("/schema/1/diff", {
         color: "ansi",
         staged: "true",
-        diff: "semantic",
+        format: "semantic",
       }),
       { ...commonFetchParams, method: "POST", body: reformatFSL(fsl) },
     );

--- a/test/schema/push.mjs
+++ b/test/schema/push.mjs
@@ -37,7 +37,7 @@ describe("schema push", function () {
     expect(gatherFSL).to.have.been.calledWith(".");
 
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/update", { force: "true", staged: "true" }),
+      buildUrl("/schema/1/update", { staged: "true" }),
       {
         method: "POST",
         headers: { AUTHORIZATION: "Bearer secret" },
@@ -71,8 +71,7 @@ describe("schema push", function () {
     await run(`schema push --secret "secret"`, container);
 
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/validate", {
-        force: "true",
+      buildUrl("/schema/1/diff", {
         staged: "true",
         color: "ansi",
       }),
@@ -125,8 +124,7 @@ describe("schema push", function () {
     await run(`schema push --secret "secret" --active`, container);
 
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/validate", {
-        force: "true",
+      buildUrl("/schema/1/diff", {
         staged: "false",
         color: "ansi",
       }),
@@ -172,8 +170,7 @@ describe("schema push", function () {
     await run(`schema push --secret "secret"`, container);
 
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/validate", {
-        force: "true",
+      buildUrl("/schema/1/diff", {
         staged: "true",
         color: "ansi",
       }),
@@ -215,8 +212,7 @@ describe("schema push", function () {
     await run(`schema push --secret "secret"`, container);
 
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/validate", {
-        force: "true",
+      buildUrl("/schema/1/diff", {
         staged: "true",
         color: "ansi",
       }),
@@ -261,8 +257,7 @@ describe("schema push", function () {
     await run(`schema push --secret "secret" --active`, container);
 
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/validate", {
-        force: "true",
+      buildUrl("/schema/1/diff", {
         staged: "false",
         color: "ansi",
       }),

--- a/test/schema/status.mjs
+++ b/test/schema/status.mjs
@@ -75,7 +75,6 @@ describe("schema status", function () {
         status: "none",
         diff: "Staged schema: none",
         pending_summary: "",
-        text_diff: "",
       }),
     );
     fetch.onCall(1).resolves(
@@ -88,12 +87,12 @@ describe("schema status", function () {
     await run(`schema status --secret "secret"`, container);
 
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/staged/status", { diff: "summary", color: "ansi" }),
+      buildUrl("/schema/1/staged/status", { format: "summary", color: "ansi" }),
       commonFetchParams,
     );
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/validate", {
-        diff: "summary",
+      buildUrl("/schema/1/diff", {
+        format: "summary",
         staged: "true",
         version: "0",
         color: "ansi",
@@ -115,7 +114,6 @@ describe("schema status", function () {
         status: "none",
         diff: "Staged schema: none",
         pending_summary: "",
-        text_diff: "",
       }),
     );
     fetch.onCall(1).resolves(
@@ -131,12 +129,12 @@ describe("schema status", function () {
     await run(`schema status --secret "secret"`, container);
 
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/staged/status", { diff: "summary", color: "ansi" }),
+      buildUrl("/schema/1/staged/status", { format: "summary", color: "ansi" }),
       commonFetchParams,
     );
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/validate", {
-        diff: "summary",
+      buildUrl("/schema/1/diff", {
+        format: "summary",
         staged: "true",
         version: "0",
         color: "ansi",
@@ -166,7 +164,6 @@ describe("schema status", function () {
         status: "ready",
         diff: summaryDiff,
         pending_summary: "",
-        text_diff: textDiff,
       }),
     );
     fetch.onCall(1).resolves(
@@ -179,13 +176,13 @@ describe("schema status", function () {
     await run(`schema status --secret "secret"`, container);
 
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/staged/status", { diff: "summary", color: "ansi" }),
+      buildUrl("/schema/1/staged/status", { format: "summary", color: "ansi" }),
       commonFetchParams,
     );
 
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/validate", {
-        diff: "summary",
+      buildUrl("/schema/1/diff", {
+        format: "summary",
         staged: "true",
         version: "0",
         color: "ansi",
@@ -211,7 +208,6 @@ describe("schema status", function () {
         status: "ready",
         diff: summaryDiff,
         pending_summary: "",
-        text_diff: "",
       }),
     );
     fetch.onCall(1).resolves(
@@ -226,12 +222,12 @@ describe("schema status", function () {
     await run(`schema status --secret "secret"`, container);
 
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/staged/status", { diff: "summary", color: "ansi" }),
+      buildUrl("/schema/1/staged/status", { format: "summary", color: "ansi" }),
       commonFetchParams,
     );
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/validate", {
-        diff: "summary",
+      buildUrl("/schema/1/diff", {
+        format: "summary",
         staged: "true",
         version: "0",
         color: "ansi",
@@ -270,7 +266,7 @@ describe("schema status", function () {
     await run(`schema status --no-color --secret "secret"`, container);
 
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/staged/status", { diff: "summary" }),
+      buildUrl("/schema/1/staged/status", { format: "summary" }),
       commonFetchParams,
     );
     expect(logger.stderr).not.to.have.been.called;

--- a/test/schema/status.mjs
+++ b/test/schema/status.mjs
@@ -15,53 +15,6 @@ describe("schema status", function () {
     "\x1B[1;34m* Modifying collection `OrderItem`\x1B[0m at collections.fsl:125:1\n" +
     "\x1B[1;34m* Modifying function `createOrUpdateCartItem`\x1B[0m at functions.fsl:2:1\n";
 
-  let textDiff =
-    "\x1B[1mcollections.fsl\x1B[22m\n" +
-    "\x1B[36m@ line 1 to 7\x1B[0m\n" +
-    "\n" +
-    "\x1B[32m+ collection NewCollection {\x1B[0m\n" +
-    "\x1B[32m+ }\x1B[0m\n" +
-    "\x1B[32m+\x1B[0m\n" +
-    "  collection Customer {\n" +
-    "    name: String\n" +
-    "    email: String\n" +
-    "\x1B[36m@ line 134 to 139\x1B[0m\n" +
-    "      terms [.order]\n" +
-    "      values [.product, .quantity]\n" +
-    "    }\n" +
-    "\x1B[31m-\x1B[0m\n" +
-    "\x1B[31m-   index byOrderAndProduct {\x1B[0m\n" +
-    "\x1B[31m-     terms [.order, .product]\x1B[0m\n" +
-    "\x1B[31m-   }\x1B[0m\n" +
-    "  }\n" +
-    "\n" +
-    "\n" +
-    "\n" +
-    "\x1B[1mfunctions.fsl\x1B[22m\n" +
-    "\x1B[36m@ line 30 to 35\x1B[0m\n" +
-    "    if (product!.stock < quantity) {\n" +
-    '      abort("Product does not have the requested quantity in stock.")\n' +
-    "    }\n" +
-    "\x1B[31m-\x1B[0m\n" +
-    "\x1B[31m-   // Attempt to find an existing order item for the order, product pair.\x1B[0m\n" +
-    "\x1B[31m-   // There is a unique constraint on [.order, .product] so this will return at most one result.\x1B[0m\n" +
-    "\x1B[31m-   let orderItem = OrderItem.byOrderAndProduct(customer!.cart, product).first()\x1B[0m\n" +
-    "\x1B[31m-\x1B[0m\n" +
-    "\x1B[31m-   if (orderItem == null) {\x1B[0m\n" +
-    "\x1B[31m-     // If the order item does not exist, create a new one.\x1B[0m\n" +
-    "\x1B[31m-     OrderItem.create({\x1B[0m\n" +
-    "\x1B[31m-       order: Order(customer!.cart!.id),\x1B[0m\n" +
-    "\x1B[31m-       product: product,\x1B[0m\n" +
-    "\x1B[31m-       quantity: quantity,\x1B[0m\n" +
-    "\x1B[31m-     })\x1B[0m\n" +
-    "\x1B[31m-   } else {\x1B[0m\n" +
-    "\x1B[31m-     // If the order item exists, update the quantity.\x1B[0m\n" +
-    "\x1B[31m-     orderItem!.update({ quantity: quantity })\x1B[0m\n" +
-    "\x1B[31m-   }\x1B[0m\n" +
-    "  }\n" +
-    "\n" +
-    "  function getOrCreateCart(id) {\n";
-
   beforeEach(() => {
     container = setupContainer();
     fetch = container.resolve("fetch");


### PR DESCRIPTION
## Problem

We plan to publicly publish the Schema HTTP API endpoints. The CLI uses the endpoints in ways we don't want to support.

## Solution

Updates the CLI to align with our [planned docs](https://deploy-preview-2707--fauna-docs.netlify.app/fauna/current/reference/http/reference/core-api/#tag/Schema):

* Replace `/schema/1/validate` with its `/schema/1/diff` alias
* Change the `?diff` param to `?format`
* Change `?diff=true` to `?format=semantic`
* Remove usage of `?force=true`. This is the default if `version` isn't passed.
* Remove `text_diff` from `/schema/1/staged/status` responses.

## Testing

Updated the tests and ran `npm run test:local`. Happy to add additional tests if needed.
