### PR TITLE
Remove --active --no-input flags from fauna local

### DIFF
--- a/src/commands/local.mjs
+++ b/src/commands/local.mjs
@@ -47,7 +47,7 @@ async function createDatabaseSchema(argv) {
   );
   // hack to let us push schema to the local database
   argv.secret = `secret:${argv.database}:admin`;
-  await pushSchema(argv);
+  await pushSchema({ ...argv, active: true, input: false });
   logger.stderr(
     colorize(
       `[CreateDatabaseSchema] Schema for database '${argv.database}' created from directory '${argv.directory}'.`,
@@ -186,18 +186,6 @@ function buildLocalCommand(yargs) {
         alias: ["dir", "directory"],
         description:
           "Path to a local directory containing `.fsl` files for the database. Valid only if --database is set.",
-      },
-      active: {
-        description:
-          "Immediately applies the local schema to the database's active schema, skipping staging the schema. To disable this, use `--no-active` or `--active=false`.",
-        type: "boolean",
-        default: true,
-      },
-      input: {
-        description:
-          "Prompt for schema input, such as confirmation. To disable prompts, use `--no-input` or `--input=false`. Disabled prompts are useful for scripts, CI/CD, and automation workflows.",
-        default: true,
-        type: "boolean",
       },
     })
     .check((argv) => {


### PR DESCRIPTION
## Problem

`fauna local` allows you to push a schema while bootstrapping. You need to manually confirm it, and that feels a little weird given the context of the command.

## Solution

Remove `--input` and `--active` from the command, but set `input` to `false` and `active` to `true` when calling `pushSchema`.

## Result

Schema is pushed to the current active schema without a prompt.

## Testing

The existing tests where updated to match the new behavior.
