### PR TITLE
update package.json engine

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: ["20.18", "22.x"]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ You can use the CLI to:
 
 ## Requirements
 
-- [Node.js](https://nodejs.org/en/download/package-manager) v20.x or later.
+- [Node.js](https://nodejs.org/en/download/package-manager) v20.18 or later.
+  - [Node.js](https://nodejs.org/en/download/package-manager) v22 or later recommended.
 - A Fauna account. You can sign up for a free account at https://dashboard.fauna.com/register.
 
 ## Quick start

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fauna-shell",
-  "version": "4.0.0-beta",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fauna-shell",
-      "version": "4.0.0-beta",
+      "version": "4.0.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
@@ -59,7 +59,7 @@
         "typescript": "^5.6.3"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=20.18.0"
       }
     },
     "node_modules/@balena/dockerignore": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript": "^5.6.3"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.18.0"
   },
   "files": [
     "/dist"


### PR DESCRIPTION
more accurately describe the minimum functional version of node required to run the CLI.

also modifies the tests to run on our minimum supported node version to ensure we don't have regressions in v20.18 that don't show up in v20.x.