### PR TITLE
Handle Invalid Database Names

### DIFF
--- a/test/database/create.mjs
+++ b/test/database/create.mjs
@@ -54,6 +54,22 @@ describe("database create", () => {
     },
     {
       error: new ServiceError({
+        error: {
+          code: "constraint_failure",
+          message: "whatever",
+          constraint_failures: [
+            {
+              paths: [["name"]],
+              message: "Invalid identifier.",
+            },
+          ],
+        },
+      }),
+      expectedMessage:
+        "Constraint failure: The database name 'testdb' is invalid. Database names must begin with letters and include only letters, numbers, and underscores.",
+    },
+    {
+      error: new ServiceError({
         error: { code: "unauthorized", message: "whatever" },
       }),
       expectedMessage:


### PR DESCRIPTION
Ticket(s): FE-6209

## Problem
When trying to create a database with an invalid name, such as `db-test`, we return a vague error message that doesn't really tell the user what the actual problem is.

## Solution
Handle this error case explicitly and give the user a more actionable error message.

## Result
We clearly state when an invalid database name is provided.

## Testing
Added a test case.
