### PR TITLE
Improve `--typechecked` help text

### DIFF
--- a/src/commands/database/create.mjs
+++ b/src/commands/database/create.mjs
@@ -85,7 +85,7 @@ function buildCreateCommand(yargs) {
       typechecked: {
         type: "boolean",
         description:
-          "Enable typechecking for the database. Defaults to the typechecking setting of the parent database.",
+          "Enable typechecking for the database. Use --no-typechecked to disable. Defaults to enabled for top-level databases. Inherits the parent database's setting for child databases.",
       },
       protected: {
         type: "boolean",

--- a/src/commands/local.mjs
+++ b/src/commands/local.mjs
@@ -70,6 +70,15 @@ async function createDatabase(argv) {
       color,
     }),
   );
+
+  // In the docker container, typechecked will be false by default if not set.
+  // We need to set it to true if it's not set. We can't do it in the options,
+  // because we don't want to validate it unless --database is set.
+  let typechecked = argv.typechecked;
+  if (argv.database && argv.typechecked === undefined) {
+    typechecked = true;
+  }
+
   try {
     const db = await runQuery({
       secret: "secret",
@@ -78,7 +87,7 @@ async function createDatabase(argv) {
       let name = ${argv.database}
       let database = Database.byName(name)
       let protected = ${argv.protected ?? null}
-      let typechecked = ${argv.typechecked ?? null}
+      let typechecked = ${typechecked}
       let priority = ${argv.priority ?? null}
       if (database == null) {
         Database.create({
@@ -169,7 +178,7 @@ function buildLocalCommand(yargs) {
         describe:
           "Enable typechecking for the database. Use --no-typechecked to disable. Valid only if --database is set.",
         type: "boolean",
-        default: true,
+        default: undefined,
       },
       protected: {
         describe:
@@ -208,7 +217,7 @@ function buildLocalCommand(yargs) {
           "--interval must be greater than or equal to 0.",
         );
       }
-      if (argv.typechecked && !argv.database) {
+      if (argv.typechecked !== undefined && !argv.database) {
         throw new ValidationError(
           "--typechecked can only be set if --database is set.",
         );

--- a/src/commands/local.mjs
+++ b/src/commands/local.mjs
@@ -167,8 +167,9 @@ function buildLocalCommand(yargs) {
       },
       typechecked: {
         describe:
-          "Enable typechecking for the database. Use --no-typechecked to disable. Defaults to enabled. Valid only if --database is set.",
+          "Enable typechecking for the database. Use --no-typechecked to disable. Valid only if --database is set.",
         type: "boolean",
+        default: true,
       },
       protected: {
         describe:

--- a/src/commands/local.mjs
+++ b/src/commands/local.mjs
@@ -167,7 +167,7 @@ function buildLocalCommand(yargs) {
       },
       typechecked: {
         describe:
-          "Enable typechecking for the database. Valid only if --database is set.",
+          "Enable typechecking for the database. Use --no-typechecked to disable. Defaults to enabled for top-level databases. Inherits the parent database's setting for child databases. Valid only if --database is set.",
         type: "boolean",
       },
       protected: {

--- a/src/commands/local.mjs
+++ b/src/commands/local.mjs
@@ -176,7 +176,7 @@ function buildLocalCommand(yargs) {
       },
       typechecked: {
         describe:
-          "Enable typechecking for the database. Use --no-typechecked to disable. Valid only if --database is set.",
+          "Enable typechecking for the database. Use --no-typechecked to disable. Defaults to enabled. Valid only if --database is set.",
         type: "boolean",
         default: undefined,
       },

--- a/src/commands/local.mjs
+++ b/src/commands/local.mjs
@@ -167,7 +167,7 @@ function buildLocalCommand(yargs) {
       },
       typechecked: {
         describe:
-          "Enable typechecking for the database. Use --no-typechecked to disable. Defaults to enabled for top-level databases. Inherits the parent database's setting for child databases. Valid only if --database is set.",
+          "Enable typechecking for the database. Use --no-typechecked to disable. Defaults to enabled. Valid only if --database is set.",
         type: "boolean",
       },
       protected: {


### PR DESCRIPTION
Ticket(s): FE-###

## Problem

The following isn't clear for the `--typechecked` help text:

* For top-level databases, typechecking defaults to `true`  if `--typechecked `is unspecified.
* For child databases, the database inherits typechecking from the parent DB if `--typechecked` is unspecified.
* You can disable typechecking with `--no-typechecked`.

## Solution

Edit the `--typechecked` help text for clarity.

## Result

Fewer surprises when creating databases.

