### PR TITLE
Export: Use AWS example bucket in help strings

### DIFF
--- a/src/commands/export/create.mjs
+++ b/src/commands/export/create.mjs
@@ -54,23 +54,23 @@ async function createS3Export(argv) {
 
 const sharedExamples = [
   [
-    "$0 export create s3 --database us/my_db --bucket my-bucket --path exports/my_db",
-    "Export the 'us-std/my_db' database to the 'exports/my_db' path of the 'my-bucket' S3 bucket. Outputs the export ID.",
+    "$0 export create s3 --database us/my_db --bucket doc-example-bucket --path exports/my_db",
+    "Export the 'us-std/my_db' database to the 'exports/my_db' path of the 'doc-example-bucket' S3 bucket. Outputs the export ID.",
   ],
   [
-    "$0 export create s3 --database us/my_db --bucket my-bucket --path my-prefix --json",
+    "$0 export create s3 --database us/my_db --bucket doc-example-bucket --path my-prefix --json",
     "Output the full JSON of the export request.",
   ],
   [
-    "$0 export create s3 --database us/my_db --bucket my-bucket --path my-prefix --collection my-collection",
+    "$0 export create s3 --database us/my_db --bucket doc-example-bucket --path my-prefix --collection my-collection",
     "Export the 'my-collection' collection only.",
   ],
   [
-    "$0 export create s3 --database us/my_db --bucket my-bucket --path my-prefix --format tagged",
+    "$0 export create s3 --database us/my_db --bucket doc-example-bucket --path my-prefix --format tagged",
     "Encode the export's document data using the 'tagged' format.",
   ],
   [
-    "$0 export create s3 --database us/my_db --bucket my-bucket --path my-prefix --wait --max-wait 180",
+    "$0 export create s3 --database us/my_db --bucket doc-example-bucket --path my-prefix --wait --max-wait 180",
     "Wait for the export to complete or fail before exiting. Waits up to 180 minutes.",
   ],
 ];

--- a/src/commands/export/export.mjs
+++ b/src/commands/export/export.mjs
@@ -47,8 +47,8 @@ function buildExportCommand(yargs) {
     .command(getCommand)
     .example([
       [
-        "$0 export create s3 --database us/my_db --bucket my-bucket --path exports/my_db",
-        "Export the 'us-std/my_db' database to the 'exports/my_db' path of the 'my-bucket' S3 bucket. Outputs the export ID.",
+        "$0 export create s3 --database us/my_db --bucket doc-example-bucket --path exports/my_db",
+        "Export the 'us-std/my_db' database to the 'exports/my_db' path of the 'doc-example-bucket' S3 bucket. Outputs the export ID.",
       ],
       [
         "$0 export get 123456789",


### PR DESCRIPTION
## Problem

We use `my-bucket` as an example in help text. This is a public bucket. If a user doesn't update the example, they could leak data.

## Solution

Use the `doc-example-bucket` example that AWS uses.

## Result

No leaks. 🤞 

## Testing

`npm run test:local` is 🟢 .
