### PR TITLE
Support idempotency on create export in the CLI.

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "build:sea": "node ./sea/build.cjs",
     "format": "prettier -w --log-level silent .",
     "format:check": "prettier -c .",
-    "prepare": "husky"
+    "prepare": "husky",
+    "pr-check": "npm run format:check && npm run lint && npm run test"
   },
   "husky": {
     "hooks": {

--- a/src/commands/export/create.mjs
+++ b/src/commands/export/create.mjs
@@ -154,6 +154,9 @@ function buildCreateS3ExportCommand(yargs) {
           "Either --destination or both --bucket and --path are required to create an export.",
         );
       }
+      if (argv.idempotency?.trim() === "") {
+        throw new ValidationError("--idempotency cannot be an empty string.");
+      }
       return true;
     })
     .example(sharedExamples);

--- a/src/commands/export/create.mjs
+++ b/src/commands/export/create.mjs
@@ -19,6 +19,7 @@ async function createS3Export(argv) {
     maxWait,
     quiet,
     destination,
+    idempotency,
   } = argv;
   const logger = container.resolve("logger");
   const { createExport } = container.resolve("accountAPI");
@@ -37,6 +38,7 @@ async function createS3Export(argv) {
     collections,
     destination: destinationInput,
     format,
+    idempotency,
   });
 
   if (wait && !createdExport.is_terminal) {
@@ -63,6 +65,10 @@ const sharedExamples = [
   [
     "$0 export create s3 --bucket doc-example-bucket --path exports/my_db",
     "You can also specify the S3 location using --bucket and --path options rather than --destination.",
+  ],
+  [
+    "$0 export create s3 --destination s3://doc-example-bucket/my-prefix --idempotency f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    "Set the idempotency key for the request, prevents replaying the same requests within 24 hours.",
   ],
   [
     "$0 export create s3 --destination s3://doc-example-bucket/my-prefix --json",
@@ -115,6 +121,13 @@ function buildCreateS3ExportCommand(yargs) {
           "Data format used to encode the exported FQL document data as JSON.",
         choices: ["simple", "tagged"],
         default: "simple",
+        group: "API:",
+      },
+      idempotency: {
+        type: "string",
+        required: false,
+        description:
+          "Set the idempotency key for the request, prevents replaying the same requests within 24 hours.",
         group: "API:",
       },
     })

--- a/src/commands/export/create.mjs
+++ b/src/commands/export/create.mjs
@@ -68,7 +68,7 @@ const sharedExamples = [
   ],
   [
     "$0 export create s3 --destination s3://doc-example-bucket/my-prefix --idempotency f47ac10b-58cc-4372-a567-0e02b2c3d479",
-    "Set the idempotency key for the request, prevents replaying the same requests within 24 hours.",
+    "Set an idempotency key. Avoids reprocessing successful requests with the same key for 24 hours",
   ],
   [
     "$0 export create s3 --destination s3://doc-example-bucket/my-prefix --json",
@@ -127,7 +127,7 @@ function buildCreateS3ExportCommand(yargs) {
         type: "string",
         required: false,
         description:
-          "Set the idempotency key for the request, prevents replaying the same requests within 24 hours.",
+          "Idempotency key. Avoids reprocessing successful requests with the same key for 24 hours.",
         group: "API:",
       },
     })
@@ -155,7 +155,7 @@ function buildCreateS3ExportCommand(yargs) {
         );
       }
       if (argv.idempotency?.trim() === "") {
-        throw new ValidationError("--idempotency cannot be an empty string.");
+        throw new ValidationError("--idempotency can't be an empty string.");
       }
       return true;
     })

--- a/test/commands/export/create.mjs
+++ b/test/commands/export/create.mjs
@@ -203,12 +203,12 @@ idempotent_replayed: true
     {
       description: "an empty string is given as the --idempotency input",
       args: "--destination s3://test-bucket/test/key --idempotency ",
-      expectedError: "--idempotency cannot be an empty string.",
+      expectedError: "--idempotency can't be an empty string.",
     },
     {
       description: "an blank string is given as the --idempotency input",
       args: "--destination s3://test-bucket/test/key --idempotency '  '",
-      expectedError: "--idempotency cannot be an empty string.",
+      expectedError: "--idempotency can't be an empty string.",
     },
   ];
 

--- a/test/commands/export/create.mjs
+++ b/test/commands/export/create.mjs
@@ -200,6 +200,16 @@ idempotent_replayed: true
       expectedError:
         "Cannot specify --destination with --bucket or --path. Use either --destination or both --bucket and --path.",
     },
+    {
+      description: "an empty string is given as the --idempotency input",
+      args: "--destination s3://test-bucket/test/key --idempotency ",
+      expectedError: "--idempotency cannot be an empty string.",
+    },
+    {
+      description: "an blank string is given as the --idempotency input",
+      args: "--destination s3://test-bucket/test/key --idempotency '  '",
+      expectedError: "--idempotency cannot be an empty string.",
+    },
   ];
 
   invalidScenarios.forEach(({ description, args, expectedError }) => {

--- a/test/helpers.mjs
+++ b/test/helpers.mjs
@@ -7,11 +7,12 @@ import sinon from "sinon";
 
 // small helper for sinon to wrap your return value
 // in the shape fetch would return it from the network
-export function f(returnValue, status) {
+export function f(returnValue, status, headers) {
   return new Response(JSON.stringify(returnValue), {
     status: status || 200,
     headers: {
       "Content-type": "application/json",
+      ...headers,
     },
   });
 }


### PR DESCRIPTION
## Problem

The `POST /v2/exports` API supports idempotency, but this is not exposed in the CLI.

## Solution

Expose it in the CLI for `fauna export create` via an optional `--idempotency` argument

## Result

Customers can create idempotent exports if they desire.

## Testing

Ran the tests also ran with the idempotency command locally against the production API.

You can see that:

- not using `--idempotency` is properly handled (`idempotent_replayed: false` is in the output)
- using it but not replaying is properly handled (`idempotent_replayed: false` is in the output)
- replaying is properly handled  (`idempotent_replayed: true` is in the output)

This proves it works as a steal thread.


![Screenshot 2025-01-29 at 9 25 29 AM](https://github.com/user-attachments/assets/c22e0a9f-61a9-4a12-83ea-ca224907b81f)
