### PR TITLE
Typechecked should be a boolean

### DIFF
--- a/src/commands/database/create.mjs
+++ b/src/commands/database/create.mjs
@@ -79,7 +79,7 @@ function buildCreateCommand(yargs) {
         description: "Name of the child database to create.",
       },
       typechecked: {
-        type: "string",
+        type: "boolean",
         description:
           "Enable typechecking for the database. Defaults to the typechecking setting of the parent database.",
       },

--- a/test/database/create.mjs
+++ b/test/database/create.mjs
@@ -34,6 +34,11 @@ describe("database create", () => {
       message:
         "No database or secret specified. Please use either --database, --secret, or --local to connect to your desired Fauna database.",
     },
+    {
+      command:
+        "database create --name 'testdb' --secret 'secret' --typechecked 'imastring'",
+      message: "Invalid value for option typechecked: imastring",
+    },
   ].forEach(({ command, message }) => {
     it(`validates invalid arguments: ${command}`, async () => {
       try {


### PR DESCRIPTION
## Problem
The `typechecked` option is marked as a string in the create database command definition.

## Solution
Make it a boolean.

## Result
The create database command reflects the correct types of its options.

## Testing
Added a test to ensure we spit t an error if a boolean is not given.
