### PR TITLE
Remove some options from login command

### DIFF
--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -175,14 +175,6 @@ function buildYargs(argvInput) {
         default: "default",
         group: "Config:",
       },
-      user: {
-        alias: "u",
-        type: "string",
-        description:
-          "User account used to run the command. Register a user account in the CLI using `fauna login`.",
-        default: "default",
-        group: "API:",
-      },
       json: {
         type: "boolean",
         description: "Output the results as JSON.",

--- a/src/commands/login.mjs
+++ b/src/commands/login.mjs
@@ -39,7 +39,7 @@ function buildLoginCommand(yargs) {
     user: {
       alias: "u",
       type: "string",
-      description: "Name of account to register",
+      description: "User to log in as",
       default: "default",
       group: "login Options:",
     },

--- a/src/commands/login.mjs
+++ b/src/commands/login.mjs
@@ -1,7 +1,7 @@
 //@ts-check
 
 import { container } from "../cli.mjs";
-import { yargsWithCommonQueryOptions } from "../lib/command-helpers.mjs";
+import { yargsWithCommonOptions } from "../lib/command-helpers.mjs";
 import { FaunaAccountClient } from "../lib/fauna-account-client.mjs";
 
 async function doLogin() {
@@ -35,7 +35,15 @@ async function doLogin() {
  * @returns
  */
 function buildLoginCommand(yargs) {
-  return yargsWithCommonQueryOptions(yargs);
+  return yargsWithCommonOptions(yargs, {
+    user: {
+      alias: "u",
+      type: "string",
+      description: "Name of account to register",
+      default: "default",
+      group: "login Options:",
+    },
+  });
 }
 
 export default {

--- a/src/lib/command-helpers.mjs
+++ b/src/lib/command-helpers.mjs
@@ -28,7 +28,7 @@ const COMMON_QUERY_OPTIONS = {
     alias: "u",
     type: "string",
     description:
-      "User account used to run the command. Register a user account in the CLI using `fauna login`.",
+      "User used to run the command. You must first log in as the user using `fauna login`.",
     default: "default",
     group: "API:",
   },

--- a/src/lib/command-helpers.mjs
+++ b/src/lib/command-helpers.mjs
@@ -1,7 +1,37 @@
 //@ts-check
 
+const COMMON_OPTIONS = {
+  // hidden
+  accountUrl: {
+    type: "string",
+    description: "the Fauna account URL to query",
+    default: "https://account.fauna.com",
+    hidden: true,
+  },
+  clientId: {
+    type: "string",
+    description: "the client id to use when calling Fauna",
+    required: false,
+    hidden: true,
+  },
+  clientSecret: {
+    type: "string",
+    description: "the client secret to use when calling Fauna",
+    required: false,
+    hidden: true,
+  },
+};
+
 // used for queries customers can't configure that are made on their behalf
 const COMMON_QUERY_OPTIONS = {
+  user: {
+    alias: "u",
+    type: "string",
+    description:
+      "User account used to run the command. Register a user account in the CLI using `fauna login`.",
+    default: "default",
+    group: "API:",
+  },
   local: {
     type: "boolean",
     describe:
@@ -35,25 +65,6 @@ const COMMON_QUERY_OPTIONS = {
     description:
       "Role used to run the command. Mutually exclusive with `--secret`.",
     group: "API:",
-  },
-  // hidden
-  accountUrl: {
-    type: "string",
-    description: "the Fauna account URL to query",
-    default: "https://account.fauna.com",
-    hidden: true,
-  },
-  clientId: {
-    type: "string",
-    description: "the client id to use when calling Fauna",
-    required: false,
-    hidden: true,
-  },
-  clientSecret: {
-    type: "string",
-    description: "the client secret to use when calling Fauna",
-    required: false,
-    hidden: true,
   },
 };
 
@@ -180,6 +191,6 @@ export function yargsWithCommonConfigurableQueryOptions(yargs) {
   return yargsWithCommonOptions(yargs, COMMON_CONFIGURABLE_QUERY_OPTIONS);
 }
 
-function yargsWithCommonOptions(yargs, options) {
-  return yargs.options({ ...options });
+export function yargsWithCommonOptions(yargs, options) {
+  return yargs.options({ ...options, ...COMMON_OPTIONS });
 }


### PR DESCRIPTION
Ticket(s): [FE-6179](https://faunadb.atlassian.net/browse/FE-6179)

## Problem

`login` has all the options from other command, including `--user` which is described as setting the account that will be used to execute commands -- we want to use the `--user` option to set the name when registering the user. 

## Solution

Separate out "common" options from "common query" options and use those for the login command.

## Result

No changes other than to the help text. 

before
<img width="900" alt="image" src="https://github.com/user-attachments/assets/cc6156d2-a950-4cb0-ae7a-004dcb172a6b">

after
<img width="850" alt="image" src="https://github.com/user-attachments/assets/a11fa3fe-90e0-4906-8cd0-1170daf5351c">

## Testing
no functional changes


[FE-6179]: https://faunadb.atlassian.net/browse/FE-6179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ