### PR TITLE
Don't let config parse for help or version when getting profile

### DIFF
--- a/src/lib/config/config.mjs
+++ b/src/lib/config/config.mjs
@@ -80,13 +80,16 @@ export function configParser(path) {
 
   logger.debug(`Reading config from ${path}.`, "config");
   const config = getConfig(path);
-  const argv = yargs(argvInput).options({
-    profile: {
-      default: "default",
-      alias: ["p"],
-      type: "string",
-    },
-  }).argv;
+  const argv = yargs(argvInput)
+    .options({
+      profile: {
+        default: "default",
+        alias: ["p"],
+        type: "string",
+      },
+    })
+    .help(false)
+    .version(false).argv;
 
   logger.debug(`Using profile ${argv.profile}...`, "config");
   parsedProfile = config.toJSON()[argv.profile];

--- a/src/lib/config/config.mjs
+++ b/src/lib/config/config.mjs
@@ -1,7 +1,7 @@
 import yaml from "yaml";
-import yargs from "yargs";
+import yargsParser from "yargs-parser";
 
-import { argvInput, container } from "../../cli.mjs";
+import { container } from "../../cli.mjs";
 import { ValidationError } from "../command-helpers.mjs";
 
 export const validDefaultConfigNames = [
@@ -80,16 +80,15 @@ export function configParser(path) {
 
   logger.debug(`Reading config from ${path}.`, "config");
   const config = getConfig(path);
-  const argv = yargs(argvInput)
-    .options({
-      profile: {
-        default: "default",
-        alias: ["p"],
-        type: "string",
-      },
-    })
-    .help(false)
-    .version(false).argv;
+  const argv = yargsParser(process.argv.slice(2), {
+    alias: {
+      profile: ["p"],
+    },
+    default: {
+      profile: "default",
+    },
+    string: ["profile"],
+  });
 
   logger.debug(`Using profile ${argv.profile}...`, "config");
   parsedProfile = config.toJSON()[argv.profile];

--- a/src/lib/config/config.mjs
+++ b/src/lib/config/config.mjs
@@ -1,7 +1,7 @@
 import yaml from "yaml";
 import yargsParser from "yargs-parser";
 
-import { container } from "../../cli.mjs";
+import { argvInput, container } from "../../cli.mjs";
 import { ValidationError } from "../command-helpers.mjs";
 
 export const validDefaultConfigNames = [
@@ -80,7 +80,7 @@ export function configParser(path) {
 
   logger.debug(`Reading config from ${path}.`, "config");
   const config = getConfig(path);
-  const argv = yargsParser(process.argv.slice(2), {
+  const argv = yargsParser(argvInput, {
     alias: {
       profile: ["p"],
     },


### PR DESCRIPTION
## Problem

We parse args in the config middleware, but do not disable help or version. This means they will always execute before our actual help.

## Solution

Turn off help.

## Result

Help from the command show.
