### PR TITLE
Update all flags to be hyphen-case in help text

### DIFF
--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -193,7 +193,7 @@ function buildYargs(argvInput) {
         default: false,
         group: "Output:",
       },
-      verboseComponent: {
+      "verbose-component": {
         description:
           "Components to emit diagnostic logs for. Takes precedence over the `--verbosity` flag. Pass components as a space-separated list, such as `--verboseComponent fetch error`, or as separate flags, such as `--verboseComponent fetch --verboseComponent error`.",
         type: "array",

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -195,7 +195,7 @@ function buildYargs(argvInput) {
       },
       "verbose-component": {
         description:
-          "Components to emit diagnostic logs for. Takes precedence over the `--verbosity` flag. Pass components as a space-separated list, such as `--verboseComponent fetch error`, or as separate flags, such as `--verboseComponent fetch --verboseComponent error`.",
+          "Components to emit diagnostic logs for. Takes precedence over the `--verbosity` flag. Pass components as a space-separated list, such as `--verbose-component fetch error`, or as separate flags, such as `--verbose-component fetch --verbose-component error`.",
         type: "array",
         default: [],
         choices: ["fetch", "error", "config", "argv", "creds", "completion"],

--- a/src/commands/database/list.mjs
+++ b/src/commands/database/list.mjs
@@ -97,7 +97,7 @@ function buildListCommand(yargs) {
         "List all top-level databases and output as JSON.",
       ],
       [
-        "$0 database list --pageSize 10",
+        "$0 database list --page-size 10",
         "List the first 10 top-level databases.",
       ],
     ]);

--- a/src/commands/database/list.mjs
+++ b/src/commands/database/list.mjs
@@ -76,7 +76,7 @@ async function doListDatabases(argv) {
 function buildListCommand(yargs) {
   return yargs
     .options({
-      pageSize: {
+      "page-size": {
         type: "number",
         description: "Maximum number of databases to return.",
         default: 1000,

--- a/src/commands/local.mjs
+++ b/src/commands/local.mjs
@@ -94,18 +94,18 @@ ${chalk.red("Please use choose a different name using --name or align the --type
 function buildLocalCommand(yargs) {
   return yargs
     .options({
-      containerPort: {
+      "container-port": {
         describe: "The port inside the container Fauna listens on.",
         type: "number",
         default: 8443,
       },
-      hostPort: {
+      "host-port": {
         describe:
           "The port on the host machine mapped to the container's port. This is the port you'll connect to Fauna on.",
         type: "number",
         default: 8443,
       },
-      hostIp: {
+      "host-ip": {
         describe: `The IP address to bind the container's exposed port on the host.`,
         type: "string",
         default: "0.0.0.0",
@@ -116,7 +116,7 @@ function buildLocalCommand(yargs) {
         type: "number",
         default: 10000,
       },
-      maxAttempts: {
+      "max-attempts": {
         describe:
           "The maximum number of health check attempts before declaring the start Fauna continer process as failed.",
         type: "number",
@@ -155,7 +155,7 @@ function buildLocalCommand(yargs) {
     })
     .check((argv) => {
       if (argv.maxAttempts < 1) {
-        throw new ValidationError("--maxAttempts must be greater than 0.");
+        throw new ValidationError("--max-attempts must be greater than 0.");
       }
       if (argv.interval < 0) {
         throw new ValidationError(

--- a/src/lib/auth/README.md
+++ b/src/lib/auth/README.md
@@ -26,7 +26,7 @@ If no account key is provided, the CLI will prompt a login via the dashboard whe
 
 ### The CLI will look for account keys in this order:
 
-- `--accountKey` flag
+- `--account-key` flag
 - `FAUNA_ACCOUNT_KEY` environment variable
 - `--config` file `accountKey` value
 - `~/.fauna/credentials/access_keys`

--- a/src/lib/command-helpers.mjs
+++ b/src/lib/command-helpers.mjs
@@ -6,19 +6,19 @@ import { Format } from "./formatting/colorize.mjs";
 
 const COMMON_OPTIONS = {
   // hidden
-  accountUrl: {
+  "account-url": {
     type: "string",
     description: "the Fauna account URL to query",
     default: "https://account.fauna.com",
     hidden: true,
   },
-  clientId: {
+  "client-id": {
     type: "string",
     description: "the client id to use when calling Fauna",
     required: false,
     hidden: true,
   },
-  clientSecret: {
+  "client-secret": {
     type: "string",
     description: "the client secret to use when calling Fauna",
     required: false,
@@ -56,7 +56,7 @@ const COMMON_QUERY_OPTIONS = {
     required: false,
     group: "API:",
   },
-  accountKey: {
+  "account-key": {
     type: "string",
     description:
       "Fauna account key used for authentication. Negates the need for a user login. The key is used to generate short-lived database secrets for the CLI. Mutually exclusive with `--user` and `--secret`.",
@@ -82,7 +82,7 @@ const COMMON_QUERY_OPTIONS = {
 // used for queries customers can configure
 const COMMON_CONFIGURABLE_QUERY_OPTIONS = {
   ...COMMON_QUERY_OPTIONS,
-  apiVersion: {
+  "api-version": {
     description: "FQL version to use.",
     type: "string",
     alias: "v",
@@ -121,7 +121,7 @@ const COMMON_CONFIGURABLE_QUERY_OPTIONS = {
     default: false,
     group: "API:",
   },
-  performanceHints: {
+  "performance-hints": {
     type: "boolean",
     description:
       "Output the performance hints for the current query or nothing when no hints are available. Only applies to v10 queries.",

--- a/src/lib/docker-containers.mjs
+++ b/src/lib/docker-containers.mjs
@@ -210,7 +210,7 @@ async function createContainer({
   if (occupied) {
     throw new CommandError(
       `[StartContainer] The hostPort '${hostPort}' on IP '${hostIp}' is already occupied. \
-Please pass a --hostPort other than '${hostPort}'.`,
+Please pass a --host-port other than '${hostPort}'.`,
     );
   }
   const dockerContainer = await docker.createContainer({

--- a/src/lib/docker-containers.mjs
+++ b/src/lib/docker-containers.mjs
@@ -390,7 +390,7 @@ async function waitForHealthCheck({
     `[HealthCheck] Max attempts reached. Service at ${url} did not respond.`,
   );
   throw new CommandError(
-    `[HealthCheck] Fauna at ${url} is not ready after ${maxAttempts} attempts. Consider increasing --interval or --maxAttempts.`,
+    `[HealthCheck] Fauna at ${url} is not ready after ${maxAttempts} attempts. Consider increasing --interval or --max-attempts.`,
   );
 }
 

--- a/test/lib/formatting/redact.mjs
+++ b/test/lib/formatting/redact.mjs
@@ -34,6 +34,7 @@ describe("redactedStringify", () => {
       secret: "hide-me",
       mySecret: "hide-this-too",
       secret_key: "also-hidden",
+      "account-key": "also-hidden",
       bigSecret: "this-is-a-long-secret",
     };
     const result = JSON.parse(redactedStringify(obj));
@@ -41,7 +42,7 @@ describe("redactedStringify", () => {
     expect(result.normal).to.equal("visible");
     expect(result.secret).to.equal("*******");
     expect(result.mySecret).to.equal("*********-too");
-    expect(result.secret_key).to.equal("***********");
+    expect(result["account-key"]).to.equal("***********");
     expect(result.bigSecret).to.equal("this*************cret");
   });
 

--- a/test/local.mjs
+++ b/test/local.mjs
@@ -116,7 +116,7 @@ describe("ensureContainerRunning", () => {
     // Assertions
     expect(written).to.contain(
       "[StartContainer] The hostPort '8443' on IP '0.0.0.0' is already occupied. \
-Please pass a --hostPort other than '8443'.",
+Please pass a --host-port other than '8443'.",
     );
     expect(written).not.to.contain("fauna local");
     expect(written).not.to.contain("An unexpected");

--- a/test/local.mjs
+++ b/test/local.mjs
@@ -57,7 +57,7 @@ describe("ensureContainerRunning", () => {
       }
     });
 
-    serverMock.on.withArgs("listening").callsFake((event, callback) => {
+    serverMock.on.withArgs("listening").callsFake((_event, callback) => {
       if (simulateError) {
         // Trigger the error callback
         const errorCallback = serverMock.once.withArgs("error").args[0]?.[1];
@@ -81,7 +81,7 @@ describe("ensureContainerRunning", () => {
 
   function setupCreateContainerMocks() {
     docker.pull.onCall(0).resolves();
-    docker.modem.followProgress.callsFake((stream, onFinished) => {
+    docker.modem.followProgress.callsFake((_stream, onFinished) => {
       onFinished();
     });
     docker.listContainers.onCall(0).resolves([]);
@@ -100,7 +100,7 @@ describe("ensureContainerRunning", () => {
   it("Shows a clear error to the user if something is already running on the desired port.", async () => {
     simulateError = true;
     docker.pull.onCall(0).resolves();
-    docker.modem.followProgress.callsFake((stream, onFinished) => {
+    docker.modem.followProgress.callsFake((_stream, onFinished) => {
       onFinished();
     });
     docker.listContainers.onCall(0).resolves([]);
@@ -282,13 +282,13 @@ https://support.fauna.com/hc/en-us/requests/new`,
     fetch.onCall(0).rejects();
     fetch.resolves(f({}, 503)); // fail from http
     try {
-      await run("local --no-color --interval 0 --maxAttempts 3", container);
+      await run("local --no-color --interval 0 --max-attempts 3", container);
     } catch (_) {}
     const written = stderrStream.getWritten();
     expect(written).to.contain("with HTTP status: '503'");
     expect(written).to.contain("with error:");
     expect(written).to.contain(
-      "[HealthCheck] Fauna at http://0.0.0.0:8443 is not ready after 3 attempts. Consider increasing --interval or --maxAttempts.",
+      "[HealthCheck] Fauna at http://0.0.0.0:8443 is not ready after 3 attempts. Consider increasing --interval or --max-attempts.",
     );
     expect(written).not.to.contain("An unexpected");
     expect(written).not.to.contain("fauna local"); // help text
@@ -296,7 +296,7 @@ https://support.fauna.com/hc/en-us/requests/new`,
 
   it("exits if a container cannot be started", async () => {
     docker.pull.onCall(0).resolves();
-    docker.modem.followProgress.callsFake((stream, onFinished) => {
+    docker.modem.followProgress.callsFake((_stream, onFinished) => {
       onFinished();
     });
     docker.listContainers.onCall(0).resolves([
@@ -340,10 +340,10 @@ https://support.fauna.com/hc/en-us/requests/new`,
 
   it("throws an error if maxAttempts is less than 1", async () => {
     try {
-      await run("local --no-color --maxAttempts 0", container);
+      await run("local --no-color --max-attempts 0", container);
     } catch (_) {}
     const written = stderrStream.getWritten();
-    expect(written).to.contain("--maxAttempts must be greater than 0.");
+    expect(written).to.contain("--max-attempts must be greater than 0.");
     expect(written).to.contain("fauna local"); // help text
     expect(written).not.to.contain("An unexpected");
   });
@@ -403,7 +403,7 @@ https://support.fauna.com/hc/en-us/requests/new`,
   ].forEach((test) => {
     it(`Ensures a container in state '${test.state}' becomes running and available.`, async () => {
       docker.pull.onCall(0).resolves();
-      docker.modem.followProgress.callsFake((stream, onFinished) => {
+      docker.modem.followProgress.callsFake((_stream, onFinished) => {
         onFinished();
       });
       docker.listContainers.onCall(0).resolves([
@@ -463,7 +463,7 @@ https://support.fauna.com/hc/en-us/requests/new`,
   it("should throw if container exists with same name but different port", async () => {
     const desiredPort = 8443;
     docker.pull.onCall(0).resolves();
-    docker.modem.followProgress.callsFake((stream, onFinished) => {
+    docker.modem.followProgress.callsFake((_stream, onFinished) => {
       onFinished();
     });
     // Mock existing container with different port


### PR DESCRIPTION
## Problem

We are inconsistent in our help text naming conventions. Sometimes we do `--someThing` and sometimes we do `--some-thing`. While internally, this is all abstracted away, the display being inconsistent is problematic.

## Solution

Update all flags to be hyphen-case.

## Result

All the flags hyphen case. Errors related to flags are in hyphen-case.

## Testing

Related unit tests have been updated.
