### PR TITLE
Detect if port for local Fauna is already occupied. Allow users to control hostIp.

### DIFF
--- a/src/commands/local.mjs
+++ b/src/commands/local.mjs
@@ -1,4 +1,5 @@
 import { ensureContainerRunning } from "../lib/docker-containers.mjs";
+//import { CommandError } from "../lib/errors.mjs";
 
 /**
  * Starts the local Fauna container
@@ -13,6 +14,8 @@ async function startLocal(argv) {
     hostPort: argv.hostPort,
     containerPort: argv.containerPort,
     pull: argv.pull,
+    interval: argv.interval,
+    maxAttempts: argv.maxAttempts,
   });
 }
 
@@ -26,13 +29,25 @@ function buildLocalCommand(yargs) {
     containerPort: {
       describe: "The port inside the container Fauna listens on.",
       type: "number",
-      default: "8443",
+      default: 8443,
     },
     hostPort: {
       describe:
         "The port on the host machine mapped to the container's port. This is the port you'll connect to Fauna on.",
       type: "number",
-      default: "8443",
+      default: 8443,
+    },
+    interval: {
+      describe:
+        "The interval (in milliseconds) between health check attempts. Determines how often the CLI checks if the Fauna container is ready.",
+      type: "number",
+      default: 10000,
+    },
+    maxAttempts: {
+      describe:
+        "The maximum number of health check attempts before declaring the start Fauna continer process as failed.",
+      type: "number",
+      default: 100,
     },
     name: {
       describe: "The name to give the container",

--- a/src/commands/local.mjs
+++ b/src/commands/local.mjs
@@ -1,5 +1,5 @@
 import { ensureContainerRunning } from "../lib/docker-containers.mjs";
-//import { CommandError } from "../lib/errors.mjs";
+import { CommandError } from "../lib/errors.mjs";
 
 /**
  * Starts the local Fauna container
@@ -25,41 +25,51 @@ async function startLocal(argv) {
  * @returns {import('yargs').Argv} The yargs instance
  */
 function buildLocalCommand(yargs) {
-  return yargs.options({
-    containerPort: {
-      describe: "The port inside the container Fauna listens on.",
-      type: "number",
-      default: 8443,
-    },
-    hostPort: {
-      describe:
+  return yargs
+    .options({
+      containerPort: {
+        describe: "The port inside the container Fauna listens on.",
+        type: "number",
+        default: 8443,
+      },
+      hostPort: {
+        describe:
         "The port on the host machine mapped to the container's port. This is the port you'll connect to Fauna on.",
-      type: "number",
-      default: 8443,
-    },
-    interval: {
-      describe:
+        type: "number",
+        default: 8443,
+      },
+      interval: {
+        describe:
         "The interval (in milliseconds) between health check attempts. Determines how often the CLI checks if the Fauna container is ready.",
-      type: "number",
-      default: 10000,
-    },
-    maxAttempts: {
-      describe:
+        type: "number",
+        default: 10000,
+      },
+      maxAttempts: {
+        describe:
         "The maximum number of health check attempts before declaring the start Fauna continer process as failed.",
-      type: "number",
-      default: 100,
-    },
-    name: {
-      describe: "The name to give the container",
-      type: "string",
-      default: "faunadb",
-    },
-    pull: {
-      describe: "Pull the latest image before starting the container.",
-      type: "boolean",
-      default: true,
-    },
-  });
+        type: "number",
+        default: 100,
+      },
+      name: {
+        describe: "The name to give the container",
+        type: "string",
+        default: "faunadb",
+      },
+      pull: {
+        describe: "Pull the latest image before starting the container.",
+        type: "boolean",
+        default: true,
+      },
+    })
+    .check((argv) => {
+      if (argv.maxAttempts < 1) {
+        throw new CommandError("--maxAttempts must be greater than 0.", { hideHelp: false });
+      }
+      if (argv.interval < 0) {
+        throw new CommandError("--interval must be greater than or equal to 0.", { hideHelp: false });
+      }
+      return true;
+    });
 }
 
 export default {

--- a/src/commands/local.mjs
+++ b/src/commands/local.mjs
@@ -11,6 +11,7 @@ async function startLocal(argv) {
   await ensureContainerRunning({
     imageName: argv.image,
     containerName: argv.name,
+    hostIp: argv.hostIp,
     hostPort: argv.hostPort,
     containerPort: argv.containerPort,
     pull: argv.pull,
@@ -37,6 +38,11 @@ function buildLocalCommand(yargs) {
           "The port on the host machine mapped to the container's port. This is the port you'll connect to Fauna on.",
         type: "number",
         default: 8443,
+      },
+      hostIp: {
+        describe: `The IP address to bind the container's exposed port on the host.`,
+        type: "string",
+        default: "0.0.0.0",
       },
       interval: {
         describe:

--- a/src/commands/local.mjs
+++ b/src/commands/local.mjs
@@ -34,19 +34,19 @@ function buildLocalCommand(yargs) {
       },
       hostPort: {
         describe:
-        "The port on the host machine mapped to the container's port. This is the port you'll connect to Fauna on.",
+          "The port on the host machine mapped to the container's port. This is the port you'll connect to Fauna on.",
         type: "number",
         default: 8443,
       },
       interval: {
         describe:
-        "The interval (in milliseconds) between health check attempts. Determines how often the CLI checks if the Fauna container is ready.",
+          "The interval (in milliseconds) between health check attempts. Determines how often the CLI checks if the Fauna container is ready.",
         type: "number",
         default: 10000,
       },
       maxAttempts: {
         describe:
-        "The maximum number of health check attempts before declaring the start Fauna continer process as failed.",
+          "The maximum number of health check attempts before declaring the start Fauna continer process as failed.",
         type: "number",
         default: 100,
       },
@@ -63,10 +63,15 @@ function buildLocalCommand(yargs) {
     })
     .check((argv) => {
       if (argv.maxAttempts < 1) {
-        throw new CommandError("--maxAttempts must be greater than 0.", { hideHelp: false });
+        throw new CommandError("--maxAttempts must be greater than 0.", {
+          hideHelp: false,
+        });
       }
       if (argv.interval < 0) {
-        throw new CommandError("--interval must be greater than or equal to 0.", { hideHelp: false });
+        throw new CommandError(
+          "--interval must be greater than or equal to 0.",
+          { hideHelp: false },
+        );
       }
       return true;
     });

--- a/src/config/setup-container.mjs
+++ b/src/config/setup-container.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import * as fsp from "node:fs/promises";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { exit } from "node:process";
@@ -60,6 +61,7 @@ export const injectables = {
   fetch: awilix.asValue(fetchWrapper),
   fs: awilix.asValue(fs),
   fsp: awilix.asValue(fsp),
+  net: awilix.asValue(net),
   dirname: awilix.asValue(path.dirname),
   normalize: awilix.asValue(path.normalize),
   homedir: awilix.asValue(os.homedir),

--- a/src/config/setup-test-container.mjs
+++ b/src/config/setup-test-container.mjs
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import net from "node:net";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 
@@ -43,6 +44,7 @@ export function setupTestContainer() {
 
   const thingsToManuallyMock = automock(container);
   const customfs = stub({ ...fs });
+  const customNet = stub({ ...net });
   // this is a mock used by the default profile behavior
   customfs.readdirSync.withArgs(process.cwd()).returns([]);
 
@@ -58,6 +60,7 @@ export function setupTestContainer() {
     // real implementation
     parseYargs: awilix.asValue(spy(parseYargs)),
     fs: awilix.asValue(customfs),
+    net: awilix.asValue(customNet),
     homedir: awilix.asValue(
       stub().returns(path.join(__dirname, "../../test/test-homedir")),
     ),

--- a/src/lib/docker-containers.mjs
+++ b/src/lib/docker-containers.mjs
@@ -1,5 +1,5 @@
 import { container } from "../cli.mjs";
-import { CommandError } from "./errors.mjs";
+import { CommandError, SUPPORT_MESSAGE } from "./errors.mjs";
 
 const IMAGE_NAME = "fauna/faunadb:latest";
 
@@ -91,10 +91,7 @@ async function pullImage(imageName) {
       );
     });
   } catch (error) {
-    logger.stderr(
-      `[PullImage] Error pulling image ${imageName}: ${error.message}`,
-    );
-    throw error;
+    throw new CommandError(`[PullImage] Failed to pull image '${imageName}': ${error.message}. ${SUPPORT_MESSAGE}`, { cause: error });
   }
 }
 

--- a/src/lib/docker-containers.mjs
+++ b/src/lib/docker-containers.mjs
@@ -161,8 +161,9 @@ arguments --name <newName> --hostPort ${hostPort} to start the container.`,
 
 /**
  * Checks if a port is occupied.
- * @param {number} hostPort The port to check
- * @param {string} hostIp The IP address to bind the container's exposed port on the host.
+ * @param {Object} options The options object
+ * @param {number} options.hostPort The port to check
+ * @param {string} options.hostIp The IP address to bind the container's exposed port on the host.
  * @returns {Promise<boolean>} a promise that resolves to true if the port is occupied, false otherwise.
  */
 async function isPortOccupied({ hostPort, hostIp }) {
@@ -236,11 +237,12 @@ Please pass a --hostPort other than '${hostPort}'.`,
 
 /**
  * Starts a container and returns a log stream if the container is not yet running.
- * @param {string} imageName The name of the image to create the container from
- * @param {string} containerName The name of the container to start
- * @param {string} hostIp The IP address to bind the container's exposed port on the host.
- * @param {number} hostPort The port on the host machine mapped to the container's port
- * @param {number} containerPort The port inside the container Fauna listens on
+ * @param {Object} options The options object
+ * @param {string} options.imageName The name of the image to create the container from
+ * @param {string} options.containerName The name of the container to start
+ * @param {string} options.hostIp The IP address to bind the container's exposed port on the host.
+ * @param {number} options.hostPort The port on the host machine mapped to the container's port
+ * @param {number} options.containerPort The port inside the container Fauna listens on
  * @returns {Promise<Object>} The log stream
  */
 async function startContainer({

--- a/src/lib/docker-containers.mjs
+++ b/src/lib/docker-containers.mjs
@@ -91,7 +91,10 @@ async function pullImage(imageName) {
       );
     });
   } catch (error) {
-    throw new CommandError(`[PullImage] Failed to pull image '${imageName}': ${error.message}. ${SUPPORT_MESSAGE}`, { cause: error });
+    throw new CommandError(
+      `[PullImage] Failed to pull image '${imageName}': ${error.message}. ${SUPPORT_MESSAGE}`,
+      { cause: error },
+    );
   }
 }
 

--- a/src/lib/docker-containers.mjs
+++ b/src/lib/docker-containers.mjs
@@ -188,9 +188,10 @@ async function createContainer({
   containerPort,
 }) {
   const docker = container.resolve("docker");
-  if (await isPortOccupied({ hostIp, hostPort })) {
+  const occupied = await isPortOccupied({ hostIp, hostPort });
+  if (occupied) {
     throw new CommandError(
-      `The hostPort '${hostPort}' on IP '${hostIp}' is already occupied. \
+      `[StartContainer] The hostPort '${hostPort}' on IP '${hostIp}' is already occupied. \
 Please pass a --hostPort other than '${hostPort}'.`,
       { hideHelp: false },
     );

--- a/src/lib/docker-containers.mjs
+++ b/src/lib/docker-containers.mjs
@@ -10,6 +10,9 @@ const IMAGE_NAME = "fauna/faunadb:latest";
  * @param {number} hostPort The port on the host machine mapped to the container's port
  * @param {number} containerPort The port inside the container Fauna listens on
  * @param {boolean} pull Whether to pull the latest image
+ * @param {number | undefined} interval The interval (in milliseconds) between health check attempts.
+ * @param {number | undefined} maxAttempts The maximum number of health check attempts before
+ * declaring the start Fauna continer process as failed.
  * @returns {Promise<void>}
  */
 export async function ensureContainerRunning({
@@ -17,6 +20,8 @@ export async function ensureContainerRunning({
   hostPort,
   containerPort,
   pull,
+  interval,
+  maxAttempts,
 }) {
   const logger = container.resolve("logger");
   if (pull) {
@@ -34,6 +39,8 @@ export async function ensureContainerRunning({
   await waitForHealthCheck({
     url: `http://localhost:${hostPort}`,
     logStream,
+    interval,
+    maxAttempts,
   });
   logger.stderr(
     `[ContainerReady] Container '${containerName}' is up and healthy.`,
@@ -155,7 +162,7 @@ async function createContainer({
     name: containerName,
     HostConfig: {
       PortBindings: {
-        [`${containerPort}/tcp`]: [{ HostPort: hostPort }],
+        [`${containerPort}/tcp`]: [{ HostPort: `${hostPort}` }],
       },
       AutoRemove: true,
     },
@@ -274,7 +281,7 @@ async function createLogStream({ dockerContainer, containerName }) {
  * Waits for the container to be ready
  * @param {string} url The url to check
  * @param {number} maxAttempts The maximum number of attempts to check
- * @param {number} delay The delay between attempts in milliseconds
+ * @param {number} interval The interval between attempts in milliseconds
  * @param {Object} logStream The log stream to destroy when the container is ready
  * @returns {Promise<void>} a promise that resolves when the container is ready.
  * It will reject if the container is not ready after the maximum number of attempts.
@@ -282,7 +289,7 @@ async function createLogStream({ dockerContainer, containerName }) {
 async function waitForHealthCheck({
   url,
   maxAttempts = 100,
-  delay = 10000,
+  interval = 10000,
   logStream,
 }) {
   const logger = container.resolve("logger");
@@ -290,7 +297,7 @@ async function waitForHealthCheck({
   logger.stderr(`[HealthCheck] Waiting for Fauna to be ready at ${url}...`);
 
   let attemptCounter = 0;
-
+  let errorMessage = "";
   while (attemptCounter < maxAttempts) {
     try {
       /* eslint-disable-next-line no-await-in-loop */
@@ -303,23 +310,24 @@ async function waitForHealthCheck({
         logStream?.destroy();
         return;
       }
-    } catch (error) {
-      logger.stderr(
-        `[HealthCheck] Fauna is not yet ready. Attempt ${attemptCounter + 1}/${maxAttempts} failed: ${error.message}. Retrying in ${delay / 1000} seconds...`,
-      );
+      errorMessage = `with HTTP status: '${response.status}'`;
+    } catch (e) {
+      errorMessage = `with error: ${e.message}`;
     }
-
+    logger.stderr(
+      `[HealthCheck] Fauna is not yet ready. Attempt ${attemptCounter + 1}/${maxAttempts} failed ${errorMessage}. Retrying in ${interval / 1000} seconds...`,
+    );
     attemptCounter++;
     /* eslint-disable-next-line no-await-in-loop */
     await new Promise((resolve) => {
-      setTimeout(resolve, delay);
+      setTimeout(resolve, interval);
     });
   }
 
   logger.stderr(
     `[HealthCheck] Max attempts reached. Service at ${url} did not respond.`,
   );
-  throw new Error(
-    `[HealthCheck] Fauna at ${url} is not ready after ${maxAttempts} attempts.`,
+  throw new CommandError(
+    `[HealthCheck] Fauna at ${url} is not ready after ${maxAttempts} attempts. Consider increasing --interval or --maxAttempts.`,
   );
 }

--- a/src/lib/errors.mjs
+++ b/src/lib/errors.mjs
@@ -4,8 +4,10 @@ import util from "util";
 
 import { container } from "../cli.mjs";
 
-const BUG_REPORT_MESSAGE = "If you believe this is a bug, please report this issue on GitHub: https://github.com/fauna/fauna-shell/issues";
-export const SUPPORT_MESSAGE = "If this issue persists contact support: https://support.fauna.com/hc/en-us/requests/new";
+const BUG_REPORT_MESSAGE =
+  "If you believe this is a bug, please report this issue on GitHub: https://github.com/fauna/fauna-shell/issues";
+export const SUPPORT_MESSAGE =
+  "If this issue persists contact support: https://support.fauna.com/hc/en-us/requests/new";
 
 /*
  * These are the error message prefixes that yargs throws during

--- a/src/lib/errors.mjs
+++ b/src/lib/errors.mjs
@@ -4,7 +4,8 @@ import util from "util";
 
 import { container } from "../cli.mjs";
 
-const BUG_REPORT_MESSAGE = `If you believe this is a bug, please report this issue on GitHub: https://github.com/fauna/fauna-shell/issues`;
+const BUG_REPORT_MESSAGE = "If you believe this is a bug, please report this issue on GitHub: https://github.com/fauna/fauna-shell/issues";
+export const SUPPORT_MESSAGE = "If this issue persists contact support: https://support.fauna.com/hc/en-us/requests/new";
 
 /*
  * These are the error message prefixes that yargs throws during
@@ -112,6 +113,8 @@ export const handleParseYargsError = async (
       logger.debug(`unknown error thrown: ${e.name}`, "error");
       logger.debug(util.inspect(e, true, 2, false), "error");
     } else {
+      logger.debug(`known error thrown: ${e.name}`, "error");
+      logger.debug(util.inspect(e, true, 2, false), "error");
       // Otherwise, just use the error message
       subMessage = hasAnsi(e.message) ? e.message : chalk.red(e.message);
     }

--- a/test/local.mjs
+++ b/test/local.mjs
@@ -7,7 +7,7 @@ import { run } from "../src/cli.mjs";
 import { setupTestContainer } from "../src/config/setup-test-container.mjs";
 import { f } from "./helpers.mjs";
 
-describe.only("ensureContainerRunning", () => {
+describe("ensureContainerRunning", () => {
   let container,
     fetch,
     logger,

--- a/test/local.mjs
+++ b/test/local.mjs
@@ -134,7 +134,7 @@ describe.only("ensureContainerRunning", () => {
     expect(written).not.to.contain("An unexpected");
   });
 
-  it.skip("throws an error if interval is less than 0", async () => {
+  it("throws an error if interval is less than 0", async () => {
     try {
       await run("local --interval -1", container);
       throw new Error("Expected an error to be thrown.");
@@ -147,7 +147,7 @@ describe.only("ensureContainerRunning", () => {
     expect(written).not.to.contain("An unexpected");
   });
 
-  it.skip("throws an error if maxAttempts is less than 1", async () => {
+  it("throws an error if maxAttempts is less than 1", async () => {
     try {
       await run("local --maxAttempts 0", container);
       throw new Error("Expected an error to be thrown.");


### PR DESCRIPTION
Ticket(s): FE-5990

## Problem

- If the hostPort is already occupied by a process that is not the desired container with the desired name we should show a clear error.
- users might want to control the hostIp
- health check not tested
- If a container with the desired name already exists but is on a different port show an error.

## Solution

- Detect when hostPort already occupied and show a clear error.
- Allow tweak of hostIp
- test health check

## Testing

Ran all the tests
