### PR TITLE
Add a basic SECURITY.md that points to support.fauna.com

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+
+Use this section to tell people about which versions of your project are
+currently being supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 4.x.x   | :white_check_mark: |
+| < 4.0   | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+We believe our user community and unaffiliated security researchers play an important role in
+helping to keep Fauna and our customers secure. If you think you have found a security issue,
+please inform us by sending an email to security@fauna.com.
+
+Learn more about reporting a vulnerability at [support.fauna.com](https://support.fauna.com/hc/en-us/articles/4449808041115-How-do-I-report-a-vulnerability).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,4 +16,4 @@ We believe our user community and unaffiliated security researchers play an impo
 helping to keep Fauna and our customers secure. If you think you have found a security issue,
 please inform us by sending an email to security@fauna.com.
 
-Learn more about reporting a vulnerability at [support.fauna.com](https://support.fauna.com/hc/en-us/articles/4449808041115-How-do-I-report-a-vulnerability).
+Learn more about reporting a vulnerability at [trust.fauna.com](https://trust.fauna.com/).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ currently being supported with security updates.
 | Version | Supported          |
 | ------- | ------------------ |
 | 4.x.x   | :white_check_mark: |
-| < 4.0   | :white_check_mark: |
+| < 4.0.0 | :white_check_mark: |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Problem

We do not have a basic SECURITY.md for this repository.

## Solution

Add one that points to the public fauna support site that details our security policies.