### PR TITLE
default oauth to prod client

### DIFF
--- a/src/lib/auth/oauth-client.mjs
+++ b/src/lib/auth/oauth-client.mjs
@@ -5,12 +5,12 @@ import url from "url";
 import { container } from "../../cli.mjs";
 
 // Default to prod client id and secret
-const clientId = process.env.FAUNA_CLIENT_ID ?? "-_vEB3FKRoWbJdFpMg72Mx0UVAA";
+const clientId = process.env.FAUNA_CLIENT_ID ?? "Aq4_G0mOtm_F1fK3PuzE0k-i9F0";
 // Native public clients are not confidential. The client secret is not used beyond
 //   client identification. https://datatracker.ietf.org/doc/html/rfc8252#section-8.5
 const clientSecret =
   process.env.FAUNA_CLIENT_SECRET ??
-  "CGNriRe8uZakmOL6yfhuSZJ_-15Tio4ueM3whw0O38fXLb2829PHCA";
+  "2W9eZYlyN5XwnpvaP3AwOfclrtAjTXncH6k-bdFq1ZV0hZMFPzRIfg";
 const REDIRECT_URI = `http://127.0.0.1`;
 
 class OAuthClient {

--- a/src/lib/middleware.mjs
+++ b/src/lib/middleware.mjs
@@ -15,6 +15,16 @@ const DEFAULT_URL = "https://db.fauna.com";
 export function logArgv(argv) {
   const logger = container.resolve("logger");
   logger.debug(JSON.stringify(argv, null, 4), "argv", argv);
+  const faunaEnvVars = Object.entries(process.env)
+    .filter(([key]) => key.startsWith("FAUNA"))
+    .reduce((acc, [key, value]) => {
+      acc[key] = value;
+      return acc;
+    }, {});
+  logger.debug(
+    `Existing Fauna environment variables: ${JSON.stringify(faunaEnvVars)}`,
+    "argv",
+  );
   return argv;
 }
 

--- a/src/lib/middleware.mjs
+++ b/src/lib/middleware.mjs
@@ -29,7 +29,7 @@ function captureEnvVars() {
       .reduce((acc, [key, value]) => {
         acc[key] = value;
         return acc;
-      }, {})
+      }, {}),
   );
 }
 

--- a/src/lib/middleware.mjs
+++ b/src/lib/middleware.mjs
@@ -16,7 +16,7 @@ export function logArgv(argv) {
   const logger = container.resolve("logger");
   logger.debug(JSON.stringify(argv, null, 4), "argv", argv);
   const faunaEnvVars = Object.entries(process.env)
-    .filter(([key]) => key.startsWith("FAUNA"))
+    .filter(([key]) => key.startsWith("FAUNA_"))
     .reduce((acc, [key, value]) => {
       acc[key] = value;
       return acc;

--- a/src/lib/middleware.mjs
+++ b/src/lib/middleware.mjs
@@ -15,17 +15,22 @@ const DEFAULT_URL = "https://db.fauna.com";
 export function logArgv(argv) {
   const logger = container.resolve("logger");
   logger.debug(JSON.stringify(argv, null, 4), "argv", argv);
-  const faunaEnvVars = Object.entries(process.env)
-    .filter(([key]) => key.startsWith("FAUNA_"))
-    .reduce((acc, [key, value]) => {
-      acc[key] = value;
-      return acc;
-    }, {});
   logger.debug(
-    `Existing Fauna environment variables: ${JSON.stringify(faunaEnvVars)}`,
+    `Existing Fauna environment variables: ${captureEnvVars()}`,
     "argv",
   );
   return argv;
+}
+
+function captureEnvVars() {
+  return JSON.stringify(
+    Object.entries(process.env)
+      .filter(([key]) => key.startsWith("FAUNA_"))
+      .reduce((acc, [key, value]) => {
+        acc[key] = value;
+        return acc;
+      }, {})
+  );
 }
 
 export function fixPaths(argv) {


### PR DESCRIPTION
### Problem
CLI was defaulting to the oauth client that frontdoor uses when it's hosted locally. 
This means nobody should need to set any env vars when logging in to the shell, unless they wanna go to dev/prev

### Solution
Customers should default to prod. Remember this client secret isn't really secret and that's ok in this OAuth contract strategy.

Also dumping Fauna-prefixed env vars in the `logArgv` middleware for FE-6173

### Out of Scope

Option to redact specific env vars or argv attributes. Helpful for customers that want to copy pasta verbose output straight into a bug report.