### PR TITLE
Pick up rename of @fauna/typescript -> @fauna/ts-dev-utils

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,4 @@
-import { config as defaultConfig } from "@fauna/typescript/config/js/eslint.config.js";
+import { config as defaultConfig } from "@fauna/ts-dev-utils/config/js/eslint.config.js";
 import * as espree from "espree";
 import globals from "globals";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.1.0",
         "@eslint/js": "^9.16.0",
-        "@fauna/typescript": "^0.0.12",
+        "@fauna/ts-dev-utils": "^0.0.16",
         "@inquirer/testing": "^2.1.7",
         "@types/chai": "^5.0.0",
         "@types/mocha": "^10.0.1",
@@ -238,10 +238,10 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@fauna/typescript": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@fauna/typescript/-/typescript-0.0.12.tgz",
-      "integrity": "sha512-8eAq6RKaKDnUAY5AjoSgfZ6zT4TTDrNG/JkmrhQHrQjj6ScosqMEnCbPBkRhUWzhzIITDQwx5Rcs6VRGjjKhqw==",
+    "node_modules/@fauna/ts-dev-utils": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@fauna/ts-dev-utils/-/ts-dev-utils-0.0.16.tgz",
+      "integrity": "sha512-/s+fxVVXPep7XezSlYfEe9fvhJAaEhpeHeeDArAAztMEboxApeTzbblta/yG2U9MTGR6psavQ3SrMTdAep5MWw==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -1444,14 +1444,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/collect-mentions/-/collect-mentions-2.0.1.tgz",
       "integrity": "sha512-3/MkmIZDerSapDxlRLGJ2M38Zs2+GMJ6i3X4d9ilyB82PcSFVzA5VVH6A6SKXPIuzcyeE+xAS+4XdY0O1MVAxQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "mentions-regex": "^2.0.3"
-      },
-      "engines": {
-        "node": ">=20"
-      }
+      "dev": true
     },
     "node_modules/color-convert": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.1.0",
     "@eslint/js": "^9.16.0",
-    "@fauna/typescript": "^0.0.12",
+    "@fauna/ts-dev-utils": "^0.0.16",
     "@inquirer/testing": "^2.1.7",
     "@types/chai": "^5.0.0",
     "@types/mocha": "^10.0.1",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,4 +1,4 @@
-import basePrettierConfig from "@fauna/typescript/config/prettierrc.js";
+import basePrettierConfig from "@fauna/ts-dev-utils/config/prettierrc.js";
 
 /**
  * @type {import("prettier").Config}


### PR DESCRIPTION

## Problem

@fauna/typescript was renamed to @fauna/ts-dev-utils for clarity for both developers and SEO.
## Solution

Pick up this change.

## Result

We're using the real ts dev utils.

## Testing

Build and test in CI here.
