### PR TITLE
[DOCS-4068] Bump Node vers to v22

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can use the CLI to:
 
 ## Requirements
 
-- [Node.js](https://nodejs.org/en/download/package-manager) v20.x or later.
+- [Node.js](https://nodejs.org/en/download/package-manager) v22.x or later.
 - A Fauna account. You can sign up for a free account at https://dashboard.fauna.com/register.
 
 ## Quick start

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript": "^5.6.3"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "files": [
     "/dist"


### PR DESCRIPTION
## Problem

The `node:sea` module has issues running in Node v20.10.0.

## Solution

Bump the required Node version to v22, the current LTS version.

## Testing

`npm run test:local` is 🟢 .
