### PR TITLE
fix: FQL v4 queries support `--timeout`

### DIFF
--- a/src/lib/options.mjs
+++ b/src/lib/options.mjs
@@ -121,8 +121,7 @@ export const QUERY_OPTIONS = {
   },
   timeout: {
     type: "number",
-    description:
-      "Maximum query runtime in milliseconds. Only applies to v10 queries.",
+    description: "Maximum query runtime in milliseconds.",
     default: 5000,
     group: "API:",
   },


### PR DESCRIPTION
## Problem

The help text for --timeout` state it only applies to FQL v10 queries. However, it is also supported for FQL v4 queries. See this test: https://github.com/fauna/fauna-shell/blob/main/test/commands/query/v4.mjs#L106-L118 

## Solution

Fix the help string. Docs are fixed in https://github.com/fauna/docs.fauna.com/pull/3103

## Result

Accurate help output

## Testing

N/A
