### PR TITLE
make command descriptions more consistent

### DIFF
--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -210,5 +210,8 @@ function buildYargs(argvInput) {
     .fail(false)
     .exitProcess(false)
     .version()
-    .completion();
+    .completion(
+      "completion",
+      "Output bash/zsh script to enable shell completions. See command output for installation instructions.",
+    );
 }

--- a/src/commands/key.mjs
+++ b/src/commands/key.mjs
@@ -60,7 +60,7 @@ function keyHandler(argv) {
 
 export default {
   command: "key <method>",
-  description: "Interact with your database keys:",
+  description: "Manage a database's keys.",
   builder: buildKeyCommand,
   handler: keyHandler,
 };

--- a/src/commands/schema/pull.mjs
+++ b/src/commands/schema/pull.mjs
@@ -149,7 +149,7 @@ function buildPullCommand(yargs) {
         "Pull the 'us/example' database's staged schema.",
       ],
       [
-        "$0 schema pull ---secret my-secret --dir /path/to/schema",
+        "$0 schema pull --secret my-secret --dir /path/to/schema",
         "Pull the staged schema for the database scoped to a secret.",
       ],
       [


### PR DESCRIPTION
- change key command description to match style of schema/database commands
- customize `fauna completion` help text to match style of other commands

FE-6229, FE-6230