### PR TITLE
Handle No Local Schema Files

### DIFF
--- a/src/commands/schema/status.mjs
+++ b/src/commands/schema/status.mjs
@@ -19,11 +19,11 @@ async function doStatus(argv) {
   const secret = await getSecret();
   const absoluteDirPath = path.resolve(argv.dir);
   const gatherFSL = container.resolve("gatherFSL");
-  const fsl = reformatFSL(await gatherFSL(argv.dir));
+  const fslFiles = await gatherFSL(argv.dir);
+  const hasLocalSchema = fslFiles.length > 0;
+  const fsl = reformatFSL(fslFiles);
 
-  const hasLocalSchema = fsl.entries().next().done === false;
-
-  const statusParams = new URLSearchParams({ diff: "summary" });
+  const statusParams = new URLSearchParams({ format: "summary" });
   const statusResponse = await makeFaunaRequest({
     argv,
     path: "/schema/1/staged/status",
@@ -35,8 +35,8 @@ async function doStatus(argv) {
   let diffResponse = null;
   if (hasLocalSchema) {
     const diffParams = new URLSearchParams({
-      diff: "summary",
       staged: "true",
+      format: "summary",
       version: statusResponse.version,
     });
     diffResponse = await makeFaunaRequest({

--- a/src/commands/schema/status.mjs
+++ b/src/commands/schema/status.mjs
@@ -21,11 +21,6 @@ async function doStatus(argv) {
   const gatherFSL = container.resolve("gatherFSL");
   const fsl = reformatFSL(await gatherFSL(argv.dir));
 
-  // let hasLocalSchema = false;
-  // for (let _ of fsl.entries()) {
-  //   hasLocalSchema = true;
-  //   break;
-  // }
   const hasLocalSchema = fsl.entries().next().done === false;
 
   const statusParams = new URLSearchParams({ diff: "summary" });

--- a/src/commands/schema/status.mjs
+++ b/src/commands/schema/status.mjs
@@ -49,6 +49,7 @@ async function doStatus(argv) {
     });
   }
 
+  // Output the status response
   logger.stdout(`Staged changes: ${chalk.bold(statusResponse.status)}`);
   if (statusResponse.pending_summary !== "") {
     logger.stdout(statusResponse.pending_summary);
@@ -58,21 +59,27 @@ async function doStatus(argv) {
     logger.stdout(statusResponse.diff.split("\n").join("\n  "));
   }
 
+  // Output the diff response
   if (!hasLocalSchema) {
     logger.stdout(
       `Local changes: ${chalk.bold(`no schema files found in '${absoluteDirPath}'`)}\n`,
     );
-  } else if (diffResponse.error) {
-    logger.stdout(`Local changes:`);
-    throw new CommandError(diffResponse.error.message);
-  } else if (diffResponse.diff === "") {
-    logger.stdout(`Local changes: ${chalk.bold("none")}\n`);
-  } else {
-    logger.stdout(`Local changes:\n`);
-    logger.stdout(`  ${diffResponse.diff.split("\n").join("\n  ")}`);
-    logger.stdout("(use `fauna schema diff` to display local changes)");
-    logger.stdout("(use `fauna schema push` to stage local changes)");
+    return;
   }
+
+  if (diffResponse.error) {
+    throw new CommandError(diffResponse.error.message);
+  }
+
+  if (diffResponse.diff === "") {
+    logger.stdout(`Local changes: ${chalk.bold("none")}\n`);
+    return;
+  }
+
+  logger.stdout(`Local changes:\n`);
+  logger.stdout(`  ${diffResponse.diff.split("\n").join("\n  ")}`);
+  logger.stdout("(use `fauna schema diff` to display local changes)");
+  logger.stdout("(use `fauna schema push` to stage local changes)");
 }
 
 function buildStatusCommand(yargs) {

--- a/test/schema/status.mjs
+++ b/test/schema/status.mjs
@@ -86,7 +86,6 @@ describe("schema status", function () {
         status: "none",
         diff: "Staged schema: none",
         pending_summary: "",
-        text_diff: "",
       }),
     );
     fetch.onCall(1).resolves(

--- a/test/schema/status.mjs
+++ b/test/schema/status.mjs
@@ -99,12 +99,12 @@ describe("schema status", function () {
     await run(`schema status --secret "secret"`, container);
 
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/staged/status", { diff: "summary", color: "ansi" }),
+      buildUrl("/schema/1/staged/status", { format: "summary", color: "ansi" }),
       commonFetchParams,
     );
     expect(fetch).not.to.have.been.calledWith(
       buildUrl("/schema/1/validate", {
-        diff: "summary",
+        format: "summary",
         staged: "true",
         version: "0",
         color: "ansi",
@@ -140,12 +140,12 @@ describe("schema status", function () {
     await run(`schema status --secret "secret"`, container);
 
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/staged/status", { diff: "summary", color: "ansi" }),
+      buildUrl("/schema/1/staged/status", { format: "summary", color: "ansi" }),
       commonFetchParams,
     );
     expect(fetch).to.have.been.calledWith(
       buildUrl("/schema/1/diff", {
-        diff: "summary",
+        format: "summary",
         staged: "true",
         version: "0",
         color: "ansi",
@@ -184,12 +184,12 @@ describe("schema status", function () {
     await run(`schema status --secret "secret"`, container);
 
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/staged/status", { diff: "summary", color: "ansi" }),
+      buildUrl("/schema/1/staged/status", { format: "summary", color: "ansi" }),
       commonFetchParams,
     );
     expect(fetch).to.have.been.calledWith(
       buildUrl("/schema/1/diff", {
-        diff: "summary",
+        format: "summary",
         staged: "true",
         version: "0",
         color: "ansi",
@@ -233,13 +233,13 @@ describe("schema status", function () {
     await run(`schema status --secret "secret"`, container);
 
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/staged/status", { diff: "summary", color: "ansi" }),
+      buildUrl("/schema/1/staged/status", { format: "summary", color: "ansi" }),
       commonFetchParams,
     );
 
     expect(fetch).to.have.been.calledWith(
       buildUrl("/schema/1/diff", {
-        diff: "summary",
+        format: "summary",
         staged: "true",
         version: "0",
         color: "ansi",
@@ -281,12 +281,12 @@ describe("schema status", function () {
     await run(`schema status --secret "secret"`, container);
 
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/staged/status", { diff: "summary", color: "ansi" }),
+      buildUrl("/schema/1/staged/status", { format: "summary", color: "ansi" }),
       commonFetchParams,
     );
     expect(fetch).to.have.been.calledWith(
       buildUrl("/schema/1/diff", {
-        diff: "summary",
+        format: "summary",
         staged: "true",
         version: "0",
         color: "ansi",
@@ -325,7 +325,7 @@ describe("schema status", function () {
     await run(`schema status --no-color --secret "secret"`, container);
 
     expect(fetch).to.have.been.calledWith(
-      buildUrl("/schema/1/staged/status", { diff: "summary" }),
+      buildUrl("/schema/1/staged/status", { format: "summary" }),
       commonFetchParams,
     );
     expect(logger.stderr).not.to.have.been.called;


### PR DESCRIPTION
Ticket(s): FE-6217

## Problem
When no local schema files are found `schema status` tells the user that everything will be removed.

## Solution
Detect if no files were found and output a message to that effect instead.

## Result
Users will know that they have specified the wrong schema directory.

<img width="821" alt="Screenshot 2024-12-10 at 4 57 12 PM" src="https://github.com/user-attachments/assets/4b5e0414-cd6c-466f-9be2-d0948c75d517">

## Testing
Updated & added tests.
