### PR TITLE
[FE-6167] - Document --no-<arg>

### DIFF
--- a/src/commands/schema/abandon.mjs
+++ b/src/commands/schema/abandon.mjs
@@ -70,7 +70,8 @@ function buildAbandonCommand(yargs) {
   return yargsWithCommonQueryOptions(yargs)
     .options({
       input: {
-        description: "Prompt for user input (e.g., confirmations)",
+        description:
+          "Prompt for input, such as confirmation. To disable prompts, use `--no-input` or `--input=false`. Disabled prompts are useful for scripts, CI/CD, and automation workflows.",
         default: true,
         type: "boolean",
       },

--- a/src/commands/schema/push.mjs
+++ b/src/commands/schema/push.mjs
@@ -88,7 +88,8 @@ function buildPushCommand(yargs) {
   return yargsWithCommonQueryOptions(yargs)
     .options({
       input: {
-        description: "Prompt for user input (e.g., confirmations)",
+        description:
+          "Prompt for input, such as confirmation. To disable prompts, use `--no-input` or `--input=false`. Disabled prompts are useful for scripts, CI/CD, and automation workflows.",
         default: true,
         type: "boolean",
       },


### PR DESCRIPTION
Ticket(s) FE-6167

## Problem
You can use `--no-<arg>` to negate boolean arguments. We are missing this info in a couple places in our help text.

## Solution
Audit all default `true` boolean commands and update the description if it lacks this info.

## Result
The remaining default `true` boolean arguments document how to negate them.
