### PR TITLE
Remove 'login options' group from login cmd

### DIFF
--- a/src/commands/login.mjs
+++ b/src/commands/login.mjs
@@ -41,7 +41,6 @@ function buildLoginCommand(yargs) {
       type: "string",
       description: "User to log in as.",
       default: "default",
-      group: "Login options:",
     },
   })
     .example([


### PR DESCRIPTION
## Problem

For the `login` command, the `--user` flag should be in generic options, not the `Login options` group.

## Solution

Removes the group.
