### PR TITLE
Handle network errors with better messaging

### DIFF
--- a/src/commands/schema/push.mjs
+++ b/src/commands/schema/push.mjs
@@ -3,8 +3,8 @@
 import path from "path";
 
 import { container } from "../../cli.mjs";
-import { ValidationError } from "../../lib/errors.mjs";
 import { yargsWithCommonQueryOptions } from "../../lib/command-helpers.mjs";
+import { ValidationError } from "../../lib/errors.mjs";
 import { getSecret } from "../../lib/fauna-client.mjs";
 import { reformatFSL } from "../../lib/schema.mjs";
 import { localSchemaOptions } from "./schema.mjs";

--- a/src/lib/errors.mjs
+++ b/src/lib/errors.mjs
@@ -6,6 +6,11 @@ import { container } from "../cli.mjs";
 
 const BUG_REPORT_MESSAGE = `If you believe this is a bug, please report this issue on GitHub: https://github.com/fauna/fauna-shell/issues`;
 
+// This error message is used in a few places where we handle network errors.
+export const NETWORK_ERROR_MESSAGE =
+  "Unable to connect to Fauna due to a network error. If you're using --local, " +
+  "make sure your local docker container is currently running with this command: fauna local";
+
 /*
  * These are the error message prefixes that yargs throws during
  * validation. To detect these errors, you can either parse the stack

--- a/src/lib/errors.mjs
+++ b/src/lib/errors.mjs
@@ -8,8 +8,8 @@ const BUG_REPORT_MESSAGE = `If you believe this is a bug, please report this iss
 
 // This error message is used in a few places where we handle network errors.
 export const NETWORK_ERROR_MESSAGE =
-  "Unable to connect to Fauna due to a network error. If you're using --local, " +
-  "make sure your local docker container is currently running with this command: fauna local";
+  "Unable to connect to Fauna due to a network error. If using --local, " +
+  "ensure your container is running with this command: fauna local";
 
 /*
  * These are the error message prefixes that yargs throws during

--- a/src/lib/fauna.mjs
+++ b/src/lib/fauna.mjs
@@ -13,7 +13,7 @@ import {
 } from "fauna";
 
 import { container } from "../cli.mjs";
-import { ValidationError } from "./errors.mjs";
+import { NETWORK_ERROR_MESSAGE, ValidationError } from "./errors.mjs";
 import { formatQuerySummary } from "./fauna-client.mjs";
 import { colorize, Format } from "./formatting/colorize.mjs";
 
@@ -147,6 +147,10 @@ export const formatError = (err, opts = {}) => {
     // Otherwise, return the summary and fall back to the message.
     return `${chalk.red("The query failed with the following error:")}\n\n${formatQuerySummary(err.queryInfo?.summary) ?? err.message}`;
   } else {
+    if (err.name === "NetworkError") {
+      return `The query failed unexpectedly with the following error:\n\n${NETWORK_ERROR_MESSAGE}`;
+    }
+
     return `The query failed unexpectedly with the following error:\n\n${err.message}`;
   }
 };

--- a/test/schema/schema.mjs
+++ b/test/schema/schema.mjs
@@ -5,12 +5,14 @@ import chalk from "chalk";
 
 import { builtYargs, run } from "../../src/cli.mjs";
 import { setupTestContainer as setupContainer } from "../../src/config/setup-test-container.mjs";
+import { NETWORK_ERROR_MESSAGE } from "../../src/lib/errors.mjs";
 
 describe("schema", function () {
-  let container, logger;
+  let container, logger, stderr;
   beforeEach(() => {
     container = setupContainer();
     logger = container.resolve("logger");
+    stderr = container.resolve("stderrStream");
   });
 
   [
@@ -30,6 +32,22 @@ describe("schema", function () {
         `${chalk.reset(await builtYargs.getHelp())}\n\n${chalk.red("No database or secret specified. Please use either --database, --secret, or --local to connect to your desired Fauna database.")}`,
       );
       expect(container.resolve("parseYargs")).to.have.been.calledOnce;
+    });
+
+    it("can handle network errors", async function () {
+      // Schema push requires fsl locally...we need to accommodate for that, but for now, we'll just skip it
+      if (command === "schema push") {
+        return;
+      }
+      container.resolve("fetch").rejects(new TypeError("fetch failed"));
+
+      try {
+        await run(`${command} --secret=test-secret --dir=test-dir`, container);
+      } catch (e) {}
+
+      await stderr.waitForWritten();
+
+      expect(stderr.getWritten()).to.contain(NETWORK_ERROR_MESSAGE);
     });
   });
 });


### PR DESCRIPTION
## Problem

When a network error occurs in the v10 driver, we get a "The network encountered a problem" message. If fetch fails, you get a "fetch failed". Neither of these are helpful.

## Solution

Catch them with slightly better messaging and centralize the messaging so we are consistent in the places we need to handle these errors. Given the most likely cause of a network error is `--local`, add a blurb about that too.

All commands are covered by this messaging, but may display them differently depending on their error handling.

## Result

![Screenshot 2024-12-12 at 11 17 57 AM](https://github.com/user-attachments/assets/2e5c8daf-03b7-4645-90a8-0d413d37bf3c)

## Testing

Unit tests.
