### PR TITLE
Alias --wait on export commands to --watch and -w

### DIFF
--- a/src/commands/export/wait.mjs
+++ b/src/commands/export/wait.mjs
@@ -13,12 +13,13 @@ const MAX_WAIT_MINS = 60 * 2; // 2 hours
 const WAITING_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 export const WAIT_OPTIONS = {
   wait: {
+    alias: ["w", "watch"],
     type: "boolean",
     required: false,
     description:
       "Wait for the export to complete or fail before exiting. Use '--max-wait' to set a timeout.",
   },
-  maxWait: {
+  "max-wait": {
     type: "number",
     required: false,
     description: "Maximum wait time in minutes. Defaults to 120 minutes.",


### PR DESCRIPTION
## Problem

When using this command, we've seen folks use `--watch` instead of `--wait`.

## Solution

`--wait` is probably the most accurate based on some internal discussions, but we can just support both via aliases. 

## Result

`--wait`, `--watch`, and `-w` will all cause the `export create` and `export get` commands to block until an export hits a terminal state.
