### PR TITLE
Print included query info fields as yaml

### DIFF
--- a/src/commands/query.mjs
+++ b/src/commands/query.mjs
@@ -13,8 +13,8 @@ import {
 } from "../lib/errors.mjs";
 import {
   formatError,
+  formatQueryInfo,
   formatQueryResponse,
-  formatQuerySummary,
   getSecret,
 } from "../lib/fauna-client.mjs";
 import { isTTY } from "../lib/misc.mjs";
@@ -89,8 +89,8 @@ async function queryCommand(argv) {
       typecheck,
       apiVersion,
       performanceHints,
-      summary,
       color,
+      include,
     } = argv;
 
     // If we're writing to a file, don't colorize the output regardless of the user's preference
@@ -110,12 +110,16 @@ async function queryCommand(argv) {
       color: useColor,
     });
 
-    // If performance hints are enabled, print the summary to stderr.
+    // If any query info should be displayed, print to stderr.
     // This is only supported in v10.
-    if ((summary || performanceHints) && apiVersion === "10") {
-      const formattedSummary = formatQuerySummary(results.summary);
-      if (formattedSummary) {
-        logger.stderr(formattedSummary);
+    if (include.length > 0 && apiVersion === "10") {
+      const queryInfo = formatQueryInfo(results, {
+        apiVersion,
+        color: useColor,
+        include,
+      });
+      if (queryInfo) {
+        logger.stderr(queryInfo);
       }
     }
 

--- a/src/commands/shell.mjs
+++ b/src/commands/shell.mjs
@@ -151,7 +151,6 @@ async function buildCustomEval(argv) {
       // These are options used for querying and formatting the response
       const { apiVersion, color, include } = argv;
       const performanceHints = getArgvOrCtx("performanceHints", argv, ctx);
-      const summary = getArgvOrCtx("summary", argv, ctx);
 
       // Using --json output takes precedence over --format
       const outputFormat = resolveFormat({ ...argv });
@@ -179,13 +178,16 @@ async function buildCustomEval(argv) {
           format: outputFormat,
         });
 
-        if ((summary || performanceHints) && apiVersion === "10") {
-          const formattedSummary = formatQueryInfo(
-            { summary: res.summary },
-            { apiVersion, color, include },
-          );
-          if (formattedSummary) {
-            logger.stdout(formattedSummary);
+        // If any query info should be displayed, print to stderr.
+        // This is only supported in v10.
+        if (include.length > 0 && apiVersion === "10") {
+          const queryInfo = formatQueryInfo(res, {
+            apiVersion,
+            color,
+            include,
+          });
+          if (queryInfo) {
+            logger.stdout(queryInfo);
           }
         }
       } catch (err) {

--- a/src/commands/shell.mjs
+++ b/src/commands/shell.mjs
@@ -12,8 +12,8 @@ import {
   yargsWithCommonConfigurableQueryOptions,
 } from "../lib/command-helpers.mjs";
 import {
+  formatQueryInfo,
   formatQueryResponse,
-  formatQuerySummary,
   getSecret,
 } from "../lib/fauna-client.mjs";
 import { clearHistoryStorage, initHistoryStorage } from "../lib/file-util.mjs";
@@ -149,7 +149,7 @@ async function buildCustomEval(argv) {
       if (cmd.trim() === "") return cb();
 
       // These are options used for querying and formatting the response
-      const { apiVersion, color } = argv;
+      const { apiVersion, color, include } = argv;
       const performanceHints = getArgvOrCtx("performanceHints", argv, ctx);
       const summary = getArgvOrCtx("summary", argv, ctx);
 
@@ -167,7 +167,7 @@ async function buildCustomEval(argv) {
       let res;
       try {
         const secret = await getSecret();
-        const { url, timeout, typecheck } = argv;
+        const { color, timeout, typecheck, url } = argv;
 
         res = await runQueryFromString(cmd, {
           apiVersion,
@@ -180,7 +180,10 @@ async function buildCustomEval(argv) {
         });
 
         if ((summary || performanceHints) && apiVersion === "10") {
-          const formattedSummary = formatQuerySummary(res.summary);
+          const formattedSummary = formatQueryInfo(
+            { summary: res.summary },
+            { apiVersion, color, include },
+          );
           if (formattedSummary) {
             logger.stdout(formattedSummary);
           }

--- a/src/lib/command-helpers.mjs
+++ b/src/lib/command-helpers.mjs
@@ -156,13 +156,7 @@ export function yargsWithCommonConfigurableQueryOptions(yargs) {
     }
 
     if (argv.include.includes("all")) {
-      argv.include = [
-        "txnTs",
-        "schemaVersion",
-        "summary",
-        "queryTags",
-        "stats",
-      ];
+      argv.include = [...QUERY_INFO_CHOICES];
     }
 
     if (argv.performanceHints && !argv.include.includes("summary")) {

--- a/src/lib/command-helpers.mjs
+++ b/src/lib/command-helpers.mjs
@@ -125,7 +125,7 @@ const COMMON_CONFIGURABLE_QUERY_OPTIONS = {
   performanceHints: {
     type: "boolean",
     description:
-      "Output the performance hints for the current query or nothing when no hints are available. Only applies to v10 queries. Sets the '--includes summary'",
+      "Output the performance hints for the current query or nothing when no hints are available. Only applies to v10 queries. Sets '--include summary'",
     default: false,
     group: "API:",
   },
@@ -133,7 +133,7 @@ const COMMON_CONFIGURABLE_QUERY_OPTIONS = {
     type: "array",
     choices: ["all", ...QUERY_INFO_CHOICES],
     default: [],
-    describe: "Select additional query information to include in the output",
+    describe: "Include additional query response data in the output.",
   },
 };
 

--- a/src/lib/command-helpers.mjs
+++ b/src/lib/command-helpers.mjs
@@ -114,19 +114,18 @@ const COMMON_CONFIGURABLE_QUERY_OPTIONS = {
     default: 5000,
     group: "API:",
   },
-  summary: {
-    type: "boolean",
-    description:
-      "Output the summary field of the API response or nothing when it's empty. Only applies to v10 queries.",
-    default: false,
-    group: "API:",
-  },
   performanceHints: {
     type: "boolean",
     description:
-      "Output the performance hints for the current query or nothing when no hints are available. Only applies to v10 queries.",
+      "Output the performance hints for the current query or nothing when no hints are available. Only applies to v10 queries. Sets the '--includes summary'",
     default: false,
     group: "API:",
+  },
+  include: {
+    type: "array",
+    choices: ["all", "txnTs", "schemaVersion", "summary", "queryTags", "stats"],
+    default: [],
+    describe: "Select additional query information to include in the output",
   },
 };
 
@@ -135,7 +134,24 @@ export function yargsWithCommonQueryOptions(yargs) {
 }
 
 export function yargsWithCommonConfigurableQueryOptions(yargs) {
-  return yargsWithCommonOptions(yargs, COMMON_CONFIGURABLE_QUERY_OPTIONS);
+  return yargsWithCommonOptions(
+    yargs,
+    COMMON_CONFIGURABLE_QUERY_OPTIONS,
+  ).middleware((argv) => {
+    if (argv.include.includes("all")) {
+      argv.include = [
+        "txnTs",
+        "schemaVersion",
+        "summary",
+        "queryTags",
+        "stats",
+      ];
+    }
+
+    if (argv.performanceHints && !argv.include.includes("summary")) {
+      argv.include.push("summary");
+    }
+  });
 }
 
 export function yargsWithCommonOptions(yargs, options) {

--- a/src/lib/command-helpers.mjs
+++ b/src/lib/command-helpers.mjs
@@ -131,8 +131,8 @@ const COMMON_CONFIGURABLE_QUERY_OPTIONS = {
   },
   include: {
     type: "array",
-    choices: ["all", ...QUERY_INFO_CHOICES],
-    default: [],
+    choices: ["all", "none", ...QUERY_INFO_CHOICES],
+    default: ["summary"],
     describe: "Include additional query response data in the output.",
   },
 };
@@ -146,6 +146,15 @@ export function yargsWithCommonConfigurableQueryOptions(yargs) {
     yargs,
     COMMON_CONFIGURABLE_QUERY_OPTIONS,
   ).middleware((argv) => {
+    if (argv.include.includes("none")) {
+      if (argv.include.length !== 1) {
+        throw new ValidationError(
+          `'--include none' cannot be used with other include options. Provided options: '${argv.include.join(", ")}'`,
+        );
+      }
+      argv.include = [];
+    }
+
     if (argv.include.includes("all")) {
       argv.include = [
         "txnTs",

--- a/src/lib/command-helpers.mjs
+++ b/src/lib/command-helpers.mjs
@@ -79,6 +79,14 @@ const COMMON_QUERY_OPTIONS = {
   },
 };
 
+export const QUERY_INFO_CHOICES = [
+  "txnTs",
+  "schemaVersion",
+  "summary",
+  "queryTags",
+  "stats",
+];
+
 // used for queries customers can configure
 const COMMON_CONFIGURABLE_QUERY_OPTIONS = {
   ...COMMON_QUERY_OPTIONS,
@@ -123,7 +131,7 @@ const COMMON_CONFIGURABLE_QUERY_OPTIONS = {
   },
   include: {
     type: "array",
-    choices: ["all", "txnTs", "schemaVersion", "summary", "queryTags", "stats"],
+    choices: ["all", ...QUERY_INFO_CHOICES],
     default: [],
     describe: "Select additional query information to include in the output",
   },

--- a/src/lib/fauna.mjs
+++ b/src/lib/fauna.mjs
@@ -138,7 +138,7 @@ export const formatError = (err, _opts = {}) => {
     typeof err.queryInfo.summary === "string"
   ) {
     // Otherwise, return the summary and fall back to the message.
-    return `${chalk.red("The query failed with the following error:")}\n\n${formatQuerySummary(err.queryInfo?.summary) ?? err.message}`;
+    return `${chalk.red("The query failed with the following error:")}\n\n${formatQuerySummary(err.queryInfo?.summary, { color: color ?? true }) ?? err.message}`;
   } else {
     if (err.name === "NetworkError") {
       return `The query failed unexpectedly with the following error:\n\n${NETWORK_ERROR_MESSAGE}`;

--- a/src/lib/fauna.mjs
+++ b/src/lib/fauna.mjs
@@ -138,7 +138,7 @@ export const formatError = (err, _opts = {}) => {
     typeof err.queryInfo.summary === "string"
   ) {
     // Otherwise, return the summary and fall back to the message.
-    return `${chalk.red("The query failed with the following error:")}\n\n${formatQuerySummary(err.queryInfo?.summary, { color: color ?? true }) ?? err.message}`;
+    return `${chalk.red("The query failed with the following error:")}\n\n${formatQuerySummary(err.queryInfo?.summary) ?? err.message}`;
   } else {
     if (err.name === "NetworkError") {
       return `The query failed unexpectedly with the following error:\n\n${NETWORK_ERROR_MESSAGE}`;

--- a/src/lib/formatting/codeToAnsi.mjs
+++ b/src/lib/formatting/codeToAnsi.mjs
@@ -3,6 +3,7 @@ import { createHighlighterCoreSync } from "shiki/core";
 import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
 import json from "shiki/langs/json.mjs";
 import log from "shiki/langs/log.mjs";
+import yaml from "shiki/langs/yaml.mjs";
 import githubDarkHighContrast from "shiki/themes/github-dark-high-contrast.mjs";
 
 import { isTTY } from "../misc.mjs";
@@ -13,7 +14,7 @@ const THEME = "github-dark-high-contrast";
 export const createHighlighter = () => {
   const highlighter = createHighlighterCoreSync({
     themes: [githubDarkHighContrast],
-    langs: [fql, log, json],
+    langs: [fql, log, json, yaml],
     engine: createJavaScriptRegexEngine(),
   });
 

--- a/src/lib/formatting/colorize.mjs
+++ b/src/lib/formatting/colorize.mjs
@@ -1,4 +1,5 @@
 import stripAnsi from "strip-ansi";
+import YAML from "yaml";
 
 import { container } from "../../cli.mjs";
 import { codeToAnsi } from "./codeToAnsi.mjs";
@@ -8,6 +9,7 @@ export const Format = {
   LOG: "log",
   JSON: "json",
   TEXT: "text",
+  YAML: "yaml",
 };
 
 const objToString = (obj) => JSON.stringify(obj, null, 2);
@@ -52,6 +54,18 @@ const logToAnsi = (obj) => {
   return res.trim();
 };
 
+const yamlToAnsi = (obj) => {
+  const codeToAnsi = container.resolve("codeToAnsi");
+  const stringified = YAML.stringify(obj);
+  const res = codeToAnsi(stringified, "yaml");
+
+  if (!res) {
+    return "";
+  }
+
+  return res.trim();
+};
+
 /**
  * Formats an object for display with ANSI color codes.
  * @param {any} obj - The object to format
@@ -67,6 +81,8 @@ export const toAnsi = (obj, { format = Format.TEXT } = {}) => {
       return jsonToAnsi(obj);
     case Format.LOG:
       return logToAnsi(obj);
+    case Format.YAML:
+      return yamlToAnsi(obj);
     default:
       return textToAnsi(obj);
   }

--- a/src/lib/formatting/colorize.mjs
+++ b/src/lib/formatting/colorize.mjs
@@ -56,7 +56,7 @@ const logToAnsi = (obj) => {
 
 const yamlToAnsi = (obj) => {
   const codeToAnsi = container.resolve("codeToAnsi");
-  const stringified = YAML.stringify(obj);
+  const stringified = YAML.stringify(obj, { lineWidth: 0 });
   const res = codeToAnsi(stringified, "yaml");
 
   if (!res) {

--- a/test/query.mjs
+++ b/test/query.mjs
@@ -175,14 +175,13 @@ describe("query", function () {
 
     it("cannot specify '--include none' with any other options", async function () {
       try {
-        await run(
-          `query "foo" --secret=foo --include none summary`,
-          container,
-        );
+        await run(`query "foo" --secret=foo --include none summary`, container);
       } catch (e) {}
 
       expect(logger.stderr).to.have.been.calledWith(
-        sinon.match("'--include none' cannot be used with other include options."),
+        sinon.match(
+          "'--include none' cannot be used with other include options.",
+        ),
       );
     });
   });


### PR DESCRIPTION
Ticket(s): [FE-6247](https://faunadb.atlassian.net/browse/FE-6247)

## Problem

As a user, we want to be able to view various query info fields when running queries.

## Solution

This PR add a new common query option called `include`, which can be an array of one or more of the following:
```
["all", "txnTs", "schemaVersion", "summary", "queryTags", "stats"]
```

If "all" is specified, all possible info fields should be displayed.

If `--performanceHints` is used, then at least the summary should be displayed. Don't worry if there are other components to the summary.

The query info fields should displayed so that they can be read by people. Most importantly, the summary field should be displayed plainly, formatted the way it comes back from the db. That is, don't show a weird string full of escape characters.

I used the `yaml` package to format the query info as an object and loaded the yaml colorizer. If color is on, we also apply FQL colorizing to appropriate summary lines.

## Result

query
![image](https://github.com/user-attachments/assets/5d57a189-87b3-4157-8449-1bdc72b1de3d)

shell
![image](https://github.com/user-attachments/assets/da819174-df6d-498c-a5d0-9d18d8f5e705)

shell with toggling
![image](https://github.com/user-attachments/assets/65f88a2a-5dac-4ff8-93f1-e2be02a76ee5)

![image](https://github.com/user-attachments/assets/31d47ee4-cd50-4d38-8e68-cdd9adc07871)



## Testing

All existing tests pass.

WIP: will add some more tests


[FE-6247]: https://faunadb.atlassian.net/browse/FE-6247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ