### PR TITLE
Fail 'fauna local' if docker is not running

### DIFF
--- a/src/config/setup-test-container.mjs
+++ b/src/config/setup-test-container.mjs
@@ -92,6 +92,7 @@ export function setupTestContainer() {
       modem: {
         followProgress: stub(),
       },
+      ping: stub(),
       pull: stub(),
     }),
     credentials: awilix.asClass(stub()).singleton(),

--- a/src/lib/docker-containers.mjs
+++ b/src/lib/docker-containers.mjs
@@ -28,6 +28,19 @@ export async function ensureContainerRunning({
   color: _color,
 }) {
   color = _color;
+
+  // Check if the docker service is available before we point folks to Support
+  // for any issues later in the process.
+  const docker = container.resolve("docker");
+  try {
+    await docker.ping();
+  } catch (error) {
+    throw new CommandError(
+      `[StartContainer] Docker service is not available. Make sure that Docker is running.`,
+      { cause: error },
+    );
+  }
+
   if (pull) {
     await pullImage(IMAGE_NAME);
   }


### PR DESCRIPTION
## Problem

If Docker is not running and you run `fauna local`, it will error when it tries to pull the image and tell you to report to Support.

![image](https://github.com/user-attachments/assets/953f1f35-34ae-41b9-8abb-93dc04697bc7)

## Solution

Use `docker.ping()` to check if the service is running before trying to pull the latest image. Then we can have a separate error for when the service is simply not running, and keep the existing error if anything else happens when pulling the image.

## Result

![image](https://github.com/user-attachments/assets/efedeb2c-d4d8-44eb-97fb-6083e3e43b56)

## Testing

Added a new test to differentiate pull errors from ping errors.
