### PR TITLE
Review examples and help strings

### DIFF
--- a/src/commands/database/create.mjs
+++ b/src/commands/database/create.mjs
@@ -50,7 +50,7 @@ async function createDatabase(argv) {
     if (e instanceof FaunaError) {
       throwForError(e, {
         onConstraintFailure: () =>
-          `Constraint failure: The database '${argv.name}' may already exists or one of the provided options may be invalid.`,
+          `Constraint failure: The database '${argv.name}' already exists or one of the provided options is invalid.`,
       });
     }
     throw e;
@@ -63,7 +63,7 @@ function buildCreateCommand(yargs) {
       name: {
         type: "string",
         required: true,
-        description: "Name of the database to create.",
+        description: "Name of the child database to create.",
       },
       typechecked: {
         type: "string",
@@ -84,12 +84,20 @@ function buildCreateCommand(yargs) {
     .help("help", "show help")
     .example([
       [
-        "$0 database create --name 'my-database' --database 'us/example'",
-        "Create a database named 'my-database' under `us/example`.",
+        "$0 database create --name my_database --database us/example",
+        "Create a database named 'my_database' directly under 'us/example'.",
       ],
       [
-        "$0 database create --name 'my-database' --secret 'my-secret'",
-        "Create a database named 'my-database' scoped to a secret.",
+        "$0 database create --name my_database --secret my-secret",
+        "Create a database named 'my_database' directly under the database scoped to a secret.",
+      ],
+      [
+        "$0 database create --name my_database --database us/example --typechecked",
+        "Create a database with typechecking enabled.",
+      ],
+      [
+        "$0 database create --name my_database --database us/example --protected",
+        "Create a database with protected mode enabled.",
       ],
     ]);
 }

--- a/src/commands/database/delete.mjs
+++ b/src/commands/database/delete.mjs
@@ -57,12 +57,12 @@ function buildDeleteCommand(yargs) {
     .help("help", "Show help.")
     .example([
       [
-        "$0 database delete --name 'my-database' --database 'us/example'",
-        "Delete a database named 'my-database' under `us/example`.",
+        "$0 database delete --name my_database --database us/example",
+        "Delete a database named 'my_database' directly under 'us/example'.",
       ],
       [
-        "$0 database delete --name 'my-database' --secret 'my-secret'",
-        "Delete a database named 'my-database' scoped to a secret.",
+        "$0 database delete --name my_database --secret my-secret",
+        "Delete a database named 'my_database' directly under the database scoped to a secret.",
       ],
     ]);
 }

--- a/src/commands/database/list.mjs
+++ b/src/commands/database/list.mjs
@@ -87,22 +87,22 @@ function buildListCommand(yargs) {
     })
     .help("help", "Show help.")
     .example([
-      ["$0 database list", "List all top-level databases"],
+      ["$0 database list", "List all top-level databases."],
       [
-        "$0 database list --database 'us/example'",
-        "list all child databases under `us/example`",
+        "$0 database list --database us/example",
+        "List all child databases directly under the 'us/example' database.",
       ],
       [
-        "$0 database list --secret 'my-secret'",
-        "List all child databases for the database scoped to a secret",
+        "$0 database list --secret my-secret",
+        "List all child databases directly under a database scoped to a secret.",
       ],
       [
         "$0 database list --json",
-        "List all top-level databases and output as JSON",
+        "List all top-level databases and output as JSON.",
       ],
       [
         "$0 database list --pageSize 10",
-        "List the first 10 top-level databases",
+        "List the first 10 top-level databases.",
       ],
     ]);
 }

--- a/src/commands/login.mjs
+++ b/src/commands/login.mjs
@@ -39,16 +39,27 @@ function buildLoginCommand(yargs) {
     user: {
       alias: "u",
       type: "string",
-      description: "User to log in as",
+      description: "User to log in as.",
       default: "default",
-      group: "login Options:",
+      group: "Login options:",
     },
-  });
+  })
+  .example([
+    [
+      "$0 login",
+      "Log in as the 'default' user."
+    ],
+    [
+      "$0 login --user john_doe",
+      "Log in as the 'john_doe' user."
+    ],
+  ])
+  .help("help", "Show help.");
 }
 
 export default {
   command: "login",
-  describe: "Authenticate with Fauna.",
+  describe: "Log in to Fauna using a web-based browser flow.",
   builder: buildLoginCommand,
   handler: doLogin,
 };

--- a/src/commands/login.mjs
+++ b/src/commands/login.mjs
@@ -44,17 +44,11 @@ function buildLoginCommand(yargs) {
       group: "Login options:",
     },
   })
-  .example([
-    [
-      "$0 login",
-      "Log in as the 'default' user."
-    ],
-    [
-      "$0 login --user john_doe",
-      "Log in as the 'john_doe' user."
-    ],
-  ])
-  .help("help", "Show help.");
+    .example([
+      ["$0 login", "Log in as the 'default' user."],
+      ["$0 login --user john_doe", "Log in as the 'john_doe' user."],
+    ])
+    .help("help", "Show help.");
 }
 
 export default {

--- a/src/commands/query.mjs
+++ b/src/commands/query.mjs
@@ -141,23 +141,31 @@ function buildQueryCommand(yargs) {
     .example([
       [
         '$0 query "Collection.all()" --database us/example',
-        "Run the query and write the results to stdout ",
+        "Run the query in the 'us/example' database and write the results to stdout.",
+      ],
+      [
+        '$0 query "Collection.all()" --database us/example --role server',
+        "Run the query in the 'us/example' database using the 'server' role.",
+      ],
+      [
+        '$0 query "Collection.all()" --secret my-secret',
+        "Run the query in the database scoped to a secret.",
       ],
       [
         "$0 query -i /path/to/query.fql --database us/example",
-        "Run the query from a file",
+        "Run the query from a file.",
       ],
       [
         'echo "1 + 1" | $0 query - --database us/example',
-        "Run the query from stdin",
+        "Run the query from stdin.",
       ],
       [
         "$0 query -i /path/to/queries.fql --output /tmp/result.json --database us/example",
-        "Run the query and write the results to a file",
+        "Run the query and write the results to a file.",
       ],
       [
         "$0 query -i /path/to/queries.fql --extra --output /tmp/result.json --database us/example",
-        "Run the query and write the full API response to a file",
+        "Run the query and write the full API response to a file.",
       ],
     ])
     .help("help", "Show help.");

--- a/src/commands/schema/abandon.mjs
+++ b/src/commands/schema/abandon.mjs
@@ -79,15 +79,15 @@ function buildAbandonCommand(yargs) {
     .example([
       [
         "$0 schema abandon --database us/example",
-        "Abandon staged schema for the 'us/example' database."
+        "Abandon staged schema for the 'us/example' database.",
       ],
       [
         "$0 schema abandon --secret my-secret",
-        "Abandon staged schema for the database scoped to a secret."
+        "Abandon staged schema for the database scoped to a secret.",
       ],
       [
         "$0 schema abandon --database us/example --no-input",
-        "Run the command without input prompts."
+        "Run the command without input prompts.",
       ],
     ])
     .help("help", "Show help.");

--- a/src/commands/schema/abandon.mjs
+++ b/src/commands/schema/abandon.mjs
@@ -95,7 +95,7 @@ function buildAbandonCommand(yargs) {
 
 export default {
   command: "abandon",
-  description: "Abandon the current staged schema.",
+  description: "Abandon a database's staged schema.",
   builder: buildAbandonCommand,
   handler: doAbandon,
 };

--- a/src/commands/schema/abandon.mjs
+++ b/src/commands/schema/abandon.mjs
@@ -25,7 +25,7 @@ async function doAbandon(argv) {
       method: "POST",
       secret,
     });
-    logger.stdout("Schema has been abandoned");
+    logger.stdout("Schema has been abandoned.");
   } else {
     // Show status to confirm.
     const params = new URLSearchParams({ diff: "true" });
@@ -39,7 +39,7 @@ async function doAbandon(argv) {
     });
 
     if (response.status === "none")
-      throw new CommandError("There is no staged schema to abandon");
+      throw new CommandError("There is no staged schema to abandon.");
 
     logger.stdout(response.diff);
 
@@ -59,9 +59,9 @@ async function doAbandon(argv) {
         secret,
       });
 
-      logger.stdout("Schema has been abandoned");
+      logger.stdout("Schema has been abandoned.");
     } else {
-      logger.stdout("Abandon cancelled");
+      logger.stdout("Abandon cancelled.");
     }
   }
 }
@@ -76,7 +76,20 @@ function buildAbandonCommand(yargs) {
         type: "boolean",
       },
     })
-    .example([["$0 schema abandon"]])
+    .example([
+      [
+        "$0 schema abandon --database us/example",
+        "Abandon staged schema for the 'us/example' database."
+      ],
+      [
+        "$0 schema abandon --secret my-secret",
+        "Abandon staged schema for the database scoped to a secret."
+      ],
+      [
+        "$0 schema abandon --database us/example --no-input",
+        "Run the command without input prompts."
+      ],
+    ])
     .help("help", "Show help.");
 }
 

--- a/src/commands/schema/commit.mjs
+++ b/src/commands/schema/commit.mjs
@@ -80,7 +80,20 @@ function buildCommitCommand(yargs) {
         type: "boolean",
       },
     })
-    .example([["$0 schema commit"]])
+    .example([
+      [
+        "$0 schema commit --database us/example",
+        "Commit staged schema for the 'us/example' database."
+      ],
+      [
+        "$0 schema commit --secret my-secret",
+        "Commit staged schema for the database scoped to a secret."
+      ],
+      [
+        "$0 schema commit --database us/example --no-input",
+        "Run the command without input prompts."
+      ],
+    ])
     .help("help", "Show help.");
 }
 

--- a/src/commands/schema/commit.mjs
+++ b/src/commands/schema/commit.mjs
@@ -83,15 +83,15 @@ function buildCommitCommand(yargs) {
     .example([
       [
         "$0 schema commit --database us/example",
-        "Commit staged schema for the 'us/example' database."
+        "Commit staged schema for the 'us/example' database.",
       ],
       [
         "$0 schema commit --secret my-secret",
-        "Commit staged schema for the database scoped to a secret."
+        "Commit staged schema for the database scoped to a secret.",
       ],
       [
         "$0 schema commit --database us/example --no-input",
-        "Run the command without input prompts."
+        "Run the command without input prompts.",
       ],
     ])
     .help("help", "Show help.");

--- a/src/commands/schema/commit.mjs
+++ b/src/commands/schema/commit.mjs
@@ -99,7 +99,7 @@ function buildCommitCommand(yargs) {
 
 export default {
   command: "commit",
-  description: "Apply staged schema files to a database.",
+  description: "Apply a staged schema to a database.",
   builder: buildCommitCommand,
   handler: doCommit,
 };

--- a/src/commands/schema/diff.mjs
+++ b/src/commands/schema/diff.mjs
@@ -19,7 +19,7 @@ function parseTarget(argv) {
   }
 
   if (argv.active && argv.staged) {
-    throw new ValidationError("Cannot specify both --active and --staged");
+    throw new ValidationError("Cannot specify both --active and --staged.");
   }
 
   if (argv.active) {
@@ -27,7 +27,7 @@ function parseTarget(argv) {
   } else if (argv.staged) {
     return ["active", "staged"];
   } else {
-    throw new ValidationError("Invalid target. Expected: active or staged");
+    throw new ValidationError("Invalid target. Expected: active or staged.");
   }
 }
 
@@ -115,34 +115,51 @@ function buildDiffCommand(yargs) {
     .options({
       staged: {
         description:
-          "Show the diff between the active and staged schema, instead of the local schema.",
+          "Show the diff between the active and staged schema.",
         default: false,
         type: "boolean",
       },
       text: {
-        description: "Display the text diff instead of the semantic diff.",
+        description:
+          "Show a text diff. A text diff contains line-by-line changes, including comments and whitespace.",
         default: false,
         type: "boolean",
       },
       active: {
         description:
-          "Show the diff against the active schema instead of the staged schema.",
+          "Show the diff between the active and local schema.",
         default: false,
         type: "boolean",
       },
     })
     .example([
-      ["$0 schema diff"],
-      ["$0 schema diff --dir schemas/myschema"],
-      ["$0 schema diff --staged"],
-      ["$0 schema diff --active --text"],
+      [
+        "$0 schema diff --database us/example --dir /path/to/schema",
+        "Compare the 'us/example' database's staged schema to the local schema. If no schema is staged, compare the database's active schema to the local schema."
+      ],
+      [
+        "$0 schema diff --database us/example --dir /path/to/schema --active",
+        "Compare the 'us/example' database's active schema to the local schema."
+      ],
+      [
+        "$0 schema diff --secret my-secret --dir /path/to/schema --active",
+        "Compare the active schema of the database scoped to a secret to the local schema."
+      ],
+      [
+        "$0 schema diff --database us/example --dir /path/to/schema --staged",
+        "Compare the 'us/example' database's active schema to its staged schema."
+      ],
+      [
+        "$0 schema diff --database us/example --dir /path/to/schema --text",
+        "Show a text diff instead of a semantic diff."
+      ],
     ])
     .help("help", "Show help.");
 }
 
 export default {
   command: "diff",
-  description: "Print the diff between local and remote schema.",
+  description: "Show the diff between a database's local, staged, or active schema.",
   builder: buildDiffCommand,
   handler: doDiff,
 };

--- a/src/commands/schema/diff.mjs
+++ b/src/commands/schema/diff.mjs
@@ -114,8 +114,7 @@ function buildDiffCommand(yargs) {
   return yargsWithCommonQueryOptions(yargs)
     .options({
       staged: {
-        description:
-          "Show the diff between the active and staged schema.",
+        description: "Show the diff between the active and staged schema.",
         default: false,
         type: "boolean",
       },
@@ -126,8 +125,7 @@ function buildDiffCommand(yargs) {
         type: "boolean",
       },
       active: {
-        description:
-          "Show the diff between the active and local schema.",
+        description: "Show the diff between the active and local schema.",
         default: false,
         type: "boolean",
       },
@@ -135,23 +133,23 @@ function buildDiffCommand(yargs) {
     .example([
       [
         "$0 schema diff --database us/example --dir /path/to/schema",
-        "Compare the 'us/example' database's staged schema to the local schema. If no schema is staged, compare the database's active schema to the local schema."
+        "Compare the 'us/example' database's staged schema to the local schema. If no schema is staged, compare the database's active schema to the local schema.",
       ],
       [
         "$0 schema diff --database us/example --dir /path/to/schema --active",
-        "Compare the 'us/example' database's active schema to the local schema."
+        "Compare the 'us/example' database's active schema to the local schema.",
       ],
       [
         "$0 schema diff --secret my-secret --dir /path/to/schema --active",
-        "Compare the active schema of the database scoped to a secret to the local schema."
+        "Compare the active schema of the database scoped to a secret to the local schema.",
       ],
       [
         "$0 schema diff --database us/example --dir /path/to/schema --staged",
-        "Compare the 'us/example' database's active schema to its staged schema."
+        "Compare the 'us/example' database's active schema to its staged schema.",
       ],
       [
         "$0 schema diff --database us/example --dir /path/to/schema --text",
-        "Show a text diff instead of a semantic diff."
+        "Show a text diff instead of a semantic diff.",
       ],
     ])
     .help("help", "Show help.");
@@ -159,7 +157,8 @@ function buildDiffCommand(yargs) {
 
 export default {
   command: "diff",
-  description: "Show the diff between a database's local, staged, or active schema.",
+  description:
+    "Show the diff between a database's local, staged, or active schema.",
   builder: buildDiffCommand,
   handler: doDiff,
 };

--- a/src/commands/schema/pull.mjs
+++ b/src/commands/schema/pull.mjs
@@ -137,7 +137,8 @@ function buildPullCommand(yargs) {
         default: false,
       },
       active: {
-        description: "Pull the database's active schema files. If omitted, pulls the database's staged schema, if available.",
+        description:
+          "Pull the database's active schema files. If omitted, pulls the database's staged schema, if available.",
         type: "boolean",
         default: false,
       },
@@ -145,19 +146,19 @@ function buildPullCommand(yargs) {
     .example([
       [
         "$0 schema pull --database us/example --dir /path/to/schema",
-        "Pull the 'us/example' database's staged schema."
+        "Pull the 'us/example' database's staged schema.",
       ],
       [
         "$0 schema pull ---secret my-secret --dir /path/to/schema",
-        "Pull the staged schema for the database scoped to a secret."
+        "Pull the staged schema for the database scoped to a secret.",
       ],
       [
         "$0 schema pull --database us/example --dir /path/to/schema --active",
-        "Pull the 'us/example' database's active schema."
+        "Pull the 'us/example' database's active schema.",
       ],
       [
         "$0 schema pull --database us/example --dir /path/to/schema --delete",
-        "Delete `.fsl` files in the target directory that are not part of the pulled schema."
+        "Delete `.fsl` files in the target directory that are not part of the pulled schema.",
       ],
     ])
     .help("help", "Show help.");

--- a/src/commands/schema/pull.mjs
+++ b/src/commands/schema/pull.mjs
@@ -132,7 +132,7 @@ function buildPullCommand(yargs) {
     .options({
       delete: {
         description:
-          "Delete .fsl files in the target directory that are not part of the database schema",
+          "Delete .fsl files in the local directory that are not part of the database schema",
         type: "boolean",
         default: false,
       },
@@ -158,7 +158,7 @@ function buildPullCommand(yargs) {
       ],
       [
         "$0 schema pull --database us/example --dir /path/to/schema --delete",
-        "Delete `.fsl` files in the target directory that are not part of the pulled schema.",
+        "Delete `.fsl` files in the local directory that are not part of the pulled schema.",
       ],
     ])
     .help("help", "Show help.");

--- a/src/commands/schema/pull.mjs
+++ b/src/commands/schema/pull.mjs
@@ -123,7 +123,7 @@ async function doPull(argv) {
     // process writes and deletes together async - it'll be fastest
     await Promise.all(promises);
   } else {
-    logger.stdout("Change cancelled");
+    logger.stdout("Change cancelled.");
   }
 }
 
@@ -137,15 +137,28 @@ function buildPullCommand(yargs) {
         default: false,
       },
       active: {
-        description: "Pulls the active schema instead of the staged schema",
+        description: "Pull the database's active schema files. If omitted, pulls the database's staged schema, if available.",
         type: "boolean",
         default: false,
       },
     })
     .example([
-      ["$0 schema pull"],
-      ["$0 schema pull --active"],
-      ["$0 schema pull --delete"],
+      [
+        "$0 schema pull --database us/example --dir /path/to/schema",
+        "Pull the 'us/example' database's staged schema."
+      ],
+      [
+        "$0 schema pull ---secret my-secret --dir /path/to/schema",
+        "Pull the staged schema for the database scoped to a secret."
+      ],
+      [
+        "$0 schema pull --database us/example --dir /path/to/schema --active",
+        "Pull the 'us/example' database's active schema."
+      ],
+      [
+        "$0 schema pull --database us/example --dir /path/to/schema --delete",
+        "Delete `.fsl` files in the target directory that are not part of the pulled schema."
+      ],
     ])
     .help("help", "Show help.");
 }

--- a/src/commands/schema/push.mjs
+++ b/src/commands/schema/push.mjs
@@ -103,19 +103,19 @@ function buildPushCommand(yargs) {
     .example([
       [
         "$0 schema push --database us/example --dir /path/to/schema",
-        "Stage schema changes for the 'us/example' database. If schema is already staged, replace the staged schema."
+        "Stage schema changes for the 'us/example' database. If schema is already staged, replace the staged schema.",
       ],
       [
         "$0 schema push --secret my-secret --dir /path/to/schema",
-        "Stage schema changes for the database scoped to a secret. If schema is already staged, replace the staged schema."
+        "Stage schema changes for the database scoped to a secret. If schema is already staged, replace the staged schema.",
       ],
       [
         "$0 schema push --database us/example --dir /path/to/schema --active",
-        "Immediately apply changes to the 'us/example' database's active schema."
+        "Immediately apply changes to the 'us/example' database's active schema.",
       ],
       [
         "$0 schema push --database us/example --dir /path/to/schema --no-input",
-        "Run the command without input prompts."
+        "Run the command without input prompts.",
       ],
     ])
     .help("help", "Show help.");

--- a/src/commands/schema/push.mjs
+++ b/src/commands/schema/push.mjs
@@ -79,7 +79,7 @@ async function doPush(argv) {
         secret,
       });
     } else {
-      logger.stdout("Push cancelled");
+      logger.stdout("Push cancelled.");
     }
   }
 }
@@ -95,15 +95,28 @@ function buildPushCommand(yargs) {
       },
       active: {
         description:
-          "Immediately applies the schema change instead of staging it",
+          "Immediately apply changes to the database's active schema. Skips staging the schema. Can result in temporarily unavailable indexes.",
         type: "boolean",
         default: false,
       },
     })
     .example([
-      ["$0 schema push"],
-      ["$0 schema push --dir schemas/myschema"],
-      ["$0 schema push --active"],
+      [
+        "$0 schema push --database us/example --dir /path/to/schema",
+        "Stage schema changes for the 'us/example' database. If schema is already staged, replace the staged schema."
+      ],
+      [
+        "$0 schema push --secret my-secret --dir /path/to/schema",
+        "Stage schema changes for the database scoped to a secret. If schema is already staged, replace the staged schema."
+      ],
+      [
+        "$0 schema push --database us/example --dir /path/to/schema --active",
+        "Immediately apply changes to the 'us/example' database's active schema."
+      ],
+      [
+        "$0 schema push --database us/example --dir /path/to/schema --no-input",
+        "Run the command without input prompts."
+      ],
     ])
     .help("help", "Show help.");
 }

--- a/src/commands/schema/push.mjs
+++ b/src/commands/schema/push.mjs
@@ -95,7 +95,7 @@ function buildPushCommand(yargs) {
       },
       active: {
         description:
-          "Immediately apply changes to the database's active schema. Skips staging the schema. Can result in temporarily unavailable indexes.",
+          "Immediately apply the local schema to the database's active schema. Skips staging the schema. Can result in temporarily unavailable indexes.",
         type: "boolean",
         default: false,
       },

--- a/src/commands/schema/schema.mjs
+++ b/src/commands/schema/schema.mjs
@@ -14,7 +14,7 @@ function buildSchema(yargs) {
         alias: ["directory", "dir"],
         type: "string",
         description:
-          "The path to the project directory containing the schema files to interact with.",
+          "Path to a local directory containing `.fsl` files for the database.",
         default: ".",
       },
     })

--- a/src/commands/schema/status.mjs
+++ b/src/commands/schema/status.mjs
@@ -65,13 +65,22 @@ async function doStatus(argv) {
 
 function buildStatusCommand(yargs) {
   return yargsWithCommonQueryOptions(yargs)
-    .example([["$0 schema status"]])
+    .example([
+      [
+        "$0 schema status --database us/example",
+        "Get the staged schema status for the 'us/example' database."
+      ],
+      [
+        "$0 schema status --secret my-secret",
+        "Get the staged schema status for the database scoped to a secret."
+      ],
+    ])
     .help("help", "Show help.");
 }
 
 export default {
   command: "status",
-  description: "Print the staged schema's status.",
+  description: "Show a database's staged schema status.",
   builder: buildStatusCommand,
   handler: doStatus,
 };

--- a/src/commands/schema/status.mjs
+++ b/src/commands/schema/status.mjs
@@ -68,11 +68,11 @@ function buildStatusCommand(yargs) {
     .example([
       [
         "$0 schema status --database us/example",
-        "Get the staged schema status for the 'us/example' database."
+        "Get the staged schema status for the 'us/example' database.",
       ],
       [
         "$0 schema status --secret my-secret",
-        "Get the staged schema status for the database scoped to a secret."
+        "Get the staged schema status for the database scoped to a secret.",
       ],
     ])
     .help("help", "Show help.");

--- a/src/commands/shell.mjs
+++ b/src/commands/shell.mjs
@@ -52,7 +52,7 @@ async function shellCommand(argv) {
   [
     {
       cmd: "clear",
-      help: "Clear the repl",
+      help: "Clear the REPL",
       action: () => {
         // eslint-disable-next-line no-console
         console.clear();
@@ -61,7 +61,7 @@ async function shellCommand(argv) {
     },
     {
       cmd: "clearhistory",
-      help: "Clear command history",
+      help: "Clear the REPL session history",
       action: () => {
         try {
           clearHistoryStorage();
@@ -80,7 +80,7 @@ async function shellCommand(argv) {
     },
     {
       cmd: "lastError",
-      help: "Display the last error",
+      help: "Display the most recent error encountered in the REPL",
       action: () => {
         logger.stdout(shell.context.lastError);
         shell.prompt();
@@ -88,7 +88,7 @@ async function shellCommand(argv) {
     },
     {
       cmd: "toggleExtra",
-      help: "Toggle additional information in shell; off by default",
+      help: "Enable or disable additional output. Disabled by default. If enabled, outputs the full API response, including summary and query stats.",
       action: () => {
         shell.context.extra = !shell.context.extra;
         logger.stderr(
@@ -147,7 +147,20 @@ async function buildCustomEval(argv) {
 
 function buildShellCommand(yargs) {
   return yargsWithCommonConfigurableQueryOptions(yargs)
-    .example([["$0 shell"], ["$0 shell --database us/example --role admin"]])
+    .example([
+      [
+        "$0 shell --database us/example",
+        "Run queries in the 'us/example' database."
+      ],
+      [
+        "$0 shell --database us/example --role server",
+        "Run queries in the 'us/example' database using the 'server' role."
+      ],
+      [
+        "$0 shell --secret my-secret",
+        "Run queries in the database scoped to a secret."
+      ]
+    ])
     .version(false)
     .help("help", "Show help.");
 }

--- a/src/commands/shell.mjs
+++ b/src/commands/shell.mjs
@@ -150,16 +150,16 @@ function buildShellCommand(yargs) {
     .example([
       [
         "$0 shell --database us/example",
-        "Run queries in the 'us/example' database."
+        "Run queries in the 'us/example' database.",
       ],
       [
         "$0 shell --database us/example --role server",
-        "Run queries in the 'us/example' database using the 'server' role."
+        "Run queries in the 'us/example' database using the 'server' role.",
       ],
       [
         "$0 shell --secret my-secret",
-        "Run queries in the database scoped to a secret."
-      ]
+        "Run queries in the database scoped to a secret.",
+      ],
     ])
     .version(false)
     .help("help", "Show help.");

--- a/test/database/create.mjs
+++ b/test/database/create.mjs
@@ -50,7 +50,7 @@ describe("database create", () => {
         error: { code: "constraint_failure", message: "whatever" },
       }),
       expectedMessage:
-        "Constraint failure: The database 'testdb' may already exists or one of the provided options may be invalid.",
+        "Constraint failure: The database 'testdb' already exists or one of the provided options is invalid.",
     },
     {
       error: new ServiceError({

--- a/test/schema/abandon.mjs
+++ b/test/schema/abandon.mjs
@@ -41,7 +41,7 @@ describe("schema abandon", function () {
       buildUrl("/schema/1/staged/abandon", { force: "true" }),
       { ...commonFetchParams, method: "POST" },
     );
-    expect(logger.stdout).to.have.been.calledWith("Schema has been abandoned");
+    expect(logger.stdout).to.have.been.calledWith("Schema has been abandoned.");
     expect(logger.stdout).to.not.have.been.calledWith(diff);
     expect(logger.stderr).to.not.have.been.called;
     expect(confirm).to.not.have.been.called;
@@ -72,7 +72,7 @@ describe("schema abandon", function () {
       buildUrl("/schema/1/staged/abandon", { version: "1728677726190000" }),
       { ...commonFetchParams, method: "POST" },
     );
-    expect(logger.stdout).to.have.been.calledWith("Schema has been abandoned");
+    expect(logger.stdout).to.have.been.calledWith("Schema has been abandoned.");
     expect(logger.stdout).to.have.been.calledWith(diff);
     expect(logger.stderr).to.not.have.been.called;
     expect(confirm).to.have.been.calledWith(
@@ -89,7 +89,7 @@ describe("schema abandon", function () {
 
     expect(error).to.have.property("code", 1);
     expect(fetch).to.have.been.calledOnce;
-    const message = `${chalk.red("There is no staged schema to abandon")}`;
+    const message = `${chalk.red("There is no staged schema to abandon.")}`;
     expect(logger.stderr).to.have.been.calledWith(message);
 
     expect(fetch).to.have.been.calledWith(
@@ -120,7 +120,7 @@ describe("schema abandon", function () {
       buildUrl("/schema/1/staged/status", { diff: "true", color: "ansi" }),
       { ...commonFetchParams, method: "GET" },
     );
-    expect(logger.stdout).to.have.been.calledWith("Abandon cancelled");
+    expect(logger.stdout).to.have.been.calledWith("Abandon cancelled.");
     expect(logger.stdout).to.have.been.calledWith(diff);
     expect(logger.stderr).to.not.have.been.called;
     expect(confirm).to.have.been.calledWith(

--- a/test/schema/pull.mjs
+++ b/test/schema/pull.mjs
@@ -191,7 +191,7 @@ describe("schema pull", function () {
     expect(logger.stdout).to.have.been.calledWith(
       "Pull will make the following changes:",
     );
-    expect(logger.stdout).to.have.been.calledWith("Change cancelled");
+    expect(logger.stdout).to.have.been.calledWith("Change cancelled.");
     expect(fs.writeFile).to.have.not.been.called;
     expect(fsp.unlink).to.have.not.been.called;
     // Called twice during Credentials initialization, but not called during the pull command


### PR DESCRIPTION
## Problem

* Several commands are missing examples
* The REPL command help strings are inconsistent with our other strings.
* Some help strings are no longer aligned with our prospective docs.
* Some `database` examples use `my-database`, which isn't valid (hyphens aren't allowed).

## Solution

* Adds command examples.
* Reviews all command and REPL help strings.
