### PR TITLE
Fix verbosity checks

### DIFF
--- a/src/lib/logger.mjs
+++ b/src/lib/logger.mjs
@@ -49,8 +49,8 @@ export function log({
 
   if (
     argv &&
-    argv.verboseComponent &&
-    (argv.verbosity >= verbosity || argv.verboseComponent.includes(component))
+    (argv.verbosity >= verbosity ||
+      (argv.verboseComponent ?? []).includes(component))
   ) {
     const prefix = chalk.reset("[") + formatter(component) + chalk.reset("]: ");
     stream(prefix + formatter(text));


### PR DESCRIPTION
## Problem

Verbosity checks require verbosity component to be set. That's not what we want.

## Solution

Protect against empty verbosityComponent values, but don't require them.

## Result

Verbosity works by itself again.
