### PR TITLE
Clarify `--raw` flag help

### DIFF
--- a/src/commands/query.mjs
+++ b/src/commands/query.mjs
@@ -166,7 +166,7 @@ function buildQueryCommand(yargs) {
       raw: {
         type: "boolean",
         description:
-          "Output the full API response, including summary and query stats.",
+          "Output the raw JSON query response, including summary and query stats.",
         default: false,
       },
     })

--- a/src/commands/shell.mjs
+++ b/src/commands/shell.mjs
@@ -104,7 +104,7 @@ async function shellCommand(argv) {
     },
     {
       cmd: "toggleRawResponses",
-      help: "Enable or disable additional output. Disabled by default. If enabled, outputs the full API response, including summary and query stats.",
+      help: "Enable or disable additional output. Disabled by default. If enabled, outputs the raw JSON query response, including summary and query stats.",
       action: () => {
         shell.context.raw = !shell.context.raw;
         logger.stderr(


### PR DESCRIPTION
Ticket(s): [FE-6234](https://faunadb.atlassian.net/browse/FE-6234)

## Problem

The current `--raw` and `.toggleRawResponses` help text mentions the API response. This is misleading as the response actually comes from the JS driver.

## Solution

Rewords the text to avoid mentioning "full API response". 

## Result

Meh...? We could mention the JS driver here, but I think that gets very implementation-detail-y. This is mostly helpful for folks looking for query stats.

## Testing

N/A


[FE-6234]: https://faunadb.atlassian.net/browse/FE-6234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ