### PR TITLE
Clean up error handling to have less unexpected errors

### DIFF
--- a/src/commands/database/list.mjs
+++ b/src/commands/database/list.mjs
@@ -1,9 +1,7 @@
 //@ts-check
 
-import { FaunaError } from "fauna";
-
 import { container } from "../../cli.mjs";
-import { throwForError } from "../../lib/fauna.mjs";
+import { faunaToCommandError } from "../../lib/fauna.mjs";
 import { FaunaAccountClient } from "../../lib/fauna-account-client.mjs";
 import { colorize, Format } from "../../lib/formatting/colorize.mjs";
 
@@ -61,10 +59,7 @@ async function listDatabasesWithSecret(argv) {
       .resolve("logger")
       .stdout(formatQueryResponse(result, { format: Format.JSON, color }));
   } catch (e) {
-    if (e instanceof FaunaError) {
-      throwForError(e);
-    }
-    throw e;
+    faunaToCommandError(e);
   }
 }
 

--- a/src/lib/auth/accountKeys.mjs
+++ b/src/lib/auth/accountKeys.mjs
@@ -1,8 +1,7 @@
 import { container } from "../../cli.mjs";
-import { CommandError } from "../errors.mjs";
+import { AuthenticationError, CommandError } from "../errors.mjs";
 import { FaunaAccountClient } from "../fauna-account-client.mjs";
 import { AccountKeyStorage } from "../file-util.mjs";
-import { InvalidCredsError } from "../misc.mjs";
 
 /**
  * Class representing the account key(s) available to the user.
@@ -118,7 +117,7 @@ export class AccountKeys {
       const databaseKeys = container.resolve("credentials").databaseKeys;
       databaseKeys.updateAccountKey(newAccountKey.accountKey);
     } catch (e) {
-      if (e instanceof InvalidCredsError) {
+      if (e instanceof AuthenticationError) {
         this.promptLogin();
       } else {
         throw e;

--- a/src/lib/fauna-account-client.mjs
+++ b/src/lib/fauna-account-client.mjs
@@ -1,7 +1,7 @@
 //@ts-check
 
 import { container } from "../cli.mjs";
-import { InvalidCredsError } from "./misc.mjs";
+import { AuthenticationError } from "./errors.mjs";
 
 // const KEY_TTL_DEFAULT_MS = 1000 * 60 * 60 * 24;
 
@@ -20,7 +20,7 @@ export class FaunaAccountClient {
       try {
         result = await original(await this.getRequestArgs(args));
       } catch (e) {
-        if (e instanceof InvalidCredsError) {
+        if (e instanceof AuthenticationError) {
           try {
             logger.debug(
               "401 in account api, attempting to refresh session",
@@ -31,7 +31,7 @@ export class FaunaAccountClient {
             const updatedArgs = await this.getRequestArgs(args);
             result = await original(updatedArgs);
           } catch (e) {
-            if (e instanceof InvalidCredsError) {
+            if (e instanceof AuthenticationError) {
               logger.debug(
                 "Failed to refresh session, expired or missing refresh token",
                 "creds",

--- a/src/lib/misc.mjs
+++ b/src/lib/misc.mjs
@@ -1,19 +1,3 @@
-export class InvalidCredsError extends Error {
-  constructor(message) {
-    super(message);
-    this.name = "InvalidCredsError";
-    this.status = 401;
-  }
-}
-
-export class UnauthorizedError extends Error {
-  constructor(message) {
-    super(message);
-    this.name = "UnauthorizedError";
-    this.status = 403;
-  }
-}
-
 export function isTTY() {
   return process.stdout.isTTY;
 }

--- a/test/database/create.mjs
+++ b/test/database/create.mjs
@@ -6,6 +6,7 @@ import sinon from "sinon";
 
 import { run } from "../../src/cli.mjs";
 import { setupTestContainer as setupContainer } from "../../src/config/setup-test-container.mjs";
+import { AUTHENTICATION_ERROR_MESSAGE } from "../../src/lib/errors.mjs";
 import { mockAccessKeysFile } from "../helpers.mjs";
 
 describe("database create", () => {
@@ -50,7 +51,7 @@ describe("database create", () => {
         error: { code: "constraint_failure", message: "whatever" },
       }),
       expectedMessage:
-        "Constraint failure: The database 'testdb' already exists or one of the provided options is invalid.",
+        "The database 'testdb' already exists or one of the provided options is invalid.",
     },
     {
       error: new ServiceError({
@@ -66,14 +67,13 @@ describe("database create", () => {
         },
       }),
       expectedMessage:
-        "Constraint failure: The database name 'testdb' is invalid. Database names must begin with letters and include only letters, numbers, and underscores.",
+        "The database name 'testdb' is invalid. Database names must begin with letters and include only letters, numbers, and underscores.",
     },
     {
       error: new ServiceError({
         error: { code: "unauthorized", message: "whatever" },
       }),
-      expectedMessage:
-        "Authentication failed: Please either log in using 'fauna login' or provide a valid database secret with '--secret'.",
+      expectedMessage: AUTHENTICATION_ERROR_MESSAGE,
     },
   ].forEach(({ error, expectedMessage }) => {
     it(`handles ${error.code} errors when calling fauna`, async () => {
@@ -155,9 +155,7 @@ describe("database create", () => {
 
       expect(makeAccountRequest).to.not.have.been.called;
       expect(logger.stderr).to.have.been.calledWith(
-        sinon.match(
-          "Authentication failed: Please either log in using 'fauna login' or provide a valid database secret with '--secret'.",
-        ),
+        sinon.match(AUTHENTICATION_ERROR_MESSAGE),
       );
     });
   });

--- a/test/database/delete.mjs
+++ b/test/database/delete.mjs
@@ -6,6 +6,7 @@ import sinon from "sinon";
 
 import { run } from "../../src/cli.mjs";
 import { setupTestContainer as setupContainer } from "../../src/config/setup-test-container.mjs";
+import { AUTHENTICATION_ERROR_MESSAGE } from "../../src/lib/errors.mjs";
 import { mockAccessKeysFile } from "../helpers.mjs";
 
 describe("database delete", () => {
@@ -49,15 +50,14 @@ describe("database delete", () => {
       error: new ServiceError({
         error: { code: "unauthorized", message: "whatever" },
       }),
-      expectedMessage:
-        "Authentication failed: Please either log in using 'fauna login' or provide a valid database secret with '--secret'.",
+      expectedMessage: AUTHENTICATION_ERROR_MESSAGE,
     },
     {
       error: new ServiceError({
         error: { code: "document_not_found", message: "whatever" },
       }),
       expectedMessage:
-        "Not found: Database 'testdb' not found. Please check the database name and try again.",
+        "Database 'testdb' not found. Please check the database name and try again.",
     },
   ].forEach(({ error, expectedMessage }) => {
     it(`handles ${error.code} errors when calling fauna`, async () => {
@@ -120,9 +120,7 @@ describe("database delete", () => {
 
       expect(makeAccountRequest).to.not.have.been.called;
       expect(logger.stderr).to.have.been.calledWith(
-        sinon.match(
-          "Authentication failed: Please either log in using 'fauna login' or provide a valid database secret with '--secret'.",
-        ),
+        sinon.match(AUTHENTICATION_ERROR_MESSAGE),
       );
     });
   });

--- a/test/database/list.mjs
+++ b/test/database/list.mjs
@@ -6,6 +6,7 @@ import sinon from "sinon";
 
 import { run } from "../../src/cli.mjs";
 import { setupTestContainer as setupContainer } from "../../src/config/setup-test-container.mjs";
+import { AUTHENTICATION_ERROR_MESSAGE } from "../../src/lib/errors.mjs";
 import { colorize } from "../../src/lib/formatting/colorize.mjs";
 import { mockAccessKeysFile } from "../helpers.mjs";
 
@@ -126,8 +127,7 @@ describe("database list", () => {
         error: new ServiceError({
           error: { code: "unauthorized", message: "whatever" },
         }),
-        expectedMessage:
-          "Authentication failed: Please either log in using 'fauna login' or provide a valid database secret with '--secret'.",
+        expectedMessage: AUTHENTICATION_ERROR_MESSAGE,
       },
     ].forEach(({ error, expectedMessage }) => {
       it(`handles ${error.code} errors when calling fauna`, async () => {

--- a/test/lib/account.mjs
+++ b/test/lib/account.mjs
@@ -1,0 +1,159 @@
+import { expect } from "chai";
+
+import { parseResponse } from "../../src/lib/account.mjs";
+import {
+  AuthenticationError,
+  AuthorizationError,
+  CommandError,
+} from "../../src/lib/errors.mjs";
+
+describe("parseResponse", () => {
+  const createMockResponse = (
+    status,
+    body = {},
+    contentType = "application/json",
+  ) => {
+    return {
+      status,
+      headers: {
+        get: () => contentType,
+      },
+      json: async () => body,
+    };
+  };
+
+  it("should throw AuthenticationError for 401 status", async () => {
+    const response = createMockResponse(401, {
+      code: "unauthorized",
+      reason: "Invalid credentials",
+    });
+
+    try {
+      await parseResponse(response, true);
+    } catch (error) {
+      expect(error).to.be.instanceOf(AuthenticationError);
+    }
+  });
+
+  it("should throw AuthorizationError for 403 status", async () => {
+    const response = createMockResponse(403, {
+      code: "permission_denied",
+      reason: "Insufficient permissions",
+    });
+
+    try {
+      await parseResponse(response, true);
+    } catch (error) {
+      expect(error).to.be.instanceOf(AuthorizationError);
+    }
+  });
+
+  it("should throw CommandError for 400 status", async () => {
+    const response = createMockResponse(400, {
+      code: "bad_request",
+      reason: "Invalid parameters",
+    });
+
+    try {
+      await parseResponse(response, true);
+    } catch (error) {
+      expect(error).to.be.instanceOf(CommandError);
+    }
+  });
+
+  it("should throw CommandError for 404 status", async () => {
+    const response = createMockResponse(404, {
+      code: "not_found",
+      reason: "Resource not found",
+    });
+
+    try {
+      await parseResponse(response, true);
+    } catch (error) {
+      expect(error).to.be.instanceOf(CommandError);
+    }
+  });
+
+  it("should throw generic Error for other error status codes", async () => {
+    const response = createMockResponse(500, {
+      code: "internal_error",
+      reason: "Server error",
+    });
+
+    try {
+      await parseResponse(response, true);
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error);
+    }
+  });
+
+  it("should include status code in error message", async () => {
+    const response = createMockResponse(500, {
+      code: "internal_error",
+      reason: "Server error",
+    });
+
+    try {
+      await parseResponse(response, true);
+    } catch (error) {
+      expect(error.message).to.include("[500]");
+      expect(error.message).to.include("internal_error");
+      expect(error.message).to.include("Server error");
+    }
+  });
+
+  it("should not throw error when shouldThrow is false", async () => {
+    const response = createMockResponse(400, {
+      code: "bad_request",
+      reason: "Invalid parameters",
+    });
+
+    const result = await parseResponse(response, false);
+    expect(result).to.deep.equal({
+      code: "bad_request",
+      reason: "Invalid parameters",
+    });
+  });
+
+  it("should handle non-JSON responses", async () => {
+    const response = {
+      status: 400,
+      headers: {
+        get: () => "text/plain",
+      },
+    };
+
+    try {
+      await parseResponse(response, true);
+    } catch (error) {
+      expect(error).to.be.instanceOf(CommandError);
+      expect(error.message).to.include("[400]");
+    }
+  });
+
+  it("should preserve error details in cause", async () => {
+    const responseBody = {
+      code: "bad_request",
+      reason: "Invalid parameters",
+    };
+    const response = createMockResponse(400, responseBody);
+
+    try {
+      await parseResponse(response, true);
+    } catch (error) {
+      expect(error.cause).to.exist;
+      expect(error.cause.status).to.equal(400);
+      expect(error.cause.body).to.deep.equal(responseBody);
+      expect(error.cause.code).to.equal("bad_request");
+      expect(error.cause.reason).to.equal("Invalid parameters");
+    }
+  });
+
+  it("should return parsed JSON for successful responses", async () => {
+    const responseBody = { data: "success" };
+    const response = createMockResponse(200, responseBody);
+
+    const result = await parseResponse(response, true);
+    expect(result).to.deep.equal(responseBody);
+  });
+});

--- a/test/lib/fauna.mjs
+++ b/test/lib/fauna.mjs
@@ -1,0 +1,120 @@
+import { expect } from "chai";
+import { NetworkError, ServiceError } from "fauna";
+
+import {
+  AuthenticationError,
+  AuthorizationError,
+  CommandError,
+  NETWORK_ERROR_MESSAGE,
+} from "../../src/lib/errors.mjs";
+import { faunaToCommandError } from "../../src/lib/fauna.mjs";
+
+describe("faunaToCommandError", () => {
+  it("should convert unauthorized ServiceError to AuthenticationError", () => {
+    const serviceError = new ServiceError({
+      error: {
+        code: "unauthorized",
+        message: "Invalid token",
+      },
+    });
+
+    try {
+      faunaToCommandError(serviceError);
+    } catch (error) {
+      expect(error).to.be.instanceOf(AuthenticationError);
+      expect(error.cause).to.equal(serviceError);
+    }
+  });
+
+  it("should convert forbidden ServiceError to AuthorizationError", () => {
+    const serviceError = new ServiceError({
+      error: {
+        code: "forbidden",
+        message: "Permission denied",
+      },
+    });
+
+    try {
+      faunaToCommandError(serviceError);
+    } catch (error) {
+      expect(error).to.be.instanceOf(AuthorizationError);
+      expect(error.cause).to.equal(serviceError);
+    }
+  });
+
+  it("should convert permission_denied ServiceError to AuthorizationError", () => {
+    const serviceError = new ServiceError({
+      error: {
+        code: "permission_denied",
+        message: "No permission",
+      },
+    });
+
+    try {
+      faunaToCommandError(serviceError);
+    } catch (error) {
+      expect(error).to.be.instanceOf(AuthorizationError);
+      expect(error.cause).to.equal(serviceError);
+    }
+  });
+
+  it("should convert other ServiceErrors to CommandError", () => {
+    const serviceError = new ServiceError({
+      error: {
+        code: "internal_error",
+        message: "Unknown error",
+      },
+    });
+
+    try {
+      faunaToCommandError(serviceError);
+    } catch (error) {
+      expect(error).to.be.instanceOf(CommandError);
+      expect(error.cause).to.equal(serviceError);
+    }
+  });
+
+  it("should convert NetworkError to CommandError with network error message", () => {
+    const networkError = new NetworkError("Network failure");
+
+    try {
+      faunaToCommandError(networkError);
+    } catch (error) {
+      expect(error).to.be.instanceOf(CommandError);
+      expect(error.message).to.equal(NETWORK_ERROR_MESSAGE);
+      expect(error.cause).to.equal(networkError);
+    }
+  });
+
+  it("should pass through other errors unchanged", () => {
+    const genericError = new Error("Generic error");
+
+    try {
+      faunaToCommandError(genericError);
+    } catch (error) {
+      expect(error).to.equal(genericError);
+    }
+  });
+
+  it("should call custom handler if provided", () => {
+    let handlerCalled = false;
+    const serviceError = new ServiceError({
+      error: {
+        code: "unauthorized",
+        message: "Invalid token",
+      },
+    });
+
+    const handler = (e) => {
+      handlerCalled = true;
+      expect(e).to.equal(serviceError);
+    };
+
+    try {
+      faunaToCommandError(serviceError, handler);
+    } catch (error) {
+      expect(handlerCalled).to.be.true;
+      expect(error).to.be.instanceOf(AuthenticationError);
+    }
+  });
+});

--- a/test/lib/faunadb.mjs
+++ b/test/lib/faunadb.mjs
@@ -1,0 +1,99 @@
+import { expect } from "chai";
+import faunadb from "faunadb";
+
+import {
+  AuthenticationError,
+  AuthorizationError,
+  CommandError,
+  NETWORK_ERROR_MESSAGE,
+} from "../../src/lib/errors.mjs";
+import { faunadbToCommandError } from "../../src/lib/faunadb.mjs";
+
+describe("faunadbToCommandError", () => {
+  it("should convert Unauthorized error to AuthenticationError", () => {
+    const faunaError = new faunadb.errors.FaunaHTTPError("Unauthorized", {
+      responseContent: {
+        errors: [],
+      },
+    });
+
+    expect(() => faunadbToCommandError(faunaError)).to.throw(
+      AuthenticationError,
+    );
+  });
+
+  it("should convert PermissionDenied error to AuthorizationError", () => {
+    const faunaError = new faunadb.errors.FaunaHTTPError("PermissionDenied", {
+      responseContent: {
+        errors: [],
+      },
+    });
+
+    expect(() => faunadbToCommandError(faunaError)).to.throw(
+      AuthorizationError,
+    );
+  });
+
+  it("should convert BadRequest error to CommandError", () => {
+    const faunaError = new faunadb.errors.FaunaHTTPError("BadRequest", {
+      responseContent: {
+        errors: [],
+      },
+    });
+
+    expect(() => faunadbToCommandError(faunaError)).to.throw(CommandError);
+  });
+
+  it("should convert NotFound error to CommandError", () => {
+    const faunaError = new faunadb.errors.FaunaHTTPError("NotFound", {
+      responseContent: {
+        errors: [],
+      },
+    });
+
+    expect(() => faunadbToCommandError(faunaError)).to.throw(CommandError);
+  });
+
+  it("should convert network error to CommandError with network message", () => {
+    const networkError = new TypeError("fetch failed");
+
+    expect(() => faunadbToCommandError(networkError)).to.throw(
+      CommandError,
+      NETWORK_ERROR_MESSAGE,
+    );
+  });
+
+  it("should pass through other FaunaHTTPErrors unchanged", () => {
+    const faunaError = new faunadb.errors.FaunaHTTPError("Internal error", {
+      responseContent: {
+        errors: [],
+      },
+    });
+
+    expect(() => faunadbToCommandError(faunaError)).to.throw(
+      faunadb.errors.FaunaHTTPError,
+    );
+  });
+
+  it("should pass through other errors unchanged", () => {
+    const genericError = new Error("Generic error");
+
+    expect(() => faunadbToCommandError(genericError)).to.throw(Error);
+  });
+
+  it("should call optional error handler if provided", () => {
+    let handlerCalled = false;
+    const handler = () => {
+      handlerCalled = true;
+    };
+    const error = new Error("Test error");
+
+    try {
+      faunadbToCommandError(error, handler);
+    } catch (e) {
+      // Expected to throw
+    }
+
+    expect(handlerCalled).to.be.true;
+  });
+});

--- a/test/shell.mjs
+++ b/test/shell.mjs
@@ -123,6 +123,7 @@ describe("shell", function () {
       await stderr.waitForWritten();
 
       expect(stderr.getWritten()).to.contain(NETWORK_ERROR_MESSAGE);
+      expect(stderr.getWritten()).to.not.contain("failed unexpectedly");
     });
 
     describe("history", function () {


### PR DESCRIPTION
## Problem

We have a few inconsistencies in error handling:
* Account API failures were very verbose and almost always "unexpected errors" even in cases you'd expect them, such as:
  * invalid inputs: like bad region groups
  * 404s: like missing databases
* Common Fauna errors could sneak through and be very confusing. The most notable of this is if you have a bad `--secret`
* Authentication errors in general weren't being consistently caught and displayed.

## Solution

This PR does a few things, but it most notably commits to using the errors defined in `errors.mjs` in our lib code. Through adding new exceptions and common patterns to convert 3rd party errors to things we expect, we can get rid of most unexpected errors.

* New exceptions: Add `AuthenticationError` and `AuthorizationError`. The 401 case has a default message to remove the inconsistent ones we have already.
* `xxxxToCommandError` helpers: Simplified the existing `throwForError` function to just be a translation layer to catch the common error types across our dependencies.

## Result

Authentication errors and 4XX errors display consistently across the account, v4, v10, and schema APIs.

## Testing

Add unit tests for the error mappings. Updated existing error tests.
