### PR TITLE
Remove --json flag on commands that do not support it

### DIFF
--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -187,12 +187,6 @@ function buildYargs(argvInput) {
         description: "Profile from the CLI config file to use.",
         group: "Config:",
       },
-      json: {
-        type: "boolean",
-        description: "Output the results as JSON.",
-        default: false,
-        group: "Output:",
-      },
       quiet: {
         type: "boolean",
         description:

--- a/src/commands/database/create.mjs
+++ b/src/commands/database/create.mjs
@@ -7,6 +7,7 @@ import { faunaToCommandError } from "../../lib/fauna.mjs";
 import { getSecret, retryInvalidCredsOnce } from "../../lib/fauna-client.mjs";
 import { colorize, Format } from "../../lib/formatting/colorize.mjs";
 import { validateDatabaseOrSecret } from "../../lib/middleware.mjs";
+import { FORMAT_OPTIONS } from "../../lib/options.mjs";
 
 async function runCreateQuery(secret, argv) {
   const { fql } = container.resolve("fauna");
@@ -77,6 +78,7 @@ async function createDatabase(argv) {
 
 function buildCreateCommand(yargs) {
   return yargs
+    .options(FORMAT_OPTIONS)
     .options({
       name: {
         type: "string",

--- a/src/commands/database/list.mjs
+++ b/src/commands/database/list.mjs
@@ -4,6 +4,7 @@ import chalk from "chalk";
 import { container } from "../../config/container.mjs";
 import { faunaToCommandError } from "../../lib/fauna.mjs";
 import { colorize, Format } from "../../lib/formatting/colorize.mjs";
+import { FORMAT_OPTIONS } from "../../lib/options.mjs";
 
 async function listDatabasesWithAccountAPI(argv) {
   const { pageSize, database } = argv;
@@ -49,8 +50,9 @@ export async function listDatabases(argv) {
 async function doListDatabases(argv) {
   const logger = container.resolve("logger");
   const res = await listDatabases(argv);
+  const { json, color, secret } = argv;
 
-  if (argv.secret) {
+  if (secret) {
     logger.stderr(
       chalk.yellow(
         "Warning: Full database paths are not available when using --secret. Use --database if a full path, including the region group identifier and hierarchy, is needed.",
@@ -58,12 +60,12 @@ async function doListDatabases(argv) {
     );
   }
 
-  if (argv.json) {
-    logger.stdout(colorize(res, { format: Format.JSON, color: argv.color }));
+  if (json) {
+    logger.stdout(colorize(res, { format: Format.JSON, color: color }));
   } else {
     res.forEach(({ path, name }) => {
       logger.stdout(
-        colorize(path ?? name, { format: Format.CSV, color: argv.color }),
+        colorize(path ?? name, { format: Format.CSV, color: color }),
       );
     });
   }
@@ -71,6 +73,7 @@ async function doListDatabases(argv) {
 
 function buildListCommand(yargs) {
   return yargs
+    .options(FORMAT_OPTIONS)
     .options({
       "page-size": {
         type: "number",

--- a/src/commands/export/create.mjs
+++ b/src/commands/export/create.mjs
@@ -3,7 +3,7 @@
 import { container } from "../../config/container.mjs";
 import { ValidationError } from "../../lib/errors.mjs";
 import { colorize, Format } from "../../lib/formatting/colorize.mjs";
-import { DATABASE_PATH_OPTIONS } from "../../lib/options.mjs";
+import { DATABASE_PATH_OPTIONS, FORMAT_OPTIONS } from "../../lib/options.mjs";
 import { WAIT_OPTIONS, waitUntilExportIsReady } from "./wait.mjs";
 
 async function createS3Export(argv) {
@@ -86,6 +86,7 @@ const S3_URI_REGEX = /^s3:\/\/[^/]+\/.+$/;
 
 function buildCreateS3ExportCommand(yargs) {
   return yargs
+    .options(FORMAT_OPTIONS)
     .options({
       destination: {
         alias: ["uri", "destination-uri"],

--- a/src/commands/export/get.mjs
+++ b/src/commands/export/get.mjs
@@ -1,5 +1,6 @@
 import { container } from "../../config/container.mjs";
 import { colorize, Format } from "../../lib/formatting/colorize.mjs";
+import { FORMAT_OPTIONS } from "../../lib/options.mjs";
 import { WAIT_OPTIONS, waitUntilExportIsReady } from "./wait.mjs";
 
 async function getExport(argv) {
@@ -34,6 +35,7 @@ function buildGetExportCommand(yargs) {
       required: true,
     })
     .options(WAIT_OPTIONS)
+    .options(FORMAT_OPTIONS)
     .example([
       [
         "$0 export get 123456789",

--- a/src/commands/export/list.mjs
+++ b/src/commands/export/list.mjs
@@ -1,6 +1,7 @@
 import { container } from "../../config/container.mjs";
 import { EXPORT_STATES } from "../../lib/account-api.mjs";
 import { colorize, Format } from "../../lib/formatting/colorize.mjs";
+import { FORMAT_OPTIONS } from "../../lib/options.mjs";
 
 const COLUMN_SEPARATOR = "\t";
 const COLLECTION_SEPARATOR = ",";
@@ -42,6 +43,7 @@ async function listExports(argv) {
 
 function buildListExportsCommand(yargs) {
   return yargs
+    .options(FORMAT_OPTIONS)
     .options({
       "max-results": {
         alias: "max",

--- a/src/commands/query.mjs
+++ b/src/commands/query.mjs
@@ -19,6 +19,7 @@ import {
   ACCOUNT_OPTIONS,
   CORE_OPTIONS,
   DATABASE_PATH_OPTIONS,
+  FORMAT_OPTIONS,
   QUERY_OPTIONS,
 } from "../lib/options.mjs";
 import { isTTY, resolveFormat } from "../lib/utils.mjs";
@@ -157,6 +158,7 @@ function buildQueryCommand(yargs) {
     .options(DATABASE_PATH_OPTIONS)
     .options(CORE_OPTIONS)
     .options(QUERY_OPTIONS)
+    .options(FORMAT_OPTIONS)
     .middleware(resolveIncludeOptions)
     .positional("fql", {
       type: "string",

--- a/src/commands/shell.mjs
+++ b/src/commands/shell.mjs
@@ -16,6 +16,7 @@ import {
   ACCOUNT_OPTIONS,
   CORE_OPTIONS,
   DATABASE_PATH_OPTIONS,
+  FORMAT_OPTIONS,
   QUERY_INFO_CHOICES,
   QUERY_OPTIONS,
 } from "../lib/options.mjs";
@@ -229,6 +230,7 @@ function buildShellCommand(yargs) {
     .options(DATABASE_PATH_OPTIONS)
     .options(CORE_OPTIONS)
     .options(QUERY_OPTIONS)
+    .options(FORMAT_OPTIONS)
     .middleware(resolveIncludeOptions)
     .example([
       [

--- a/src/lib/options.mjs
+++ b/src/lib/options.mjs
@@ -2,6 +2,15 @@
 
 import { Format } from "./formatting/colorize.mjs";
 
+export const FORMAT_OPTIONS = {
+  json: {
+    type: "boolean",
+    description: "Output the results as JSON.",
+    default: false,
+    group: "Output:",
+  },
+};
+
 /**
  * Options required for any command making API requests to the Account API
  */

--- a/test/commands/database/create.mjs
+++ b/test/commands/database/create.mjs
@@ -115,6 +115,16 @@ describe("database create", () => {
     });
   });
 
+  it("supports --json", async () => {
+    await run(
+      'database create --name "testdb" --secret "secret" --json',
+      container,
+    );
+    expect(logger.stdout).to.have.been.calledWith(
+      JSON.stringify({ name: "testdb" }, null, 2),
+    );
+  });
+
   describe("if --secret is provided", () => {
     [
       {

--- a/test/config.mjs
+++ b/test/config.mjs
@@ -363,7 +363,6 @@ describe("configuration file", function () {
         pathMatcher: path.join(__dirname, "../fauna.config.yaml"),
         argvMatcher: sinon.match({
           color: true,
-          json: false,
           quiet: false,
         }),
         configToReturn: defaultConfig,


### PR DESCRIPTION
## Problem

`--json` is a global formatting option, but not all commands support it or even have an output.

## Solution

Move `--json` out of the global option space and into each individual command that supports it.

## Result

`--json` will only show up in the commands that actually support it. Passing `--json` to a command that doesn't support it will not cause an error.

## Testing

All commands supporting JSON have a test proving it.
