### PR TITLE
fix: `--max-backoff` accepts seconds, not ms

### DIFF
--- a/src/lib/options.mjs
+++ b/src/lib/options.mjs
@@ -143,7 +143,7 @@ export const QUERY_OPTIONS = {
   "max-backoff": {
     type: "number",
     description:
-      "Maximum backoff time (in milliseconds) between retry attempts. Only applies to v10 queries.",
+      "Maximum backoff time, in seconds, between retry attempts. Only applies to v10 queries.",
     default: undefined,
     group: "API:",
   },

--- a/test/commands/query/v10.mjs
+++ b/test/commands/query/v10.mjs
@@ -124,7 +124,7 @@ describe("query v10", function () {
 
   it("can set various query options", async function () {
     await run(
-      `query "Database.all()" --secret=foo --typecheck --performance-hints --max-attempts 5 --max-backoff 2000 --timeout 10000 --max-contention-retries 3`,
+      `query "Database.all()" --secret=foo --typecheck --performance-hints --max-attempts 5 --max-backoff 2 --timeout 10000 --max-contention-retries 3`,
       container,
     );
 
@@ -135,7 +135,7 @@ describe("query v10", function () {
         typecheck: true,
         performanceHints: true,
         maxAttempts: 5,
-        maxBackoff: 2000,
+        maxBackoff: 2,
         maxContentionRetries: 3,
       }),
     );

--- a/test/commands/shell.mjs
+++ b/test/commands/shell.mjs
@@ -343,7 +343,7 @@ describe("shell", function () {
       let query = "Database.all().take(1)";
 
       const runPromise = run(
-        "shell --secret=foo --typecheck --performance-hints --max-attempts 5 --max-backoff 2000 --timeout 10000 --max-contention-retries 3",
+        "shell --secret=foo --typecheck --performance-hints --max-attempts 5 --max-backoff 2 --timeout 10000 --max-contention-retries 3",
         container,
       );
 
@@ -359,7 +359,7 @@ describe("shell", function () {
           typecheck: true,
           performanceHints: true,
           maxAttempts: 5,
-          maxBackoff: 2000,
+          maxBackoff: 2,
           maxContentionRetries: 3,
         }),
       );


### PR DESCRIPTION
## Problem

The help text and tests for `--max-backoff` flag state/imply it accepts milliseconds.

The JS driver's corresponding `maxBackoff` client config option accepts values in seconds, not milliseconds. The value is converted from seconds to milliseconds here: https://github.com/fauna/fauna-js/blob/main/src/client.ts#L467-L468

Unless I missed it, the CLI does do any conversion of `--max-backoff` values so it should accept seconds.

## Solution

Update the help text and tests to indicate `--max-backoff` accepts seconds.

## Result

Accurate help and tests for the CLI.

## Testing

`npm run test:local` is 🟢 
