### PR TITLE
Replace --project-directory with --fsl-directory

### DIFF
--- a/src/commands/local.mjs
+++ b/src/commands/local.mjs
@@ -190,7 +190,7 @@ function buildLocalCommand(yargs) {
         description:
           "User-defined priority for the database. Valid only if --database is set.",
       },
-      "project-directory": {
+      "fsl-directory": {
         type: "string",
         alias: ["dir", "directory"],
         description:

--- a/src/commands/schema/schema.mjs
+++ b/src/commands/schema/schema.mjs
@@ -9,7 +9,7 @@ import pushCommand from "./push.mjs";
 import statusCommand from "./status.mjs";
 
 export const localSchemaOptions = {
-  "project-directory": {
+  "fsl-directory": {
     alias: ["directory", "dir"],
     type: "string",
     description:

--- a/test/local.mjs
+++ b/test/local.mjs
@@ -163,7 +163,7 @@ Please pass a --host-port other than '8443'.",
   [
     "--database Foo --dir ./bar ",
     "--database Foo --directory ./bar ",
-    "--database Foo --project-directory ./bar",
+    "--database Foo --fsl-directory ./bar",
   ].forEach((args) => {
     it("Creates a schema if requested", async () => {
       const baseUrl = "http://0.0.0.0:8443/schema/1";


### PR DESCRIPTION
## Problem

`--project-directory` in schema-related commands is leftover from when we had a project file. The current version of the CLI supports a much more flexible configuration file, and the "project" part of this flag is out-of-date.

## Solution

Rename `--project-directory` to `--fsl-directory`. We maintain the current aliases for the flag.

## Result

![Screenshot 2024-12-18 at 11 38 25 AM](https://github.com/user-attachments/assets/8eae0c35-c8e4-4827-bfb1-45cc4056c676)

## Testing

Most tests rely on the aliases and not `--project-directory`, but impacted tests have been updated.