### PR TITLE
remove test reliance on color

### DIFF
--- a/test/general-cli.mjs
+++ b/test/general-cli.mjs
@@ -17,7 +17,16 @@ import { f } from "./helpers.mjs";
 const __dirname = import.meta.dirname;
 
 describe("cli operations", function () {
-  let container, stderr;
+  let container, stderr, startingChalkLevel;
+
+  before(() => {
+    startingChalkLevel = chalk.level;
+    chalk.level = 0;
+  });
+
+  after(() => {
+    chalk.level = startingChalkLevel;
+  });
 
   beforeEach(() => {
     container = setupContainer();
@@ -33,9 +42,7 @@ describe("cli operations", function () {
     } catch (e) {}
 
     expect(logger.stdout).to.not.be.called;
-    const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
-      "Missing required argument: name",
-    )}`;
+    const message = `${await builtYargs.getHelp()}\n\nMissing required argument: name`;
     expect(logger.stderr).to.have.been.calledWith(message);
     expect(container.resolve("parseYargs")).to.have.been.calledOnce;
   });
@@ -49,9 +56,7 @@ describe("cli operations", function () {
     } catch (e) {}
 
     expect(logger.stdout).to.not.be.called;
-    const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
-      "Unknown argument: halflight",
-    )}`;
+    const message = `${await builtYargs.getHelp()}\n\nUnknown argument: halflight`;
     expect(logger.stderr).to.have.been.calledWith(message);
     expect(container.resolve("parseYargs")).to.have.been.calledOnce;
   });
@@ -65,9 +70,7 @@ describe("cli operations", function () {
     } catch (e) {}
 
     expect(logger.stdout).to.not.be.called;
-    const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
-      "Unknown argument: inland-empire",
-    )}`;
+    const message = `${await builtYargs.getHelp()}\n\nUnknown argument: inland-empire`;
     expect(logger.stderr).to.have.been.calledWith(message);
     expect(container.resolve("parseYargs")).to.have.been.calledOnce;
   });
@@ -81,9 +84,7 @@ describe("cli operations", function () {
     } catch (e) {}
 
     expect(logger.stdout).to.not.be.called;
-    const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.reset(
-      "Use 'fauna <command> --help' for more information about a command.",
-    )}`;
+    const message = `${await builtYargs.getHelp()}\n\nUse 'fauna <command> --help' for more information about a command.`;
     expect(logger.stderr).to.have.been.calledWith(message);
     expect(container.resolve("parseYargs")).to.have.been.calledOnce;
   });
@@ -97,9 +98,7 @@ describe("cli operations", function () {
     } catch (e) {}
 
     expect(logger.stdout).to.not.be.called;
-    const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
-      "An unexpected error occurred...\n\nthis is a test error\n\nIf you believe this is a bug, please report this issue on GitHub: https://github.com/fauna/fauna-shell/issues",
-    )}`;
+    const message = `${await builtYargs.getHelp()}\n\nAn unexpected error occurred...\n\nthis is a test error\n\nIf you believe this is a bug, please report this issue on GitHub: https://github.com/fauna/fauna-shell/issues`;
     expect(stderr.getWritten().trim()).to.equal(message);
     expect(container.resolve("parseYargs")).to.have.been.calledOnce;
   });
@@ -113,9 +112,7 @@ describe("cli operations", function () {
     } catch (e) {}
 
     expect(logger.stdout).to.not.be.called;
-    const message = `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red(
-      "An unexpected error occurred...\n\nthis is a rejected promise\n\nIf you believe this is a bug, please report this issue on GitHub: https://github.com/fauna/fauna-shell/issues",
-    )}`;
+    const message = `${await builtYargs.getHelp()}\n\nAn unexpected error occurred...\n\nthis is a rejected promise\n\nIf you believe this is a bug, please report this issue on GitHub: https://github.com/fauna/fauna-shell/issues`;
     expect(stderr.getWritten().trim()).to.equal(message);
     expect(container.resolve("parseYargs")).to.have.been.calledOnce;
   });


### PR DESCRIPTION
right now, 6 tests in the general CLI test suite rely on terminal color escape sequences. these are a pain to get consistent across environments and multiple developers' terminals - so for now, let's remove the escapes sequences from the text we assert and run the commands without color.