### PR TITLE
[FE-6183] Update Permissions on Credentials Files

### DIFF
--- a/src/lib/file-util.mjs
+++ b/src/lib/file-util.mjs
@@ -335,7 +335,7 @@ export function initHistoryStorage() {
   }
   const historyFile = path.join(historyDir, "history");
   if (!fileExists(historyFile)) {
-    fs.writeFileSync(historyFile, "");
+    fs.writeFileSync(historyFile, "", { mode: 0o600 });
   }
 
   return historyFile;
@@ -351,7 +351,7 @@ export function clearHistoryStorage() {
   const fs = container.resolve("fs");
   const homedir = container.resolve("homedir")();
   const historyFile = path.join(homedir, ".fauna/history");
-  fs.writeFileSync(historyFile, "");
+  fs.writeFileSync(historyFile, "", { mode: 0o600 });
 }
 
 /**

--- a/src/lib/file-util.mjs
+++ b/src/lib/file-util.mjs
@@ -123,7 +123,7 @@ export class CredentialsStorage {
     }
     this.filepath = `${this.credsDir}/${this.filename}`;
     if (!fileExists(this.filepath)) {
-      fs.writeFileSync(this.filepath, "{}");
+      fs.writeFileSync(this.filepath, "{}", { mode: 0o600 });
     }
   }
 


### PR DESCRIPTION
Ticket(s): FE-6183

## Problem
Credential files are readable by non-owners.

## Solution
Set them to `chmod 600` when the file is created.

## Result
Credential files are not readable by non-owners.

## Testing
<img width="557" alt="Screenshot 2024-12-05 at 5 10 15 PM" src="https://github.com/user-attachments/assets/413fee33-7870-40a3-adec-c64009c16310">

