### PR TITLE
Remove missed --raw reference in faunadbToCommandError

### DIFF
--- a/src/commands/database/delete.mjs
+++ b/src/commands/database/delete.mjs
@@ -29,13 +29,17 @@ async function deleteDatabase(argv) {
 
     // We use stderr for messaging and there's no stdout output for a deleted database
     logger.stderr(`Database '${argv.name}' was successfully deleted.`);
-  } catch (e) {
-    faunaToCommandError(e, (err) => {
-      if (err instanceof ServiceError && err.code === "document_not_found") {
-        throw new CommandError(
-          `Database '${argv.name}' not found. Please check the database name and try again.`,
-        );
-      }
+  } catch (err) {
+    faunaToCommandError({
+      err,
+      color: argv.color,
+      handler: (err) => {
+        if (err instanceof ServiceError && err.code === "document_not_found") {
+          throw new CommandError(
+            `Database '${argv.name}' not found. Please check the database name and try again.`,
+          );
+        }
+      },
     });
   }
 }

--- a/src/commands/database/list.mjs
+++ b/src/commands/database/list.mjs
@@ -48,7 +48,7 @@ async function listDatabasesWithSecret(argv) {
       expression: `Database.all().paginate(${pageSize}).data { ${getOutputFields(argv)} }`,
     });
   } catch (e) {
-    return faunaToCommandError(e);
+    return faunaToCommandError({ err: e, color: argv.color });
   }
 }
 

--- a/src/lib/fauna-client.mjs
+++ b/src/lib/fauna-client.mjs
@@ -125,10 +125,11 @@ export const isQueryable = async (argv) => {
       throw err;
     }
 
+    const { color } = argv;
     if (argv.apiVersion === "4") {
-      faunadbToCommandError(err);
+      faunadbToCommandError({ err, color });
     } else {
-      faunaToCommandError(err);
+      faunaToCommandError({ err, color });
     }
   }
 

--- a/src/lib/fauna.mjs
+++ b/src/lib/fauna.mjs
@@ -168,34 +168,35 @@ export const formatQueryResponse = (res, opts = {}) => {
  * can be provided for different types of errors, and a default error
  * message is thrown if no handler is provided. This may be used when we run
  * commands on the users behalf and want to provide a more helpful error message.
- *
- * @param {import("fauna").FaunaError} e - The Fauna error to handle
- * @param {(e: import("fauna").FaunaError) => void} [handler] - Optional error handler to handle and throw in
+ * @param {object} opts
+ * @param {import("fauna").FaunaError} opts.err - The Fauna error to handle
+ * @param {(e: import("fauna").FaunaError) => void} [opts.handler] - Optional error handler to handle and throw in
+ * @param {boolean} [opts.color] - Whether to colorize the error
  * @throws {Error} Always throws an error with a message based on the error code or handler response
  * @returns {never} This function always throws an error
  */
 
-export const faunaToCommandError = (e, handler) => {
+export const faunaToCommandError = ({ err, handler, color }) => {
   if (handler) {
-    handler(e);
+    handler(err);
   }
 
-  if (e instanceof ServiceError) {
-    switch (e.code) {
+  if (err instanceof ServiceError) {
+    switch (err.code) {
       case "unauthorized":
-        throw new AuthenticationError({ cause: e });
+        throw new AuthenticationError({ cause: err });
       case "forbidden":
-        throw new AuthorizationError({ cause: e });
+        throw new AuthorizationError({ cause: err });
       case "permission_denied":
-        throw new AuthorizationError({ cause: e });
+        throw new AuthorizationError({ cause: err });
       default:
-        throw new CommandError(formatError(e), { cause: e });
+        throw new CommandError(formatError(err, { color }), { cause: err });
     }
   }
 
-  if (e instanceof NetworkError) {
-    throw new CommandError(NETWORK_ERROR_MESSAGE, { cause: e });
+  if (err instanceof NetworkError) {
+    throw new CommandError(NETWORK_ERROR_MESSAGE, { cause: err });
   }
 
-  throw e;
+  throw err;
 };

--- a/src/lib/faunadb.mjs
+++ b/src/lib/faunadb.mjs
@@ -134,10 +134,13 @@ export const formatError = (err, opts = {}) => {
 
 /**
  * Converts a Fauna HTTP error to a CommandError.
- * @param {any} err - The error to convert
- * @param {(e: import("fauna").FaunaError) => void} [handler] - Optional error handler to handle and throw in
+ * @param {object} opts
+ * @param {any} opts.err - The error to convert
+ * @param {(e: import("fauna").FaunaError) => void} [opts.handler] - Optional error handler to handle and throw in
+ * @param {boolean} [opts.color] - Whether to colorize the error
+ * @returns {void}
  */
-export const faunadbToCommandError = (err, handler) => {
+export const faunadbToCommandError = ({ err, handler, color }) => {
   if (handler) {
     handler(err);
   }
@@ -150,7 +153,7 @@ export const faunadbToCommandError = (err, handler) => {
         throw new AuthorizationError({ cause: err });
       case "BadRequest":
       case "NotFound":
-        throw new CommandError(formatError(err, { raw: true }), { cause: err });
+        throw new CommandError(formatError(err, { color }), { cause: err });
       default:
         throw err;
     }

--- a/test/lib/fauna.mjs
+++ b/test/lib/fauna.mjs
@@ -19,7 +19,7 @@ describe("faunaToCommandError", () => {
     });
 
     try {
-      faunaToCommandError(serviceError);
+      faunaToCommandError({ err: serviceError });
     } catch (error) {
       expect(error).to.be.instanceOf(AuthenticationError);
       expect(error.cause).to.equal(serviceError);
@@ -35,7 +35,7 @@ describe("faunaToCommandError", () => {
     });
 
     try {
-      faunaToCommandError(serviceError);
+      faunaToCommandError({ err: serviceError });
     } catch (error) {
       expect(error).to.be.instanceOf(AuthorizationError);
       expect(error.cause).to.equal(serviceError);
@@ -51,7 +51,7 @@ describe("faunaToCommandError", () => {
     });
 
     try {
-      faunaToCommandError(serviceError);
+      faunaToCommandError({ err: serviceError });
     } catch (error) {
       expect(error).to.be.instanceOf(AuthorizationError);
       expect(error.cause).to.equal(serviceError);
@@ -67,7 +67,7 @@ describe("faunaToCommandError", () => {
     });
 
     try {
-      faunaToCommandError(serviceError);
+      faunaToCommandError({ err: serviceError });
     } catch (error) {
       expect(error).to.be.instanceOf(CommandError);
       expect(error.cause).to.equal(serviceError);
@@ -78,7 +78,7 @@ describe("faunaToCommandError", () => {
     const networkError = new NetworkError("Network failure");
 
     try {
-      faunaToCommandError(networkError);
+      faunaToCommandError({ err: networkError });
     } catch (error) {
       expect(error).to.be.instanceOf(CommandError);
       expect(error.message).to.equal(NETWORK_ERROR_MESSAGE);
@@ -90,7 +90,7 @@ describe("faunaToCommandError", () => {
     const genericError = new Error("Generic error");
 
     try {
-      faunaToCommandError(genericError);
+      faunaToCommandError({ err: genericError });
     } catch (error) {
       expect(error).to.equal(genericError);
     }
@@ -111,7 +111,7 @@ describe("faunaToCommandError", () => {
     };
 
     try {
-      faunaToCommandError(serviceError, handler);
+      faunaToCommandError({ err: serviceError, handler });
     } catch (error) {
       expect(handlerCalled).to.be.true;
       expect(error).to.be.instanceOf(AuthenticationError);

--- a/test/lib/faunadb.mjs
+++ b/test/lib/faunadb.mjs
@@ -17,7 +17,7 @@ describe("faunadbToCommandError", () => {
       },
     });
 
-    expect(() => faunadbToCommandError(faunaError)).to.throw(
+    expect(() => faunadbToCommandError({ err: faunaError })).to.throw(
       AuthenticationError,
     );
   });
@@ -29,7 +29,7 @@ describe("faunadbToCommandError", () => {
       },
     });
 
-    expect(() => faunadbToCommandError(faunaError)).to.throw(
+    expect(() => faunadbToCommandError({ err: faunaError })).to.throw(
       AuthorizationError,
     );
   });
@@ -41,7 +41,9 @@ describe("faunadbToCommandError", () => {
       },
     });
 
-    expect(() => faunadbToCommandError(faunaError)).to.throw(CommandError);
+    expect(() => faunadbToCommandError({ err: faunaError })).to.throw(
+      CommandError,
+    );
   });
 
   it("should convert NotFound error to CommandError", () => {
@@ -51,13 +53,15 @@ describe("faunadbToCommandError", () => {
       },
     });
 
-    expect(() => faunadbToCommandError(faunaError)).to.throw(CommandError);
+    expect(() => faunadbToCommandError({ err: faunaError })).to.throw(
+      CommandError,
+    );
   });
 
   it("should convert network error to CommandError with network message", () => {
     const networkError = new TypeError("fetch failed");
 
-    expect(() => faunadbToCommandError(networkError)).to.throw(
+    expect(() => faunadbToCommandError({ err: networkError })).to.throw(
       CommandError,
       NETWORK_ERROR_MESSAGE,
     );
@@ -70,7 +74,7 @@ describe("faunadbToCommandError", () => {
       },
     });
 
-    expect(() => faunadbToCommandError(faunaError)).to.throw(
+    expect(() => faunadbToCommandError({ err: faunaError })).to.throw(
       faunadb.errors.FaunaHTTPError,
     );
   });
@@ -78,7 +82,7 @@ describe("faunadbToCommandError", () => {
   it("should pass through other errors unchanged", () => {
     const genericError = new Error("Generic error");
 
-    expect(() => faunadbToCommandError(genericError)).to.throw(Error);
+    expect(() => faunadbToCommandError({ err: genericError })).to.throw(Error);
   });
 
   it("should call optional error handler if provided", () => {
@@ -89,7 +93,7 @@ describe("faunadbToCommandError", () => {
     const error = new Error("Test error");
 
     try {
-      faunadbToCommandError(error, handler);
+      faunadbToCommandError({ err: error, handler });
     } catch (e) {
       // Expected to throw
     }


### PR DESCRIPTION
Ticket(s): FE-###

## Problem

`faunadbToCommandError`was still referencing `raw`. While it didn't break anything we should remove it since `raw` is no longer a CLI option. Color wasn't always being obeyed in this code path.

## Solution

Refactor function interface to be an object. Always pass `color`. No longer pass `raw`.

## Result

Everything just works.
