### PR TITLE
Fix colorizing summaries when outputted via --include

### DIFF
--- a/src/lib/fauna-client.mjs
+++ b/src/lib/fauna-client.mjs
@@ -1,12 +1,18 @@
 //@ts-check
 
+import stripAnsi from "strip-ansi";
+
 import { container } from "../cli.mjs";
 import { isUnknownError } from "./errors.mjs";
 import { faunaToCommandError } from "./fauna.mjs";
 import { faunadbToCommandError } from "./faunadb.mjs";
 import { colorize, Format } from "./formatting/colorize.mjs";
 
-const SUMMARY_FQL_REGEX = /^(\s\s\|)|(\d\s\|)/;
+/**
+ * Regex to match the FQL diagnostic line.
+ * @type {RegExp}
+ */
+export const FQL_DIAGNOSTIC_REGEX = /^(\s{2,}\|)|(\s*\d{1,}\s\|)/;
 
 /**
  * Gets a secret for the current credentials.
@@ -168,7 +174,7 @@ export const formatQuerySummary = (summary) => {
 
   try {
     const lines = summary.split("\n").map((line) => {
-      if (!line.match(SUMMARY_FQL_REGEX)) {
+      if (!line.match(FQL_DIAGNOSTIC_REGEX)) {
         return line;
       }
       return colorize(line, { format: Format.FQL });
@@ -228,14 +234,16 @@ export const formatQueryInfo = (response, { apiVersion, color, include }) => {
 
     if (Object.keys(queryInfoToDisplay).length === 0) return "";
 
-    const SUMMARY_IN_QUERY_INFO_FQL_REGEX = /^(\s\s\s\s\|)|(\d\s\|)/;
+    // We colorize the entire query info object as YAML, but then need to
+    // colorize the diagnostic lines individually. To simplify this, we
+    // strip the ansi when we're checking if the line is a diagnostic line.
     const colorized = colorize(queryInfoToDisplay, {
       color,
       format: Format.YAML,
     })
       .split("\n")
       .map((line) => {
-        if (!line.match(SUMMARY_IN_QUERY_INFO_FQL_REGEX)) {
+        if (!stripAnsi(line).match(FQL_DIAGNOSTIC_REGEX)) {
           return line;
         }
         return colorize(line, { format: Format.FQL });

--- a/test/lib/fauna-client.mjs
+++ b/test/lib/fauna-client.mjs
@@ -1,0 +1,30 @@
+import { expect } from "chai";
+
+import { FQL_DIAGNOSTIC_REGEX } from "../../src/lib/fauna-client.mjs";
+
+describe("FQL_DIAGNOSTIC_REGEX", () => {
+  const validLines = ["1 |", "12 |", "123 |", "  |", "   |", "    |", " 1 |"];
+
+  const invalidLines = [
+    "normal text",
+    "1  |",
+    "| invalid",
+    "abc |",
+    "|",
+    "1|",
+    " | ",
+    "text | more",
+  ];
+
+  validLines.forEach((line) => {
+    it(`should match diagnostic line: "${line}"`, () => {
+      expect(line).to.match(FQL_DIAGNOSTIC_REGEX);
+    });
+  });
+
+  invalidLines.forEach((line) => {
+    it(`should not match non-diagnostic line: "${line}"`, () => {
+      expect(line).to.not.match(FQL_DIAGNOSTIC_REGEX);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

I noticed summary outputs do not fully colorize the FQL diagnostic help/hints/text when used with `--include`.

![Screenshot 2024-12-18 at 3 44 33 PM](https://github.com/user-attachments/assets/ec07944c-d784-4499-a57c-85fbf607e332)

Specifically, all "|" and "^" should be red the above example.

## Solution

Update the regular expression used for summary colorization to be the same as query errors. To do this, I needed to strip ansi when checking if it is a fql diagnostic line. This isn't ideal, but it's out of scope to revisit the yaml formatting for these at the moment.

While I was here, I expanded the regex to support lines >9.

## Result

Summaries:
![Screenshot 2024-12-18 at 3 44 06 PM](https://github.com/user-attachments/assets/1c2dd392-2122-49e4-91c9-e59ff458917a)

Errors
![Screenshot 2024-12-18 at 3 45 02 PM](https://github.com/user-attachments/assets/a7fdec18-9cc6-475b-9f72-37948398b741)

## Testing

I added a regex test suite for how we detect fql diagnostic lines.
