### PR TITLE
fix: export list `--state` example

### DIFF
--- a/src/commands/export/list.mjs
+++ b/src/commands/export/list.mjs
@@ -68,7 +68,7 @@ function buildListExportsCommand(yargs) {
       ["$0 export list --json", "List exports in JSON format."],
       ["$0 export list --max-results 50", "List up to 50 exports."],
       [
-        "$0 export list --states Pending Complete",
+        "$0 export list --state Pending Complete",
         "List exports in the 'Pending' or 'Complete' state.",
       ],
     ]);


### PR DESCRIPTION
## Problem

A help example for `fauna export list` is incorrect. The flag is `--state`, not `--states`. 

## Solution

Fix the help example.

## Result

Accurate help for the CLI. If you run the current example, it doesn't actually filter the exports.

## Testing

`npm run test:local` is 🟢 
