### PR TITLE
Optionally, create a db when starting a local container

### DIFF
--- a/src/commands/database/create.mjs
+++ b/src/commands/database/create.mjs
@@ -21,6 +21,7 @@ async function runCreateQuery(secret, argv) {
         typechecked: ${argv.typechecked ?? null},
         priority: ${argv.priority ?? null},
       })`,
+    options: { format: "decorated" },
   });
 }
 

--- a/src/commands/database/create.mjs
+++ b/src/commands/database/create.mjs
@@ -21,7 +21,6 @@ async function runCreateQuery(secret, argv) {
         typechecked: ${argv.typechecked ?? null},
         priority: ${argv.priority ?? null},
       })`,
-    options: { format: "decorated" },
   });
 }
 

--- a/src/commands/local.mjs
+++ b/src/commands/local.mjs
@@ -1,5 +1,10 @@
+import chalk from "chalk";
+import { AbortError } from "fauna";
+
+import { container } from "../cli.mjs";
 import { ensureContainerRunning } from "../lib/docker-containers.mjs";
 import { CommandError } from "../lib/errors.mjs";
+import { colorize, Format } from "../lib/formatting/colorize.mjs";
 
 /**
  * Starts the local Fauna container
@@ -8,6 +13,7 @@ import { CommandError } from "../lib/errors.mjs";
  * It will reject if the container is not ready after the maximum number of attempts.
  */
 async function startLocal(argv) {
+  const color = argv.color;
   await ensureContainerRunning({
     imageName: argv.image,
     containerName: argv.name,
@@ -17,8 +23,69 @@ async function startLocal(argv) {
     pull: argv.pull,
     interval: argv.interval,
     maxAttempts: argv.maxAttempts,
-    color: argv.color,
+    color,
   });
+  if (argv.database) {
+    await createDatabase(argv);
+  }
+}
+
+async function createDatabase(argv) {
+  const { fql } = container.resolve("fauna");
+  const { runQuery } = container.resolve("faunaClientV10");
+  const logger = container.resolve("logger");
+  const color = argv.color;
+  logger.stderr(
+    colorize(`[CreateDatabase] Creating database '${argv.database}'...`, {
+      format: Format.LOG,
+      color,
+    }),
+  );
+  try {
+    const db = await runQuery({
+      secret: "secret",
+      url: `http://${argv.hostIp}:${argv.hostPort}`,
+      query: fql`
+      let name = ${argv.name}
+      let database = Database.byName(name)
+      let protected = ${argv.protected ?? null}
+      let typechecked = ${argv.typechecked ?? null}
+      let priority = ${argv.priority ?? null}
+      let params = {
+        name: name,
+        protected: ${argv.protected ?? null},
+        typechecked: ${argv.typechecked ?? null},
+        priority: ${argv.priority ?? null},
+      }
+      if (database == null) {
+        Database.create(params)
+      } else if (protected == database.protected && typechecked == database.typechecked && priority == database.priority) {
+        database
+      } else {
+        abort(database)
+      }`,
+      options: { format: "decorated" },
+    });
+    logger.stderr(
+      colorize(`[CreateDatabase] Database '${argv.database}' created.`, {
+        format: Format.LOG,
+        color,
+      }),
+    );
+    logger.stderr(colorize(db.data, { format: Format.FQL, color }));
+  } catch (e) {
+    if (e instanceof AbortError) {
+      throw new CommandError(
+        `${chalk.red(`[CreateDatabase] Database '${argv.database}' already exists but with differrent properties than requested:\n`)}
+-----------------
+${colorize(e.abort, { format: Format.FQL, color })}
+-----------------
+${chalk.red("Please use choose a different name using --name or align the --typechecked, --priority, and --protected with what is currently present.")}`,
+        { hideHelp: false },
+      );
+    }
+    throw e;
+  }
 }
 
 /**
@@ -67,6 +134,26 @@ function buildLocalCommand(yargs) {
         type: "boolean",
         default: true,
       },
+      database: {
+        describe:
+          "The name of a database to create in the container. Omit to create no database.",
+        type: "string",
+      },
+      typechecked: {
+        describe:
+          "Enable typechecking for the database. Valid only if --database is set.",
+        type: "boolean",
+      },
+      protected: {
+        describe:
+          "Enable protected mode for the database. Protected mode disallows destructive schema changes. Valid only if --database is set.",
+        type: "boolean",
+      },
+      priority: {
+        type: "number",
+        description:
+          "User-defined priority for the database. Valid only if --database is set.",
+      },
     })
     .check((argv) => {
       if (argv.maxAttempts < 1) {
@@ -77,6 +164,24 @@ function buildLocalCommand(yargs) {
       if (argv.interval < 0) {
         throw new CommandError(
           "--interval must be greater than or equal to 0.",
+          { hideHelp: false },
+        );
+      }
+      if (argv.typechecked && !argv.database) {
+        throw new CommandError(
+          "--typechecked can only be set if --database is set.",
+          { hideHelp: false },
+        );
+      }
+      if (argv.protected && !argv.database) {
+        throw new CommandError(
+          "--protected can only be set if --database is set.",
+          { hideHelp: false },
+        );
+      }
+      if (argv.priority && !argv.database) {
+        throw new CommandError(
+          "--priority can only be set if --database is set.",
           { hideHelp: false },
         );
       }

--- a/src/commands/local.mjs
+++ b/src/commands/local.mjs
@@ -46,19 +46,18 @@ async function createDatabase(argv) {
       secret: "secret",
       url: `http://${argv.hostIp}:${argv.hostPort}`,
       query: fql`
-      let name = ${argv.name}
+      let name = ${argv.database}
       let database = Database.byName(name)
       let protected = ${argv.protected ?? null}
       let typechecked = ${argv.typechecked ?? null}
       let priority = ${argv.priority ?? null}
-      let params = {
-        name: name,
-        protected: ${argv.protected ?? null},
-        typechecked: ${argv.typechecked ?? null},
-        priority: ${argv.priority ?? null},
-      }
       if (database == null) {
-        Database.create(params)
+        Database.create({
+          name: name,
+          protected: protected,
+          typechecked: typechecked,
+          priority: priority,
+        })
       } else if (protected == database.protected && typechecked == database.typechecked && priority == database.priority) {
         database
       } else {
@@ -81,7 +80,6 @@ async function createDatabase(argv) {
 ${colorize(e.abort, { format: Format.FQL, color })}
 -----------------
 ${chalk.red("Please use choose a different name using --name or align the --typechecked, --priority, and --protected with what is currently present.")}`,
-        { hideHelp: false },
       );
     }
     throw e;

--- a/src/commands/local.mjs
+++ b/src/commands/local.mjs
@@ -3,7 +3,7 @@ import { AbortError } from "fauna";
 
 import { container } from "../cli.mjs";
 import { ensureContainerRunning } from "../lib/docker-containers.mjs";
-import { CommandError } from "../lib/errors.mjs";
+import { CommandError, ValidationError } from "../lib/errors.mjs";
 import { colorize, Format } from "../lib/formatting/colorize.mjs";
 
 /**
@@ -155,32 +155,26 @@ function buildLocalCommand(yargs) {
     })
     .check((argv) => {
       if (argv.maxAttempts < 1) {
-        throw new CommandError("--maxAttempts must be greater than 0.", {
-          hideHelp: false,
-        });
+        throw new ValidationError("--maxAttempts must be greater than 0.");
       }
       if (argv.interval < 0) {
-        throw new CommandError(
+        throw new ValidationError(
           "--interval must be greater than or equal to 0.",
-          { hideHelp: false },
         );
       }
       if (argv.typechecked && !argv.database) {
-        throw new CommandError(
+        throw new ValidationError(
           "--typechecked can only be set if --database is set.",
-          { hideHelp: false },
         );
       }
       if (argv.protected && !argv.database) {
-        throw new CommandError(
+        throw new ValidationError(
           "--protected can only be set if --database is set.",
-          { hideHelp: false },
         );
       }
       if (argv.priority && !argv.database) {
-        throw new CommandError(
+        throw new ValidationError(
           "--priority can only be set if --database is set.",
-          { hideHelp: false },
         );
       }
       return true;

--- a/src/lib/docker-containers.mjs
+++ b/src/lib/docker-containers.mjs
@@ -154,7 +154,6 @@ async function findContainer({ containerName, hostPort }) {
       `[FindContainer] Container '${containerName}' is already \
 in use on hostPort '${diffPort.PublicPort}'. Please use a new name via \
 arguments --name <newName> --hostPort ${hostPort} to start the container.`,
-      { hideHelp: false },
     );
   }
   return result;
@@ -212,7 +211,6 @@ async function createContainer({
     throw new CommandError(
       `[StartContainer] The hostPort '${hostPort}' on IP '${hostIp}' is already occupied. \
 Please pass a --hostPort other than '${hostPort}'.`,
-      { hideHelp: false },
     );
   }
   const dockerContainer = await docker.createContainer({

--- a/test/local.mjs
+++ b/test/local.mjs
@@ -1,7 +1,6 @@
 //@ts-check
 
 import { expect } from "chai";
-import { fql } from "fauna";
 import sinon, { stub } from "sinon";
 
 import { run } from "../src/cli.mjs";
@@ -124,20 +123,9 @@ Please pass a --hostPort other than '8443'.",
   });
 
   [
-    {
-      args: "--database Foo",
-      argv: { database: "Foo" },
-    },
-    {
-      args: "--database Foo --typechecked --protected --priority 1",
-      argv: {
-        database: "Foo",
-        typechecked: true,
-        protected: true,
-        priority: 1,
-      },
-    },
-  ].forEach(({ args, argv }) => {
+    "--database Foo",
+    "--database Foo --typechecked --protected --priority 1",
+  ].forEach((args) => {
     it("Creates a database if requested", async () => {
       setupCreateContainerMocks();
       const { runQuery } = container.resolve("faunaClientV10");
@@ -148,24 +136,7 @@ Please pass a --hostPort other than '8443'.",
       expect(runQuery).to.have.been.calledWith({
         secret: "secret",
         url: "http://0.0.0.0:8443",
-        query: fql`
-      let name = ${argv.database}
-      let database = Database.byName(name)
-      let protected = ${argv.protected ?? null}
-      let typechecked = ${argv.typechecked ?? null}
-      let priority = ${argv.priority ?? null}
-      if (database == null) {
-        Database.create({
-          name: name,
-          protected: protected,
-          typechecked: typechecked,
-          priority: priority,
-        })
-      } else if (protected == database.protected && typechecked == database.typechecked && priority == database.priority) {
-        database
-      } else {
-        abort(database)
-      }`,
+        query: sinon.match.any,
         options: { format: "decorated" },
       });
       const written = stderrStream.getWritten();

--- a/test/local.mjs
+++ b/test/local.mjs
@@ -1,12 +1,12 @@
 //@ts-check
 
 import { expect } from "chai";
+import { AbortError } from "fauna";
 import sinon, { stub } from "sinon";
 
 import { run } from "../src/cli.mjs";
 import { setupTestContainer } from "../src/config/setup-test-container.mjs";
 import { f } from "./helpers.mjs";
-import { AbortError } from "fauna";
 
 describe("ensureContainerRunning", () => {
   let container,
@@ -148,7 +148,7 @@ Please pass a --hostPort other than '8443'.",
   it("Exits with an expected error if teh query aborts", async () => {
     setupCreateContainerMocks();
     const { runQuery } = container.resolve("faunaClientV10");
-    runQuery.rejects(new AbortError({ error: { abort: "Taco" }}));
+    runQuery.rejects(new AbortError({ error: { abort: "Taco" } }));
     try {
       await run(`local --no-color --database Foo`, container);
     } catch (_) {}
@@ -159,7 +159,7 @@ Please pass a --hostPort other than '8443'.",
       options: { format: "decorated" },
     });
     const written = stderrStream.getWritten();
-    expect(written).to.contain('Taco');
+    expect(written).to.contain("Taco");
     expect(written).not.to.contain("fauna local");
     expect(written).not.to.contain("An unexpected");
   });

--- a/test/local.mjs
+++ b/test/local.mjs
@@ -106,7 +106,6 @@ describe("ensureContainerRunning", () => {
     try {
       // Run the actual command
       await run("local --no-color", container);
-      throw new Error("Expected an error to be thrown.");
     } catch (_) {
       // Expected error, no action needed
     }
@@ -142,6 +141,25 @@ Please pass a --hostPort other than '8443'.",
       const written = stderrStream.getWritten();
       expect(written).to.contain("[CreateDatabase] Database 'Foo' created.");
       expect(written).to.contain('"name": "Foo"');
+    });
+  });
+
+  [
+    "--typechecked",
+    "--protected",
+    "--priority 1",
+  ].forEach((args) => {
+    it("Rejects invalid create database args", async () => {
+      setupCreateContainerMocks();
+      const { runQuery } = container.resolve("faunaClientV10");
+      try {
+        await run(`local --no-color ${args}`, container);
+      } catch (_) {}
+      expect(runQuery).not.to.have.been.called;
+      const written = stderrStream.getWritten();
+      expect(written).to.contain("fauna local");
+      expect(written).not.to.contain("An unexpected");
+      expect(written).to.contain("can only be set if");
     });
   });
 
@@ -223,7 +241,6 @@ Please pass a --hostPort other than '8443'.",
     docker.pull.onCall(0).rejects(new Error("Remote repository not found"));
     try {
       await run("local --no-color", container);
-      throw new Error("Expected an error to be thrown.");
     } catch (_) {}
     expect(docker.pull).to.have.been.called;
     expect(docker.modem.followProgress).not.to.have.been.called;
@@ -246,7 +263,6 @@ https://support.fauna.com/hc/en-us/requests/new`,
     fetch.resolves(f({}, 503)); // fail from http
     try {
       await run("local --no-color --interval 0 --maxAttempts 3", container);
-      throw new Error("Expected an error to be thrown.");
     } catch (_) {}
     const written = stderrStream.getWritten();
     expect(written).to.contain("with HTTP status: '503'");
@@ -282,7 +298,6 @@ https://support.fauna.com/hc/en-us/requests/new`,
     });
     try {
       await run("local --no-color", container);
-      throw new Error("Expected an error to be thrown.");
     } catch (_) {}
     const written = stderrStream.getWritten();
     expect(written).to.contain(
@@ -294,7 +309,6 @@ https://support.fauna.com/hc/en-us/requests/new`,
   it("throws an error if interval is less than 0", async () => {
     try {
       await run("local --no-color --interval -1", container);
-      throw new Error("Expected an error to be thrown.");
     } catch (_) {}
     const written = stderrStream.getWritten();
     expect(written).to.contain(
@@ -307,7 +321,6 @@ https://support.fauna.com/hc/en-us/requests/new`,
   it("throws an error if maxAttempts is less than 1", async () => {
     try {
       await run("local --no-color --maxAttempts 0", container);
-      throw new Error("Expected an error to be thrown.");
     } catch (_) {}
     const written = stderrStream.getWritten();
     expect(written).to.contain("--maxAttempts must be greater than 0.");
@@ -447,7 +460,6 @@ https://support.fauna.com/hc/en-us/requests/new`,
 
     try {
       await run(`local --hostPort ${desiredPort}`, container);
-      throw new Error("Expected an error to be thrown.");
     } catch (_) {}
     expect(docker.listContainers).to.have.been.calledWith({
       all: true,

--- a/test/local.mjs
+++ b/test/local.mjs
@@ -145,7 +145,7 @@ Please pass a --hostPort other than '8443'.",
     });
   });
 
-  it("Exits with an expected error if teh query aborts", async () => {
+  it("Exits with an expected error if the create db query aborts", async () => {
     setupCreateContainerMocks();
     const { runQuery } = container.resolve("faunaClientV10");
     runQuery.rejects(new AbortError({ error: { abort: "Taco" } }));
@@ -179,6 +179,13 @@ Please pass a --hostPort other than '8443'.",
     });
   });
 
+  it("Does not create a database when not requested to do so", async () => {
+    setupCreateContainerMocks();
+    const { runQuery } = container.resolve("faunaClientV10");
+    await run("local --no-color", container);
+    expect(runQuery).not.to.have.been.called;
+  });
+
   it("Creates and starts a container when none exists", async () => {
     setupCreateContainerMocks();
     await run("local --no-color", container);
@@ -208,9 +215,6 @@ Please pass a --hostPort other than '8443'.",
         "8443/tcp": {},
       },
     });
-    expect(logger.stderr).to.have.been.calledWith(
-      "[ContainerReady] Container 'faunadb' is up and healthy.",
-    );
   });
 
   it("The user can control the hostIp, hostPort, containerPort, and name", async () => {


### PR DESCRIPTION
## Problem

Inner dev loops will be fastest if the user can:

1. start a Fauna container
2. create a database in that container
3. deploy a schema to that database

with a single command.

Right now we only support (1).

## Solution

Implement support for (2).

Do so by creating the requested DB if it doesn't exist, succeeding if it already exists with desired properties, failing if it exists but with different properties.
## Result

We got some tooling in place for supporting inner dev loops.
## Testing

Ran the tests; including new ones for happy and failure paths for creating a db.
