### PR TITLE
Bump package version to v4.0.0-beta1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fauna-shell",
   "description": "faunadb shell",
-  "version": "4.0.0-beta",
+  "version": "4.0.0-beta1",
   "author": "Fauna",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Problem

We've added support to beta export commands, and want to release them in a new beta version of the package.

## Solution

Bumped the current package version to v4.0.0-beta1. We could also make it v4.0.0-beta2 if we wanted, but since we didn't have a beta1 yet, that's what I chose.
