### PR TITLE
Improve DB names in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ To get started:
    hierarchy, to run the command in. For example:
 
    ```shell
-   # Runs a query in the top-level 'example' database
+   # Runs a query in the top-level 'my_db' database
    # in the 'us' Region Group. Use the default admin role.
    fauna query "Collection.all()" \
-     --database us/example
+     --database us/my_db
    ```
 
 ## Installation

--- a/src/commands/database/create.mjs
+++ b/src/commands/database/create.mjs
@@ -100,23 +100,23 @@ function buildCreateCommand(yargs) {
     .check(validateDatabaseOrSecret)
     .example([
       [
-        "$0 database create --name example --database us",
-        "Create the top-level 'example' database in the 'us' Region Group.",
+        "$0 database create --name my_db --database us",
+        "Create the top-level 'my_db' database in the 'us' Region Group.",
       ],
       [
-        "$0 database create --name my_db --database us/example",
-        "Create the 'my_db' child database directly under 'us/example'.",
+        "$0 database create --name child_db --database us/parent_db",
+        "Create the 'child_db' child database directly under 'us/parent_db'.",
       ],
       [
-        "$0 database create --name my_db --secret my-secret",
-        "Create the 'my_db' child database directly under the database scoped to a secret.",
+        "$0 database create --name child_db --secret my-secret",
+        "Create the 'child_db' child database directly under the database scoped to a secret.",
       ],
       [
-        "$0 database create --name example --database us --typechecked",
+        "$0 database create --name my_db --database us --typechecked",
         "Create a database with typechecking enabled.",
       ],
       [
-        "$0 database create --name example --database us --protected",
+        "$0 database create --name my_db --database us --protected",
         "Create a database with protected mode enabled.",
       ],
     ]);

--- a/src/commands/database/delete.mjs
+++ b/src/commands/database/delete.mjs
@@ -56,16 +56,16 @@ function buildDeleteCommand(yargs) {
     .check(validateDatabaseOrSecret)
     .example([
       [
-        "$0 database delete --name example --database us",
-        "Delete the top-level 'example' database in the 'us' Region Group.",
+        "$0 database delete --name my_db --database us",
+        "Delete the top-level 'my_db' database in the 'us' Region Group.",
       ],
       [
-        "$0 database delete --name my_db --database us/example",
-        "Delete the 'my_db' child database directly under 'us/example'.",
+        "$0 database delete --name child_db --database us/parent_db",
+        "Delete the 'child_db' child database directly under 'us/parent_db'.",
       ],
       [
-        "$0 database delete --name my_db --secret my-secret",
-        "Delete the 'my_db' child database directly under the database scoped to a secret.",
+        "$0 database delete --name child_db --secret my-secret",
+        "Delete the 'child_db' child database directly under the database scoped to a secret.",
       ],
     ]);
 }

--- a/src/commands/database/list.mjs
+++ b/src/commands/database/list.mjs
@@ -76,8 +76,8 @@ function buildListCommand(yargs) {
     .example([
       ["$0 database list", "List all top-level databases."],
       [
-        "$0 database list --database us/example",
-        "List all child databases directly under the 'us/example' database.",
+        "$0 database list --database us/parent_db",
+        "List all child databases directly under the 'us/parent_db' database.",
       ],
       [
         "$0 database list --secret my-secret",

--- a/src/commands/local.mjs
+++ b/src/commands/local.mjs
@@ -237,11 +237,11 @@ function buildLocalCommand(yargs) {
         "Map host port `1234` to container port `6789`.",
       ],
       [
-        "$0 local --database example",
-        "Start a local Fauna container with the 'example' database.",
+        "$0 local --database my_db",
+        "Start a local Fauna container with the 'my_db' database.",
       ],
       [
-        "$0 local --database example --dir /path/to/schema/dir",
+        "$0 local --database my_db --dir /path/to/schema/dir",
         "Start a local Fauna container with a database with specified schema.",
       ],
     ]);

--- a/src/commands/query.mjs
+++ b/src/commands/query.mjs
@@ -170,27 +170,27 @@ function buildQueryCommand(yargs) {
     })
     .example([
       [
-        '$0 query "Collection.all()" --database us/example',
-        "Run the query in the 'us/example' database and write the results to stdout.",
+        '$0 query "Collection.all()" --database us/my_db',
+        "Run the query in the 'us/my_db' database and write the results to stdout.",
       ],
       [
-        '$0 query "Collection.all()" --database us/example --role server',
-        "Run the query in the 'us/example' database using the 'server' role.",
+        '$0 query "Collection.all()" --database us/my_db --role server',
+        "Run the query in the 'us/my_db' database using the 'server' role.",
       ],
       [
         '$0 query "Collection.all()" --secret my-secret',
         "Run the query in the database scoped to a secret.",
       ],
       [
-        "$0 query -i /path/to/query.fql --database us/example",
+        "$0 query -i /path/to/query.fql --database us/my_db",
         "Run the query from a file.",
       ],
       [
-        'echo "1 + 1" | $0 query - --database us/example',
+        'echo "1 + 1" | $0 query - --database us/my_db',
         "Run the query from stdin.",
       ],
       [
-        "$0 query -i /path/to/queries.fql --output /tmp/result.json --database us/example",
+        "$0 query -i /path/to/query.fql --output /tmp/result.json --database us/my_db",
         "Run the query and write the results to a file.",
       ],
     ]);

--- a/src/commands/schema/abandon.mjs
+++ b/src/commands/schema/abandon.mjs
@@ -75,15 +75,15 @@ function buildAbandonCommand(yargs) {
     })
     .example([
       [
-        "$0 schema abandon --database us/example",
-        "Abandon staged schema for the 'us/example' database.",
+        "$0 schema abandon --database us/my_db",
+        "Abandon staged schema for the 'us/my_db' database.",
       ],
       [
         "$0 schema abandon --secret my-secret",
         "Abandon staged schema for the database scoped to a secret.",
       ],
       [
-        "$0 schema abandon --database us/example --no-input",
+        "$0 schema abandon --database us/my_db --no-input",
         "Run the command without input prompts.",
       ],
     ]);

--- a/src/commands/schema/commit.mjs
+++ b/src/commands/schema/commit.mjs
@@ -79,15 +79,15 @@ function buildCommitCommand(yargs) {
     })
     .example([
       [
-        "$0 schema commit --database us/example",
-        "Commit staged schema for the 'us/example' database.",
+        "$0 schema commit --database us/my_db",
+        "Commit staged schema for the 'us/my_db' database.",
       ],
       [
         "$0 schema commit --secret my-secret",
         "Commit staged schema for the database scoped to a secret.",
       ],
       [
-        "$0 schema commit --database us/example --no-input",
+        "$0 schema commit --database us/my_db --no-input",
         "Run the command without input prompts.",
       ],
     ]);

--- a/src/commands/schema/diff.mjs
+++ b/src/commands/schema/diff.mjs
@@ -132,23 +132,23 @@ function buildDiffCommand(yargs) {
     })
     .example([
       [
-        "$0 schema diff --database us/example --dir /path/to/schema/dir",
-        "Compare the 'us/example' database's staged schema to the local schema. If no schema is staged, compare the database's active schema to the local schema.",
+        "$0 schema diff --database us/my_db --dir /path/to/schema/dir",
+        "Compare the 'us/my_db' database's staged schema to the local schema. If no schema is staged, compare the database's active schema to the local schema.",
       ],
       [
-        "$0 schema diff --database us/example --dir /path/to/schema/dir --active",
-        "Compare the 'us/example' database's active schema to the local schema.",
+        "$0 schema diff --database us/my_db --dir /path/to/schema/dir --active",
+        "Compare the 'us/my_db' database's active schema to the local schema.",
       ],
       [
         "$0 schema diff --secret my-secret --dir /path/to/schema/dir --active",
         "Compare the active schema of the database scoped to a secret to the local schema.",
       ],
       [
-        "$0 schema diff --database us/example --dir /path/to/schema/dir --staged",
-        "Compare the 'us/example' database's active schema to its staged schema.",
+        "$0 schema diff --database us/my_db --dir /path/to/schema/dir --staged",
+        "Compare the 'us/my_db' database's active schema to its staged schema.",
       ],
       [
-        "$0 schema diff --database us/example --dir /path/to/schema/dir --text",
+        "$0 schema diff --database us/my_db --dir /path/to/schema/dir --text",
         "Show a text diff instead of a semantic diff.",
       ],
     ]);

--- a/src/commands/schema/pull.mjs
+++ b/src/commands/schema/pull.mjs
@@ -152,19 +152,19 @@ function buildPullCommand(yargs) {
     })
     .example([
       [
-        "$0 schema pull --database us/example --dir /path/to/schema/dir",
-        "Pull the 'us/example' database's staged schema.",
+        "$0 schema pull --database us/my_db --dir /path/to/schema/dir",
+        "Pull the 'us/my_db' database's staged schema.",
       ],
       [
         "$0 schema pull --secret my-secret --dir /path/to/schema/dir",
         "Pull the staged schema for the database scoped to a secret.",
       ],
       [
-        "$0 schema pull --database us/example --dir /path/to/schema/dir --active",
-        "Pull the 'us/example' database's active schema.",
+        "$0 schema pull --database us/my_db --dir /path/to/schema/dir --active",
+        "Pull the 'us/my_db' database's active schema.",
       ],
       [
-        "$0 schema pull --database us/example --dir /path/to/schema/dir --delete",
+        "$0 schema pull --database us/my_db --dir /path/to/schema/dir --delete",
         "Delete .fsl files in the local directory that are not part of the pulled schema.",
       ],
     ]);

--- a/src/commands/schema/push.mjs
+++ b/src/commands/schema/push.mjs
@@ -115,19 +115,19 @@ function buildPushCommand(yargs) {
     })
     .example([
       [
-        "$0 schema push --database us/example --dir /path/to/schema/dir",
-        "Stage schema changes for the 'us/example' database. If schema is already staged, replace the staged schema.",
+        "$0 schema push --database us/my_db --dir /path/to/schema/dir",
+        "Stage schema changes for the 'us/my_db' database. If schema is already staged, replace the staged schema.",
       ],
       [
         "$0 schema push --secret my-secret --dir /path/to/schema/dir",
         "Stage schema changes for the database scoped to a secret. If schema is already staged, replace the staged schema.",
       ],
       [
-        "$0 schema push --database us/example --dir /path/to/schema/dir --active",
-        "Immediately apply changes to the 'us/example' database's active schema.",
+        "$0 schema push --database us/my_db --dir /path/to/schema/dir --active",
+        "Immediately apply changes to the 'us/my_db' database's active schema.",
       ],
       [
-        "$0 schema push --database us/example --dir /path/to/schema/dir --no-input",
+        "$0 schema push --database us/my_db --dir /path/to/schema/dir --no-input",
         "Run the command without input prompts.",
       ],
     ]);

--- a/src/commands/schema/status.mjs
+++ b/src/commands/schema/status.mjs
@@ -85,8 +85,8 @@ function buildStatusCommand(yargs) {
     .options(localSchemaOptions)
     .example([
       [
-        "$0 schema status --database us/example",
-        "Get the staged schema status for the 'us/example' database.",
+        "$0 schema status --database us/my_db",
+        "Get the staged schema status for the 'us/my_db' database.",
       ],
       [
         "$0 schema status --secret my-secret",

--- a/src/commands/shell.mjs
+++ b/src/commands/shell.mjs
@@ -223,12 +223,12 @@ function buildShellCommand(yargs) {
   return yargsWithCommonConfigurableQueryOptions(yargs)
     .example([
       [
-        "$0 shell --database us/example",
-        "Run queries in the 'us/example' database.",
+        "$0 shell --database us/my_db",
+        "Run queries in the 'us/my_db' database.",
       ],
       [
-        "$0 shell --database us/example --role server",
-        "Run queries in the 'us/example' database using the 'server' role.",
+        "$0 shell --database us/my_db --role server",
+        "Run queries in the 'us/my_db' database using the 'server' role.",
       ],
       [
         "$0 shell --secret my-secret",


### PR DESCRIPTION
## Problem

This is strictly a QoL improvement. No real problem here.

* When using `fauna database create/delete`, the relationship can get confusing between child and parent DBs, particularly when using a `--secret`.
* Using `example` as the default database name is fine but it's not descriptive.


## Solution

* Where applicable,  use `child_db` and `parent_db` in examples so it's more obvious.
* Use the shorter but more descriptive `my_db` as the default database name. The name also indicates that underscores are supported in database names.
