### PR TITLE
Do not support --active and --input in fauna local

### DIFF
--- a/src/commands/local.mjs
+++ b/src/commands/local.mjs
@@ -47,7 +47,7 @@ async function createDatabaseSchema(argv) {
   );
   // hack to let us push schema to the local database
   argv.secret = `secret:${argv.database}:admin`;
-  await pushSchema(argv);
+  await pushSchema({ ...argv, input: false, active: true });
   logger.stderr(
     colorize(
       `[CreateDatabaseSchema] Schema for database '${argv.database}' created from directory '${argv.directory}'.`,
@@ -185,17 +185,6 @@ function buildLocalCommand(yargs) {
         alias: ["dir", "directory"],
         description:
           "Path to a local directory containing .fsl files for the database. Valid only if --database is set.",
-      },
-      active: {
-        description:
-          "Apply the local schema to the database's active schema. Skips staging the schema. Use --no-active to disable.",
-        type: "boolean",
-        default: true,
-      },
-      input: {
-        description: "Prompt for input. Use --no-input to disable.",
-        default: true,
-        type: "boolean",
       },
     })
     .check((argv) => {

--- a/test/local.mjs
+++ b/test/local.mjs
@@ -24,8 +24,6 @@ describe("local command", () => {
     gatherFSL,
     confirm;
 
-  const diffString =
-    "\u001b[1;34m* Modifying collection `Customer`\u001b[0m at collections.fsl:2:1:\n  * Defined fields:\n\u001b[31m  - drop field `.age`\u001b[0m\n\n";
 
   const fsl = [
     {
@@ -180,32 +178,18 @@ Please pass a --host-port other than '8443'.",
         data: JSON.stringify({ name: "Foo" }, null, 2),
       });
 
-      // The first call pings the container, then the second creates the diff...
-      fetch
-        .onCall(1)
-        .resolves(
-          f({
-            version: 1728675598430000,
-            diff: diffString,
-          }),
-        )
-        .onCall(2)
-        .resolves(
-          f({
-            version: 1728675598430000,
-          }),
-        );
+      // The first call pings the container, then the second updates the schema.
+      fetch.onCall(1).resolves(
+        f({
+          version: 1728675598430000,
+        }),
+      );
 
       await run(`local --no-color ${args}`, container);
 
       expect(gatherFSL).to.have.been.calledWith("bar");
-      expect(fetch).to.have.been.calledWith(`${baseUrl}/diff?staged=false`, {
-        method: "POST",
-        headers: { AUTHORIZATION: "Bearer secret:Foo:admin" },
-        body: reformatFSL(fsl),
-      });
       expect(fetch).to.have.been.calledWith(
-        `${baseUrl}/update?staged=false&version=1728675598430000`,
+        `${baseUrl}/update?force=true&staged=false`,
         {
           method: "POST",
           headers: { AUTHORIZATION: "Bearer secret:Foo:admin" },
@@ -216,65 +200,6 @@ Please pass a --host-port other than '8443'.",
       expect(written).to.contain(
         "[CreateDatabaseSchema] Schema for database 'Foo' created from directory './bar'.",
       );
-    });
-  });
-
-  [
-    "--database Foo --dir ./bar --no-active",
-    "--database Foo --directory ./bar --no-active",
-    "--database Foo --project-directory ./bar --no-active",
-  ].forEach((args) => {
-    it(`Creates a staged schema without forcing if requested using ${args}`, async () => {
-      const baseUrl = "http://0.0.0.0:8443/schema/1";
-      const { runQuery } = container.resolve("faunaClientV10");
-
-      confirm.resolves(true);
-      setupCreateContainerMocks();
-      runQuery.resolves({
-        data: JSON.stringify({ name: "Foo" }, null, 2),
-      });
-
-      // The first call pings the container, then the second creates the diff...
-      fetch
-        .onCall(1)
-        .resolves(
-          f({
-            version: 1728675598430000,
-            diff: diffString,
-          }),
-        )
-        .onCall(2)
-        .resolves(
-          f({
-            version: 1728675598430000,
-          }),
-        );
-
-      await run(`local --no-color ${args}`, container);
-
-      expect(gatherFSL).to.have.been.calledWith("bar");
-      expect(fetch).to.have.been.calledWith(`${baseUrl}/diff?staged=true`, {
-        method: "POST",
-        headers: { AUTHORIZATION: "Bearer secret:Foo:admin" },
-        body: reformatFSL(fsl),
-      });
-      expect(fetch).to.have.been.calledWith(
-        `${baseUrl}/update?staged=true&version=1728675598430000`,
-        {
-          method: "POST",
-          headers: { AUTHORIZATION: "Bearer secret:Foo:admin" },
-          body: reformatFSL(fsl),
-        },
-      );
-      expect(logger.stdout).to.have.been.calledWith("Proposed diff:\n");
-      const written = stderrStream.getWritten();
-      expect(written).to.contain(
-        "[CreateDatabaseSchema] Schema for database 'Foo' created from directory './bar'.",
-      );
-      expect(confirm).to.have.been.calledWith(
-        sinon.match.has("message", "Stage the above changes?"),
-      );
-      expect(logger.stdout).to.have.been.calledWith(diffString);
     });
   });
 


### PR DESCRIPTION
## Problem

When bootstrapping a new database with `fauna local`, we expose the `--active` and `--no-input` flags from `fauna schema push`. In this context, these flags are confusing because:

* --active: Lets you stage or force push a schema
* --input: Lets you turn off confirmations

In the context of creating a new empty database and applying a schema, neither flag makes much sense at the moment. Users can still do normal schema operations against the container via `fauna schema`.

## Solution

Remove `--active` and `--input` and pass them as `true` and `false` respectively to the push schema command.

## Result

![Screenshot 2024-12-18 at 10 11 33 AM](https://github.com/user-attachments/assets/43c8f5ce-c999-474d-82f1-f8bfd29a581a)

## Testing

Removed tests for the other workflows we no longer support.
