### PR TITLE
Fast succeed login when --local arg is given

### DIFF
--- a/src/commands/login.mjs
+++ b/src/commands/login.mjs
@@ -4,8 +4,12 @@ import { container } from "../cli.mjs";
 import { yargsWithCommonOptions } from "../lib/command-helpers.mjs";
 import { FaunaAccountClient } from "../lib/fauna-account-client.mjs";
 
-async function doLogin() {
+async function doLogin(argv) {
   const logger = container.resolve("logger");
+  if (argv.local) {
+    logger.stdout(`Using a local Fauna container does not require login.\n`);
+    return;
+  }
   const open = container.resolve("open");
   const credentials = container.resolve("credentials");
   const oAuth = container.resolve("oauthClient");

--- a/test/login.mjs
+++ b/test/login.mjs
@@ -1,80 +1,25 @@
 //@ts-check
-import path from "node:path";
 
-import * as awilix from "awilix";
 import { expect } from "chai";
-import { spy, stub } from "sinon";
+import { stub } from "sinon";
 
 import { run } from "../src/cli.mjs";
 import { setupTestContainer as setupContainer } from "../src/config/setup-test-container.mjs";
 
-describe.skip("login", function () {
+describe("login", function () {
   let container;
   let fs;
   const sessionCreds = {
     accountKey: "account-key",
     refreshToken: "refresh-token",
   };
-  const mockOAuth = () => {
-    let handlers = {};
-
-    return {
-      _receiveAuthCode: spy(async () => {
-        await handlers.auth_code_received();
-      }),
-      start: spy(async () => {
-        await handlers.ready();
-      }),
-      getOAuthParams: () => {
-        return {
-          client_id: "client-id",
-          redirect_uri: "redirect-uri",
-          code_challenge: "challenge",
-          code_challenge_method: "S256",
-          response_type: "code",
-          scope: "create_session",
-          state: "state",
-        };
-      },
-      getTokenParams: () => {
-        return {
-          clientId: "client-id",
-          clientSecret: "client-secret",
-          authCode: "auth-code",
-          redirectURI: "redirect-uri",
-          codeVerifier: "code-verifier",
-        };
-      },
-      server: {
-        on: (eventName, handler) => {
-          handlers[eventName] = handler;
-        },
-      },
-    };
-  };
-  const mockAccountClient = () => {
-    return {
-      startOAuthRequest: stub().resolves("dashboard-url"),
-      listDatabases: stub().resolves("test databases"),
-      getSession: stub().resolves(sessionCreds),
-      getToken: stub().resolves({ accessToken: "access-token" }),
-    };
-  };
 
   beforeEach(() => {
-    const __dirname = import.meta.dirname;
-    const homedir = path.join(__dirname, "./test-homedir");
-
     container = setupContainer();
-    container.register({
-      oauthClient: awilix.asFunction(mockOAuth).scoped(),
-      AccountClient: awilix.asValue(mockAccountClient),
-      homedir: awilix.asFunction(() => homedir).scoped(),
-    });
     fs = container.resolve("fs");
   });
 
-  it("can login", async function () {
+  it.skip("can login", async function () {
     // Run the command first so container is set.
     await run(`login`, container);
     // After container is set, we can get the mocks
@@ -111,7 +56,7 @@ describe.skip("login", function () {
     );
   });
 
-  it("overwrites credentials on login", async function () {
+  it.skip("overwrites credentials on login", async function () {
     const existingCreds = {
       testProfile: {
         accountKey: "oldkey",
@@ -137,6 +82,14 @@ describe.skip("login", function () {
     // We save the session credentials and overwrite the profile of the same name locally
     expect(JSON.parse(fs.writeFileSync.args[0][1])).to.deep.equal(
       expectedCreds,
+    );
+  });
+
+  it("fast completes when using --local", async function () {
+    await run(`login --local`, container);
+    const logger = container.resolve("logger");
+    expect(logger.stdout).to.have.been.calledWith(
+      "Using a local Fauna container does not require login.\n",
     );
   });
 });


### PR DESCRIPTION

## Problem

There's no need to try to do any login when running against a local.

## Solution

Fast succeed.

## Testing
Ran the tests and the command:


![Screenshot 2024-12-06 at 3 53 07 PM](https://github.com/user-attachments/assets/90096195-8e59-4c2b-9143-aff6979e4a6c)
