### PR TITLE
Align fauna local error messaging casing with command argument casing for 'host-port'

### DIFF
--- a/src/lib/docker-containers.mjs
+++ b/src/lib/docker-containers.mjs
@@ -165,8 +165,8 @@ async function findContainer({ containerName, hostPort }) {
   if (diffPort) {
     throw new CommandError(
       `[FindContainer] Container '${containerName}' is already \
-in use on hostPort '${diffPort.PublicPort}'. Please use a new name via \
-arguments --name <newName> --hostPort ${hostPort} to start the container.`,
+in use on host-port '${diffPort.PublicPort}'. Please use a new name via \
+arguments --name <newName> --host-port ${hostPort} to start the container.`,
     );
   }
   return result;
@@ -222,7 +222,7 @@ async function createContainer({
   const occupied = await isPortOccupied({ hostIp, hostPort });
   if (occupied) {
     throw new CommandError(
-      `[StartContainer] The hostPort '${hostPort}' on IP '${hostIp}' is already occupied. \
+      `[StartContainer] The host-port '${hostPort}' on IP '${hostIp}' is already occupied. \
 Please pass a --host-port other than '${hostPort}'.`,
     );
   }

--- a/test/commands/local.mjs
+++ b/test/commands/local.mjs
@@ -130,7 +130,7 @@ describe("local command", () => {
 
     // Assertions
     expect(written).to.contain(
-      "[StartContainer] The hostPort '8443' on IP '0.0.0.0' is already occupied. \
+      "[StartContainer] The host-port '8443' on IP '0.0.0.0' is already occupied. \
 Please pass a --host-port other than '8443'.",
     );
     expect(written).not.to.contain("fauna local");
@@ -567,8 +567,8 @@ https://support.fauna.com/hc/en-us/requests/new`,
     expect(logsStub).not.to.have.been.called;
     const written = stderrStream.getWritten();
     expect(written).to.contain(
-      `[FindContainer] Container 'faunadb' is already in use on hostPort '9999'. \
-Please use a new name via arguments --name <newName> --hostPort ${desiredPort} \
+      `[FindContainer] Container 'faunadb' is already in use on host-port '9999'. \
+Please use a new name via arguments --name <newName> --host-port ${desiredPort} \
 to start the container.`,
     );
     expect(written).not.to.contain("An unexpected");


### PR DESCRIPTION
## Problem

Error messages in `fauna local` refer to `hostPort`. Our command documents `host-port`. Although `--hostPort` is acceptable, updating the error messages to refer to `host-port` for consistency.

## Solution

Although `--hostPort` is acceptable, updating the error messages to refer to `host-port` for consistency.

## Result

More consistent text.

## Testing

Ran the tests